### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps `package.json` and `package-lock.json` from `1.1.0-beta.1` → `1.1.0` ahead of the stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)