### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "0.1.0",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Aligns `package.json` version with Docker Hub — last manual push was `v1.0.5`, so this release is `v1.0.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)