### PR TITLE
Fix all ESLint warnings — 0 warnings (issue #25)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,12 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      // Allow _ and _name as intentionally-unused parameter placeholders
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:
@@ -12,6 +18,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Generated coverage reports
+    "coverage/**",
   ]),
 ]);
 

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -12,8 +12,6 @@
 
 import { test, expect } from "@playwright/test";
 
-// The mock LLM always responds: "Here is the answer."
-const MOCK_RESPONSE = "Here is the answer.";
 
 test.describe("Chat interface", () => {
   test("chat page renders the textarea and sidebar", async ({ page }) => {

--- a/tests/e2e/global-setup-docker.ts
+++ b/tests/e2e/global-setup-docker.ts
@@ -43,7 +43,7 @@ async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
   throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
 }
 
-export default async function globalSetup(_config: FullConfig) {
+export default async function globalSetup(_: FullConfig) {
   // 1. Start mock servers — they bind to 127.0.0.1 which is reachable from
   //    the container because we use --network=host
   const mocks = await startMockServers();

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -14,7 +14,7 @@
  *      teardown can clean everything up
  */
 
-import { chromium, FullConfig, request } from "@playwright/test";
+import { FullConfig, request } from "@playwright/test";
 import { spawn, ChildProcess } from "child_process";
 import { mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -48,7 +48,7 @@ async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
 // Global setup entry point
 // ---------------------------------------------------------------------------
 
-export default async function globalSetup(config: FullConfig) {
+export default async function globalSetup(_: FullConfig) {
   // 1. Start mock servers
   const mocks = await startMockServers();
   console.log(`[e2e] Mock Plex server:  ${mocks.plexUrl}`);


### PR DESCRIPTION
## Summary
- Add `coverage/**` to ESLint ignores (was scanning generated lcov files)
- Add `argsIgnorePattern: "^_"` so `_` and `_name` params are recognised as intentionally unused
- Remove unused `MOCK_RESPONSE` constant from `chat.spec.ts`
- Remove unused `chromium` import from `global-setup.ts`
- Rename unused `config`/`_config` params to `_` in both global-setup files

Lint now passes with **0 warnings, 0 errors**.

Closes #25 (partial — ESLint warnings resolved; npm audit vulnerabilities tracked separately via Dependabot).

## Test plan
- [ ] CI lint step passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)