### PR TITLE
Skip CI for docs and non-code file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - dev
       - main
+    paths-ignore:
+      - '**.md'
+      - '**.MD'
+      - '.claude/**'
+      - 'docker-compose.yml'
+      - 'LICENSE'
 
 jobs:
   test:


### PR DESCRIPTION
Adds `paths-ignore` to the CI `pull_request` trigger so PRs that only touch the following files skip the full test pipeline:

- `**.md` / `**.MD` — all markdown docs (README, PLAN, CLAUDE, TODO etc.)
- `.claude/**` — Claude Code settings
- `docker-compose.yml` — local dev convenience file
- `LICENSE`

Everything else (src, tests, public, config files, Dockerfile, drizzle, workflows) still triggers CI as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)