### PR TITLE
fix(realtime): restrict realtime API to OpenAI endpoints only (issue …

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -186,6 +186,15 @@ Build an LLM-powered chat frontend for media management (*arr stack). Users log 
 #### Features
 - [x] **PWA installability (#76)** — Added `public/manifest.json` (standalone display, dark theme color) and `public/sw.js` (minimal network-first service worker). Updated `layout.tsx` with `manifest` metadata and `appleWebApp` properties. New `PwaInstallBanner` component shows a dismissible banner at the top of the chat window on mobile only (`pointer: coarse` detection); on Android/Chrome it uses `beforeinstallprompt` to trigger native install, on iOS it shows manual Share → Add to Home Screen instructions (iOS 16.4+ required). New "General" settings tab has platform-aware install UI: desktop users see a redirect message, iOS users see manual steps, Android users get a direct Install button. A module-level singleton in `pwa.ts` (`storeDeferredPrompt`, `triggerPwaInstall`, `isPwaInstallAvailable`, `onPwaAvailabilityChange`) shares the deferred prompt across SPA page navigations; `isMobileDevice()` and `isIos()` helpers cover platform detection. `usePwaInstall` hook provides reactive access and registers the SW. Settings defaults to LLM Setup during initial setup, General otherwise. — `public/manifest.json` (new), `public/sw.js` (new), `src/lib/pwa.ts` (new), `src/hooks/use-pwa-install.ts` (new), `src/components/chat/pwa-install-banner.tsx` (new), `src/app/layout.tsx`, `src/app/chat/page.tsx`, `src/app/settings/page.tsx`, `src/__tests__/lib/pwa.test.ts` (new)
 
+### Phase 17: Realtime OpenAI-Only Guard (issue #80)
+
+#### Bug Fix
+- [x] **Realtime restricted to api.openai.com only (#80)** — ChatGPT-compatible providers (Gemini, Anthropic, local proxies) expose an OpenAI-compatible REST surface but do not implement the WebRTC-based Realtime API. Previously, `probeRealtimeSupport` would scan any endpoint's `/models` list for model IDs containing "realtime", which could falsely flag non-OpenAI endpoints as realtime-capable. Two guards added: (1) `isOpenAIEndpoint(url)` helper (exported from `test-connection.ts`) returns `true` only when the URL hostname is `api.openai.com`; `probeRealtimeSupport` returns `null` immediately for any other host. (2) `POST /api/realtime/session` checks `isOpenAIEndpoint(ep.baseUrl)` after the existing `supportsRealtime` check and returns HTTP 400 for non-OpenAI endpoints as a defence-in-depth measure. — `src/lib/services/test-connection.ts`, `src/app/api/realtime/session/route.ts`
+
+#### Tests
+- [x] **`src/__tests__/lib/services/is-openai-endpoint.test.ts`** — Unit tests for `isOpenAIEndpoint`: true for `api.openai.com`, false for Gemini/Anthropic/localhost/invalid URLs
+- [x] **`src/__tests__/api/realtime-session.test.ts`** — Two new cases: Gemini-compatible endpoint (non-openai.com host) and Anthropic endpoint both return HTTP 400 even when `supportsRealtime: true`
+
 ### Phase 14: Coordinated Dependency Upgrades (issue #68)
 
 #### Dependency Upgrades

--- a/src/__tests__/api/realtime-session.test.ts
+++ b/src/__tests__/api/realtime-session.test.ts
@@ -136,6 +136,56 @@ describe("POST /api/realtime/session", () => {
     expect(body.data.realtimeModel).toBe("gpt-4o-realtime-preview-2024-12-17");
   });
 
+  it("returns 400 when endpoint is ChatGPT-compatible but not OpenAI (e.g. Gemini)", async () => {
+    mockGetEndpointConfig.mockReturnValue({
+      id: "ep-gemini",
+      name: "Gemini",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+      apiKey: "gemini-key",
+      model: "gemini-2.0-flash",
+      systemPrompt: "",
+      enabled: true,
+      supportsVoice: false,
+      supportsRealtime: true,
+      realtimeModel: "gemini-realtime",
+      realtimeSystemPrompt: "",
+    });
+    const req = new Request("http://localhost/api/realtime/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ modelId: "ep-gemini:gemini-2.0-flash" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/openai/i);
+  });
+
+  it("returns 400 when endpoint is Anthropic-compatible but not OpenAI", async () => {
+    mockGetEndpointConfig.mockReturnValue({
+      id: "ep-anthropic",
+      name: "Anthropic",
+      baseUrl: "https://api.anthropic.com/v1",
+      apiKey: "anthropic-key",
+      model: "claude-sonnet-4-6",
+      systemPrompt: "",
+      enabled: true,
+      supportsVoice: false,
+      supportsRealtime: true,
+      realtimeModel: "claude-realtime",
+      realtimeSystemPrompt: "",
+    });
+    const req = new Request("http://localhost/api/realtime/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ modelId: "ep-anthropic:claude-sonnet-4-6" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/openai/i);
+  });
+
   it("returns 502 when OpenAI Realtime API fails", async () => {
     mockFetch.mockResolvedValue({
       ok: false,

--- a/src/__tests__/lib/services/is-openai-endpoint.test.ts
+++ b/src/__tests__/lib/services/is-openai-endpoint.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { isOpenAIEndpoint } from "@/lib/services/test-connection";
+
+describe("isOpenAIEndpoint", () => {
+  it("returns true for the canonical OpenAI base URL", () => {
+    expect(isOpenAIEndpoint("https://api.openai.com/v1")).toBe(true);
+  });
+
+  it("returns true for OpenAI URL with trailing slash", () => {
+    expect(isOpenAIEndpoint("https://api.openai.com/v1/")).toBe(true);
+  });
+
+  it("returns false for Gemini OpenAI-compatible endpoint", () => {
+    expect(isOpenAIEndpoint("https://generativelanguage.googleapis.com/v1beta/openai")).toBe(false);
+  });
+
+  it("returns false for Anthropic endpoint", () => {
+    expect(isOpenAIEndpoint("https://api.anthropic.com/v1")).toBe(false);
+  });
+
+  it("returns false for local LM Studio or Ollama proxy", () => {
+    expect(isOpenAIEndpoint("http://localhost:11434/v1")).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isOpenAIEndpoint("")).toBe(false);
+  });
+
+  it("returns false for a non-URL string", () => {
+    expect(isOpenAIEndpoint("not-a-url")).toBe(false);
+  });
+});

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { getEndpointConfig } from "@/lib/llm/client";
 import { buildRealtimeSystemPrompt } from "@/lib/llm/system-prompt";
+import { isOpenAIEndpoint } from "@/lib/services/test-connection";
 import { initializeTools } from "@/lib/tools/init";
 import { getOpenAITools } from "@/lib/tools/registry";
 import { checkUserApiRateLimit } from "@/lib/security/api-rate-limit";
@@ -40,6 +41,13 @@ export async function POST(request: Request) {
   if (!ep || !ep.supportsRealtime || !ep.realtimeModel) {
     return NextResponse.json<ApiResponse>(
       { success: false, error: "This endpoint does not support the Realtime API" },
+      { status: 400 },
+    );
+  }
+
+  if (!isOpenAIEndpoint(ep.baseUrl)) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Realtime is only supported on OpenAI endpoints (api.openai.com)" },
       { status: 400 },
     );
   }

--- a/src/lib/services/test-connection.ts
+++ b/src/lib/services/test-connection.ts
@@ -1,6 +1,21 @@
 import type { TestConnectionRequest, TestConnectionResponse } from "@/types/api";
 import { validateServiceUrl } from "@/lib/security/url-validation";
 
+/**
+ * Returns true only for genuine OpenAI endpoints (api.openai.com).
+ * ChatGPT-compatible providers (Gemini, Anthropic, local proxies, etc.) do not
+ * support the WebRTC-based Realtime API even if they expose an OpenAI-compatible
+ * REST surface, so realtime capability must never be advertised for them.
+ */
+export function isOpenAIEndpoint(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === "api.openai.com";
+  } catch {
+    return false;
+  }
+}
+
 async function probeVoiceSupport(url: string, apiKey: string): Promise<boolean> {
   try {
     const base = url.replace(/\/$/, "");
@@ -20,6 +35,8 @@ async function probeVoiceSupport(url: string, apiKey: string): Promise<boolean> 
 }
 
 async function probeRealtimeSupport(url: string, apiKey: string): Promise<string | null> {
+  // Realtime (WebRTC) is an OpenAI-exclusive API — skip probing for any other provider.
+  if (!isOpenAIEndpoint(url)) return null;
   try {
     const base = url.replace(/\/$/, "");
     const res = await fetch(`${base}/models`, {


### PR DESCRIPTION
…#80)

ChatGPT-compatible providers (Gemini, Anthropic, local proxies) can expose models with "realtime" in their ID but do not support the WebRTC-based OpenAI Realtime API. Previously probeRealtimeSupport() would falsely detect realtime capability on these endpoints.

- Add isOpenAIEndpoint(url) helper that returns true only for api.openai.com
- Gate probeRealtimeSupport() on isOpenAIEndpoint so non-OpenAI providers always get supportsRealtime=false during capability detection
- Add defence-in-depth check in POST /api/realtime/session: rejects with HTTP 400 if the endpoint's baseUrl is not api.openai.com even if supportsRealtime is somehow set to true in stored config
- Add unit tests for isOpenAIEndpoint and two new session route test cases (Gemini-compatible, Anthropic) verifying they return 400

https://claude.ai/code/session_01197wupLcn7tWM9WdenS4Ac