### PR TITLE
chore: bump version to 1.1.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.0.6",
+  "version": "1.1.0-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps `package.json` version from `1.0.6` to `1.1.0-beta.1` ahead of the first beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)