### PR TITLE
Fix Docker E2E UID/GID check to read from /proc/1/status

### DIFF
--- a/tests/e2e/global-setup-docker.ts
+++ b/tests/e2e/global-setup-docker.ts
@@ -77,11 +77,14 @@ export default async function globalSetup(_config: FullConfig) {
   await waitForServer(DOCKER_BASE_URL);
   console.log("[e2e-docker] Container is ready");
 
-  // 5. Verify PUID/PGID — confirms entrypoint.sh ran correctly
-  const [uid, gid] = execSync(`docker exec ${CONTAINER_NAME} sh -c 'id -u && id -g'`)
-    .toString()
-    .trim()
-    .split("\n");
+  // 5. Verify PUID/PGID — check PID 1's actual UID/GID from /proc, not the
+  //    docker exec session which always runs as root regardless of su-exec
+  const uid = execSync(
+    `docker exec ${CONTAINER_NAME} sh -c 'cat /proc/1/status | grep "^Uid:" | awk "{print \\$2}"'`,
+  ).toString().trim();
+  const gid = execSync(
+    `docker exec ${CONTAINER_NAME} sh -c 'cat /proc/1/status | grep "^Gid:" | awk "{print \\$2}"'`,
+  ).toString().trim();
   if (uid !== TEST_PUID || gid !== TEST_PGID) {
     throw new Error(
       `Container running as UID=${uid} GID=${gid}, expected ${TEST_PUID}:${TEST_PGID}`,


### PR DESCRIPTION
## Summary

- `docker exec` always runs as root regardless of `su-exec` in the entrypoint, so `id -u` / `id -g` returned 0 instead of the expected 1001
- Fix: read PID 1's real UID/GID from `/proc/1/status` which reflects what `su-exec` actually set

## Test plan
- [ ] Docker E2E global setup now correctly verifies `UID=1001 GID=1001`
- [ ] CI E2E job passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)