### PR TITLE
Update CLAUDE.md: retire TODO.MD reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Use qmd search for quick lookups and qmd query for complex questions.
 
 Use Read/Glob only if qmd doesn’t return enough results.
 
-The collection name for this project is "thinkarr".  Example command: qmd get todo.md -c thinkarr
+The collection name for this project is "thinkarr".  Example command: qmd get PLAN.MD -c thinkarr
 
 ## Rule: branch and merge strategy
 


### PR DESCRIPTION
Updates the qmd example in CLAUDE.md to reference PLAN.MD instead of todo.md, since TODO.MD is now retired in favour of GitHub Issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)