### PR TITLE
fix: clean up root-owned temp files in dirty-migration smoke test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           DIRTY_DIR=$(mktemp -d)
           # Ensure cleanup even if the step fails or times out
-          trap 'docker rm -f thinkarr-dirty-test 2>/dev/null || true; rm -rf "${DIRTY_DIR}"' EXIT
+          trap 'docker rm -f thinkarr-dirty-test 2>/dev/null || true; docker run --rm -v "${DIRTY_DIR}:/cleanup" alpine sh -c "rm -rf /cleanup/*" 2>/dev/null || true; rm -rf "${DIRTY_DIR}" 2>/dev/null || true' EXIT
 
           # Create dirty DB using the project's own drizzle setup
           node scripts/create-dirty-db.mjs "${DIRTY_DIR}"


### PR DESCRIPTION
The Docker container runs as root, so files written to the mounted DIRTY_DIR volume are owned by root. The runner user cannot rm -rf them, causing the trap EXIT handler to fail with "Operation not permitted" even though the test itself passed.

Fix: spin up a temporary Alpine container (as root) to delete the files before attempting rm -rf from the runner. Both rm calls now use || true so a leftover empty dir never fails the step.

https://claude.ai/code/session_019KQbv8p3vidP3QvX6c4rGW