### PR TITLE
fix: resolve Trivy CRITICAL/HIGH findings (zlib + npm-internal CVEs)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,6 +104,7 @@ jobs:
           exit-code: '1'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          trivyignores: .trivyignore
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,24 @@
+# Vulnerabilities in npm CLI's own bundled dependencies (tar, minimatch, glob).
+# These packages live in /usr/local/lib/node_modules/npm/ and are only used by
+# the npm CLI tool itself. Our production container never runs 'npm install' or
+# any npm commands — it runs 'node server.js' only. The attack surface for these
+# CVEs (malicious archive extraction, glob injection) does not exist at runtime.
+#
+# Suppress until the node:22-alpine base image ships a patched npm version,
+# at which point these entries should be removed.
+
+# glob: Command Injection via Malicious Filenames (npm-internal only)
+CVE-2025-64756
+
+# minimatch: DoS via crafted glob patterns (npm-internal only)
+CVE-2026-26996
+CVE-2026-27903
+CVE-2026-27904
+
+# node-tar: various path traversal / file overwrite (npm-internal only)
+CVE-2026-23745
+CVE-2026-23950
+CVE-2026-24842
+CVE-2026-26960
+CVE-2026-29786
+CVE-2026-31802

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 ENV TZ=UTC
 
-RUN apk add --no-cache shadow su-exec tzdata && \
+RUN apk upgrade --no-cache zlib && \
+    apk add --no-cache shadow su-exec tzdata && \
     mkdir -p /config && \
     chown node:node /config
 


### PR DESCRIPTION
## Problem

Trivy scan was blocking the Docker publish pipeline with 1 CRITICAL + 22 HIGH findings.

## Root cause analysis

| Finding | Location | Runtime risk |
|---|---|---|
| zlib CVE-2026-22184 (CRITICAL) | Alpine base image | **Real** — zlib is used at runtime |
| tar/minimatch/glob CVEs (22 HIGH) | `/usr/local/lib/node_modules/npm/` | **None** — npm CLI's own bundled tools, never executed in production container |

## Fixes

1. **Dockerfile**: `apk upgrade --no-cache zlib` in runner stage → pulls `1.3.2-r0` (patched)
2. **`.trivyignore`**: suppresses npm-internal CVEs with documented justification
3. **docker-publish.yml**: passes `trivyignores: .trivyignore` to Trivy action

## Verification

Built and scanned locally in WSL2 before pushing:
```
Remaining CRITICAL/HIGH: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)