### PR TITLE
fix: use native arm64 runner to eliminate QEMU SIGILL failures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -119,8 +119,69 @@ jobs:
           retention-days: 7
 
   docker:
-    name: Build & Push Docker Image
+    name: Build Docker Image (${{ matrix.platform }})
     needs: docker-e2e
+    # Use native runners per platform to avoid QEMU emulation failures
+    # (SIGILL / "Illegal instruction" when compiling native modules under QEMU).
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set version
+        run: echo "APP_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: chrisrothwell/thinkarr
+
+      - name: Build and push by digest
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ env.APP_VERSION }}
+          outputs: type=image,name=chrisrothwell/thinkarr,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
+    name: Merge Multi-Arch Manifests & Push
+    needs: docker
     runs-on: ubuntu-latest
     permissions:
       contents: write  # required for anchore/sbom-action to attach SBOM to release
@@ -131,8 +192,12 @@ jobs:
       - name: Set version
         run: echo "APP_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -155,22 +220,20 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') }}
             type=raw,value=beta,enable=${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-') }}
 
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            APP_VERSION=${{ env.APP_VERSION }}
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'chrisrothwell/thinkarr@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect chrisrothwell/thinkarr:${{ steps.meta.outputs.version }}
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: chrisrothwell/thinkarr@${{ steps.push.outputs.digest }}
+          image: chrisrothwell/thinkarr:${{ steps.meta.outputs.version }}
           artifact-name: sbom-${{ env.APP_VERSION }}.spdx.json
           output-file: sbom-${{ env.APP_VERSION }}.spdx.json
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -456,3 +456,16 @@ External MCP access uses bearer token (from `mcp.bearerToken` config). Optional 
 ### Phase 19: Version Bump to 1.1.1-beta.2
 
 - Bumped `package.json` and `package-lock.json` version from `1.1.0-beta.1` to `1.1.1-beta.2`.
+
+### Phase 20: Fix Docker Build Flakiness (issue #26)
+
+**Problem:** Multi-arch Docker builds using QEMU emulation for `linux/arm64` intermittently failed with `qemu: uncaught target signal 4 (Illegal instruction) - core dumped` during `npm ci`. QEMU cannot reliably emulate all CPU instructions Node.js uses when compiling native modules (`better-sqlite3`).
+
+**Fix:** Replaced single QEMU-based multi-arch build job with native runners per platform:
+- `linux/amd64` builds on `ubuntu-latest` (x86_64)
+- `linux/arm64` builds on `ubuntu-24.04-arm` (native arm64)
+
+Each platform builds and pushes by digest, then a `docker-merge` job assembles the final multi-arch manifest via `docker buildx imagetools create`.
+
+**Files changed:**
+- `.github/workflows/docker-publish.yml` — split `docker` job into matrix + added `docker-merge` job


### PR DESCRIPTION
QEMU-emulated linux/arm64 builds intermittently crashed with "Illegal instruction" (signal 4) during npm ci, caused by Node.js using CPU instructions QEMU cannot reliably emulate when compiling native modules (better-sqlite3).

Replace the single QEMU multi-arch build job with a matrix of native runners:
- linux/amd64 → ubuntu-latest
- linux/arm64 → ubuntu-24.04-arm

Each platform job pushes by digest; a new docker-merge job assembles the final multi-arch manifest with `docker buildx imagetools create`.

https://claude.ai/code/session_01GAUCfUeehyYwCyB88xwfoB