### PR TITLE
fix(ci): deduplicate and correct docker-publish tag logic

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -143,13 +143,10 @@ jobs:
           images: chrisrothwell/thinkarr
           tags: |
             type=ref,event=branch,enable=${{ github.ref == 'refs/heads/beta' }}
-            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-            type=raw,value=beta,enable=${{ contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') }}
+            type=raw,value=beta,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-') }}
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
## Problem

PR #34's merge left duplicate and conflicting tag entries in `docker-publish.yml` (lines 145–152). Specifically:
- Lines 146/149 and 147/150 were exact duplicates
- Line 148 emitted `:latest` for **all** `v*` tags including pre-releases — `v1.1.0-beta.1` would have overwritten `:latest`

## Fix

Collapsed to a single clean set:

| Trigger | Tags produced |
|---|---|
| Push to `beta` branch | `:beta` |
| `v1.x.x` tag (stable) | `:1.x.x` `:1.x` `:latest` |
| `v1.x.x-beta.y` tag (pre-release) | `:1.x.x-beta.y` `:beta` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)