### PR TITLE
Fix rate-limit E2E test hardcoded BASE_URL breaking Docker config

### DIFF
--- a/tests/e2e/rate-limit.spec.ts
+++ b/tests/e2e/rate-limit.spec.ts
@@ -10,26 +10,10 @@
  *   2. UI level (here) — the error appears inline in the chat, not as a crash
  */
 
-import { test, expect, request } from "@playwright/test";
-import { BASE_URL } from "./global-setup";
-
-// Seed messages via API to exhaust the rate limit without going through the UI
-async function seedMessagesToLimit(sessionCookie: string, convId: string, count: number) {
-  const ctx = await request.newContext({ baseURL: BASE_URL });
-
-  for (let i = 0; i < count; i++) {
-    await ctx.post("/api/chat", {
-      headers: { Cookie: sessionCookie },
-      // We can't easily seed raw DB messages through the API in E2E tests,
-      // so we set the user's rate limit via the settings API instead.
-    });
-  }
-
-  await ctx.dispose();
-}
+import { test, expect } from "@playwright/test";
 
 test.describe("Rate limit UI", () => {
-  test("rate limit error appears inline when limit is exceeded", async ({ page, context }) => {
+  test("rate limit error appears inline when limit is exceeded", async ({ page, context, request }) => {
     await page.goto("/chat");
 
     // Lower the rate limit to 0 via settings API so the next message is blocked.
@@ -38,8 +22,7 @@ test.describe("Rate limit UI", () => {
     const sessionCookie = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
 
     // Get the current user id from the session
-    const apiCtx = await request.newContext({ baseURL: BASE_URL });
-    const sessionRes = await apiCtx.get("/api/auth/session", {
+    const sessionRes = await request.get("/api/auth/session", {
       headers: { Cookie: sessionCookie },
     });
     const { data: sessionData } = await sessionRes.json();
@@ -52,11 +35,10 @@ test.describe("Rate limit UI", () => {
     }
 
     // Set rate limit to 0 messages/day so the very next chat message is blocked
-    await apiCtx.patch("/api/settings/users", {
+    await request.patch("/api/settings/users", {
       headers: { Cookie: sessionCookie },
       data: { userId, rateLimitMessages: 0, rateLimitPeriod: "day" },
     });
-    await apiCtx.dispose();
 
     // Now send a chat message — it should be blocked
     await page.getByPlaceholder("Type a message...").fill("This should be rate limited");


### PR DESCRIPTION
## Summary

- Rate-limit E2E test was importing `BASE_URL` from `global-setup` (port 3001) and passing it to `request.newContext()`, which ignored the Docker Playwright config's `use.baseURL` (port 3000), causing `ECONNREFUSED` on every Docker E2E run
- Fix: use Playwright's built-in `request` fixture parameter instead — it automatically inherits `use.baseURL` from whichever config is active
- Also removed the unused `seedMessagesToLimit` helper

## Test plan
- [ ] `npm run test:e2e` passes (port 3001)
- [ ] `npm run test:e2e:docker` passes (port 3000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)