### PR TITLE
fix(ci): follow redirects in smoke test, verify response body, force-…

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -118,24 +118,38 @@ jobs:
             -v "${DIRTY_DIR}:/config" \
             thinkarr:ci-test
 
-          # Poll /api/health — 200 = fallback fired and schema is intact
-          # 503 = fallback did not run and schema is still broken
+          # Poll /api/health — must ultimately return JSON {"status":"ok"}.
+          # -L follows any routing redirect (e.g. trailing-slash normalisation in
+          # the standalone production server) so we check the final response, not
+          # the first hop.  We also validate the body so that an accidental HTML
+          # redirect to /setup can't produce a false pass.
+          # 200 + body contains "ok" = ensureSchemaIntegrity ran and repaired the schema.
+          # 307 without -L / 503 = fallback did not run or schema is still broken.
           OK=false
           for i in $(seq 1 30); do
-            CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health 2>/dev/null || echo "000")
-            echo "Attempt ${i}/30: HTTP ${CODE}"
-            if [ "${CODE}" = "200" ]; then OK=true; break; fi
+            BODY=$(curl -sL --max-redirs 5 -w "\n%{http_code}" \
+              http://localhost:3000/api/health 2>/dev/null || true)
+            CODE=$(printf '%s' "$BODY" | tail -1)
+            PAYLOAD=$(printf '%s' "$BODY" | head -n -1)
+            # Also capture the redirect target for diagnostics when not following
+            REDIR=$(curl -s -o /dev/null -w "%{redirect_url}" \
+              http://localhost:3000/api/health 2>/dev/null || true)
+            echo "Attempt ${i}/30: HTTP ${CODE} | redirect_url=${REDIR:-none} | body=${PAYLOAD}"
+            if [ "${CODE}" = "200" ] && printf '%s' "$PAYLOAD" | grep -q '"status":"ok"'; then
+              OK=true
+              break
+            fi
             sleep 3
           done
 
-          echo "--- Container logs (last 30 lines) ---"
-          docker logs thinkarr-dirty-test 2>&1 | tail -30
+          echo "--- Container logs (last 50 lines) ---"
+          docker logs thinkarr-dirty-test 2>&1 | tail -50
 
           if [ "${OK}" != "true" ]; then
             echo "FAIL: Container did not recover from dirty migration state within 90s"
             exit 1
           fi
-          echo "PASS: /api/health returned 200 — defensive fallback correctly restored duration_ms"
+          echo "PASS: /api/health returned 200 with status:ok — ensureSchemaIntegrity correctly restored duration_ms"
 
       - name: E2E tests against Docker container
         run: npm run test:e2e:docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,6 @@ EXPOSE 3000
 VOLUME /config
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD wget -qO- http://localhost:3000/api/health || exit 1
+  CMD wget -qO- http://localhost:3000/api/health | grep -q '"status":"ok"' || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import * as schema from "@/lib/db/schema";
 
+// Never cache or pre-render this route — every request must hit the live DB
+// so that ensureSchemaIntegrity runs and the probe reflects the real schema state.
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   try {
     const db = getDb();


### PR DESCRIPTION
…dynamic on health route

The dirty-migration smoke test polled /api/health with plain curl (no -L), so any routing-level redirect (e.g. trailing-slash normalisation emitted by the Next.js 16 standalone production server before the handler runs) caused every attempt to report HTTP 307 and the test to time out.

Three changes:

1. docker-publish.yml smoke test
   - Use `curl -sL` (follow up to 5 redirects) so benign routing redirects don't count as failures.
   - Validate the response body contains `"status":"ok"` — prevents an accidental HTML redirect to /setup producing a false pass.
   - Capture `%{redirect_url}` on every attempt for diagnostics.
   - Increase log tail from 30 to 50 lines to capture ensureSchemaIntegrity output that was previously truncated.

2. src/app/api/health/route.ts
   - Export `dynamic = "force-dynamic"` so Next.js never statically pre-renders or caches the health route.  Without this, a Next.js version that caches GET handlers by default could serve a stale build-time response instead of hitting the live DB.

3. Dockerfile HEALTHCHECK
   - Pipe wget output through `grep -q '"status":"ok"'` so the Docker health check also validates the response body, consistent with the smoke test.

https://claude.ai/code/session_019KQbv8p3vidP3QvX6c4rGW