### PR TITLE
fix: guard post-stream reload against stale conversation in use-chat

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -170,6 +170,11 @@ Build an LLM-powered chat frontend for media management (*arr stack). Users log 
 - [x] **Reset to Default system prompt (#7)** — "Reset to Default" button appears next to the System Prompt label in LLM Settings when the field is non-empty; clicking it clears the field so the system falls back to `DEFAULT_SYSTEM_PROMPT`. — `src/app/settings/page.tsx`
 - [x] **Version number in UI (#4)** — `NEXT_PUBLIC_APP_VERSION` exposed from `package.json` via `next.config.ts` env. Version displayed as `v{version}` in the bottom-left corner of the chat page (muted, non-interactive). — `next.config.ts`, `src/app/chat/page.tsx`
 
+### Phase 13: React 19 Upgrade Fix
+
+#### Bug Fixes
+- [x] **E2E tests #15/#16 broken by React 19.2.4 upgrade (#60)** — Fixed a race condition in `use-chat.ts` where the post-stream message reload fetch in `sendMessage`'s `finally` block could resolve after the user clicked "New Chat", overwriting the cleared state and preventing the `empty-chat-state` element from appearing. Added a `conversationIdRef` that tracks the current active conversation; the reload is now skipped (at both the pre-fetch and post-fetch stages) if the active conversation has changed since the message was sent. — `src/hooks/use-chat.ts`
+
 #### Housekeeping
 - [x] **ESLint warnings resolved (#25)** — Added `eslint-disable` comments for intentional `<img>` usage in `avatar.tsx` and `title-card.tsx`; fixed unused destructuring var in `registry.ts`; moved `options` to a ref in `use-chat.ts` to satisfy `react-hooks/exhaustive-deps` without stale closures. Zero warnings. — `src/components/ui/avatar.tsx`, `src/components/chat/title-card.tsx`, `src/lib/tools/registry.ts`, `src/hooks/use-chat.ts`
 

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -18,6 +18,9 @@ export function useChat(conversationId: string | null, options?: UseChatOptions)
   // Ref tracks streaming without stale-closure issues — loadMessages checks this
   // before overwriting state so it never races with an active SSE stream.
   const streamingRef = useRef(false);
+  // Tracks the current conversationId so async callbacks can detect stale fetches.
+  const conversationIdRef = useRef(conversationId);
+  conversationIdRef.current = conversationId;
   // Keep options in a ref so sendMessage can read the latest callbacks without
   // including the options object itself in the useCallback dependency array
   // (which would cause a new function on every render).
@@ -167,15 +170,20 @@ export function useChat(conversationId: string | null, options?: UseChatOptions)
         abortRef.current = null;
         // Reload messages from server so tool call results (including display_titles
         // carousels) are persisted in state and survive subsequent messages.
-        try {
-          const res = await fetch(`/api/conversations/${convId}`);
-          const data = await res.json();
-          if (data.success && data.data.messages) {
-            setMessages(data.data.messages);
-            setToolCalls(new Map());
+        // Guard: skip if the user has navigated away (e.g. clicked "New Chat")
+        // before this fetch resolves, otherwise the reload would overwrite the
+        // cleared state and break the empty-chat view.
+        if (conversationIdRef.current === convId) {
+          try {
+            const res = await fetch(`/api/conversations/${convId}`);
+            const data = await res.json();
+            if (data.success && data.data.messages && conversationIdRef.current === convId) {
+              setMessages(data.data.messages);
+              setToolCalls(new Map());
+            }
+          } catch {
+            // Best-effort — messages stay as optimistic state if reload fails
           }
-        } catch {
-          // Best-effort — messages stay as optimistic state if reload fails
         }
       }
     },


### PR DESCRIPTION
After streaming completes, sendMessage fires a reload fetch to persist
tool-call results. In React 19 the scheduler exposes a race: the fetch
can resolve *after* the user clicks "New Chat" and clearMessages() has
already run, causing the old messages to overwrite the empty state and
hiding the empty-chat-state element (breaking E2E tests #15/#16 in PR #60).

Fix: add a conversationIdRef that mirrors the current conversationId prop.
The reload fetch is now skipped entirely if the active conversation has
changed by the time it would start, and the resulting setMessages call is
skipped a second time in case the ID changed while the request was in
flight.

https://claude.ai/code/session_01FTSh8tGSRS3gDTvtqsvDjc