### PR TITLE
fix: add /api/health to middleware public paths

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for src/proxy.ts (Next.js 16 middleware)
+ *
+ * Covers:
+ *   - Public paths bypass auth check (no session cookie required)
+ *   - /api/health is publicly accessible (required for Docker HEALTHCHECK and CI smoke test)
+ *   - Protected paths redirect to /login when no session cookie present
+ *   - x-middleware-subrequest header is blocked (CVE-2025-29927 mitigation)
+ */
+
+import { describe, it, expect } from "vitest";
+import { proxy } from "@/proxy";
+import type { NextRequest } from "next/server";
+
+function makeRequest(path: string, opts: { cookie?: string; header?: Record<string, string> } = {}) {
+  const url = `http://localhost:3000${path}`;
+  const headers = new Headers(opts.header ?? {});
+  if (opts.cookie) headers.set("cookie", opts.cookie);
+  return {
+    nextUrl: new URL(url),
+    cookies: { has: (name: string) => !!opts.cookie?.includes(name) },
+    headers,
+    url,
+  } as unknown as NextRequest;
+}
+
+describe("proxy middleware", () => {
+  it("allows /api/health without a session cookie", () => {
+    const res = proxy(makeRequest("/api/health"));
+    // NextResponse.next() has no Location header and no redirect status
+    expect(res.status).not.toBe(307);
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it.each(["/setup", "/login", "/api/setup", "/api/auth/callback", "/api/mcp"])(
+    "allows public path %s without a session cookie",
+    (path) => {
+      const res = proxy(makeRequest(path));
+      expect(res.status).not.toBe(307);
+    }
+  );
+
+  it("redirects protected path to /login when no session cookie", () => {
+    const res = proxy(makeRequest("/"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/login");
+  });
+
+  it("allows protected path when session cookie is present", () => {
+    const res = proxy(makeRequest("/", { cookie: "thinkarr_session=abc123" }));
+    expect(res.status).not.toBe(307);
+  });
+
+  it("blocks x-middleware-subrequest header (CVE-2025-29927)", () => {
+    const res = proxy(makeRequest("/", { header: { "x-middleware-subrequest": "1" } }));
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-const PUBLIC_PATHS = ["/setup", "/login", "/api/setup", "/api/auth", "/api/mcp"];
+const PUBLIC_PATHS = ["/setup", "/login", "/api/setup", "/api/auth", "/api/mcp", "/api/health"];
 const SESSION_COOKIE = "thinkarr_session";
 
 export function proxy(request: NextRequest) {


### PR DESCRIPTION
The Next.js 16 middleware (proxy.ts) was not exempting /api/health from the session-cookie check, causing every request to be redirected to /login. The CI smoke test follows redirects (-L) so it landed on the login page HTML (HTTP 200) instead of {"status":"ok"}, triggering the body-check failure after all 30 retries.

Fix: add "/api/health" to PUBLIC_PATHS so the route is reachable without authentication — required by the Docker HEALTHCHECK and the dirty-migration smoke test.

Also adds a unit test for the proxy middleware covering all public paths, the protected-path redirect, cookie bypass, and the CVE-2025-29927 header block.

https://claude.ai/code/session_019KQbv8p3vidP3QvX6c4rGW