### PR TITLE
chore: bump version to 1.1.1 (stable release)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1006,3 +1006,12 @@ Final `"Database ready"` line confirms all checks passed and the app is serving 
 | File | Change |
 |------|--------|
 | `src/lib/db/index.ts` | Added 4-section startup diagnostic log sequence; `ensureSchemaIntegrity` logs per-table result; NOT NULL error includes structured context |
+
+
+### Phase 36: Version Bump to 1.1.1
+
+Bumped `package.json` version from `1.1.1-beta.5` to `1.1.1` (stable release).
+
+| File | Change |
+|------|--------|
+| `package.json` | Version `1.1.1-beta.5` → `1.1.1` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.1-beta.5",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Promotes 1.1.1-beta.5 → 1.1.1.

https://claude.ai/code/session_018DvVvjJc6M1yiaMqu2Psuk