### PR TITLE
feat: internal log endpoint for Claude diagnostics (issue #132)

### DIFF
--- a/.claude/commands/beta-logs.md
+++ b/.claude/commands/beta-logs.md
@@ -1,0 +1,14 @@
+Fetch the last 300 log lines from the beta server and use them as diagnostic context before responding.
+
+```bash
+curl -s -H "X-Api-Key: $THINKARR_INTERNAL_KEY" \
+  "https://ai-beta.plexorcist.synology.me/api/internal/logs?tail=300"
+```
+
+If `THINKARR_INTERNAL_KEY` is not set or the request returns 401:
+1. Open the beta admin UI and navigate to **Settings → Logs → Internal API Key**
+2. Copy the key
+3. Add it to your `.claude/settings.json` under `env` as `THINKARR_INTERNAL_KEY`
+4. Re-run this command
+
+Do not commit or log the key value.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,3 +138,12 @@ For every feature or bug fix, check whether a unit or E2E test already covers th
 - E2E tests live in `tests/e2e/` and use Playwright.
 - Prefer unit tests for logic/API behaviour; prefer E2E tests only for UI interactions that can't be covered at the unit level.
 - If an existing test already covers the behaviour, no new test is needed — but do not remove or weaken existing tests.
+## Rule: use /beta-logs before diagnosing runtime issues
+
+When investigating a bug reported against beta (unexpected behaviour,
+missing data, wrong API response), run /beta-logs first to pull the last
+300 log lines from the live container before forming a hypothesis.
+
+- The command requires `THINKARR_INTERNAL_KEY` to be set in `.claude/settings.json` under `env`
+- Retrieve the key from **Settings → Logs → Internal API Key** in the beta admin UI
+- Do not commit or log the key value

--- a/PLAN.md
+++ b/PLAN.md
@@ -1015,3 +1015,62 @@ Bumped `package.json` version from `1.1.1-beta.5` to `1.1.1` (stable release).
 | File | Change |
 |------|--------|
 | `package.json` | Version `1.1.1-beta.5` → `1.1.1` |
+
+### Phase 37: Internal Log Endpoint for Claude Diagnostics (Issue #132)
+
+Adds a zero-config internal diagnostic endpoint so Claude can pull live log lines directly from the
+running container without needing a Plex session or shell access.
+
+#### Features
+
+- **`GET /api/internal/logs`** — Returns the last N log lines (default 300, max 2000) aggregated
+  across all daily log files in `/config/logs/`. Protected by a static `X-Api-Key` header; returns
+  `401` for any missing or incorrect key. No Plex session required.
+
+- **Auto-generated key on first boot** — `getDb()` now checks for `internal_api_key` in
+  `app_config` immediately after schema integrity passes. If absent it generates a 64-char hex key
+  via `crypto.randomBytes(32)` and persists it with `encrypted: true`. Fully zero-config for the
+  operator.
+
+- **`GET /api/settings/internal-api-key`** — Admin-session-protected endpoint that returns the
+  current key so the settings UI can display it.
+
+- **`POST /api/settings/internal-api-key`** — Admin-session-protected endpoint that generates and
+  stores a new key, returning the new value immediately.
+
+- **Settings UI — Internal API Key card** — Added to the Logs tab above the file viewer. Shows the
+  key in a read-only input with a Copy button and a Regenerate button (same pattern as the MCP
+  bearer token). Key is loaded when the Logs tab is first opened.
+
+- **`.claude/commands/beta-logs.md`** — Custom slash command. Running `/beta-logs` in a Claude
+  session executes `curl -s -H "X-Api-Key: $THINKARR_INTERNAL_KEY" …/api/internal/logs?tail=300`
+  and uses the output as diagnostic context.
+
+- **`CLAUDE.md` rule** — New section "Rule: use /beta-logs before diagnosing runtime issues"
+  documents when to run the command and how to set `THINKARR_INTERNAL_KEY` in settings.json.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/app/api/internal/logs/route.ts` | New — `GET /api/internal/logs`, X-Api-Key auth, tail param |
+| `src/app/api/settings/internal-api-key/route.ts` | New — `GET` / `POST` for admin UI display + regeneration |
+| `src/lib/db/index.ts` | Auto-generate `internal_api_key` on first boot after schema integrity check |
+| `src/app/settings/page.tsx` | Internal API Key card added to Logs tab; state + fetch functions added |
+| `.claude/commands/beta-logs.md` | New slash command — fetches live logs from beta container |
+| `CLAUDE.md` | Added "use /beta-logs before diagnosing runtime issues" rule |
+| `src/__tests__/api/internal-logs.test.ts` | New — 401 on missing/wrong key, 200 on valid key, tail param, multi-file aggregation |
+
+#### Config keys added
+
+| Key | Encrypted | Description |
+|-----|-----------|-------------|
+| `internal_api_key` | true | 64-char hex key for `GET /api/internal/logs` |
+
+#### API routes added
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/internal/logs` | `X-Api-Key` header | Return last N log lines |
+| `GET` | `/api/settings/internal-api-key` | Admin session | Fetch current key for UI display |
+| `POST` | `/api/settings/internal-api-key` | Admin session | Regenerate and return new key |

--- a/src/__tests__/api/internal-logs.test.ts
+++ b/src/__tests__/api/internal-logs.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for GET /api/internal/logs
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+import path from "path";
+import fs from "fs";
+
+// ── Mock getConfig ────────────────────────────────────────────────────────────
+
+const mockGetConfig = vi.fn();
+vi.mock("@/lib/config", () => ({ getConfig: (key: string) => mockGetConfig(key) }));
+
+// ── Temp dir setup ────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let logsDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "thinkarr-internal-logs-test-"));
+  logsDir = path.join(tmpDir, "logs");
+  process.env.CONFIG_DIR = tmpDir;
+  // Default: valid key stored
+  mockGetConfig.mockImplementation((key: string) =>
+    key === "internal_api_key" ? "test-secret-key-abc" : null,
+  );
+});
+
+async function getRoute() {
+  vi.resetModules();
+  const mod = await import("@/app/api/internal/logs/route");
+  return mod.GET;
+}
+
+function makeRequest(url: string, apiKey?: string): Request {
+  return new Request(url, apiKey ? { headers: { "x-api-key": apiKey } } : {});
+}
+
+// ── Auth tests ────────────────────────────────────────────────────────────────
+
+describe("GET /api/internal/logs — authentication", () => {
+  it("returns 401 when no X-Api-Key header is provided", async () => {
+    const GET = await getRoute();
+    const res = await GET(makeRequest("http://localhost/api/internal/logs"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 401 when X-Api-Key header is wrong", async () => {
+    const GET = await getRoute();
+    const res = await GET(makeRequest("http://localhost/api/internal/logs", "wrong-key"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 401 when internal_api_key is not set in config", async () => {
+    mockGetConfig.mockReturnValue(null);
+    const GET = await getRoute();
+    const res = await GET(makeRequest("http://localhost/api/internal/logs", "any-key"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with valid X-Api-Key", async () => {
+    const GET = await getRoute();
+    const res = await GET(
+      makeRequest("http://localhost/api/internal/logs", "test-secret-key-abc"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+});
+
+// ── Response shape tests ──────────────────────────────────────────────────────
+
+describe("GET /api/internal/logs — response", () => {
+  const VALID_KEY = "test-secret-key-abc";
+
+  it("returns empty lines when logs dir does not exist", async () => {
+    const GET = await getRoute();
+    const res = await GET(makeRequest("http://localhost/api/internal/logs", VALID_KEY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.lines).toEqual([]);
+    expect(body.data.tail).toBe(0);
+  });
+
+  it("returns last 300 lines by default", async () => {
+    fs.mkdirSync(logsDir, { recursive: true });
+    const lines = Array.from({ length: 400 }, (_, i) => `line ${i + 1}`);
+    fs.writeFileSync(path.join(logsDir, "thinkarr-2026-03-24.log"), lines.join("\n"));
+
+    const GET = await getRoute();
+    const res = await GET(makeRequest("http://localhost/api/internal/logs", VALID_KEY));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.lines).toHaveLength(300);
+    expect(body.data.lines[299]).toBe("line 400");
+    expect(body.data.lines[0]).toBe("line 101");
+  });
+
+  it("honours ?tail= parameter", async () => {
+    fs.mkdirSync(logsDir, { recursive: true });
+    const lines = Array.from({ length: 100 }, (_, i) => `entry ${i + 1}`);
+    fs.writeFileSync(path.join(logsDir, "thinkarr-2026-03-24.log"), lines.join("\n"));
+
+    const GET = await getRoute();
+    const res = await GET(
+      makeRequest("http://localhost/api/internal/logs?tail=10", VALID_KEY),
+    );
+    const body = await res.json();
+    expect(body.data.lines).toHaveLength(10);
+    expect(body.data.lines[9]).toBe("entry 100");
+  });
+
+  it("collects lines across multiple log files in chronological order", async () => {
+    fs.mkdirSync(logsDir, { recursive: true });
+    fs.writeFileSync(path.join(logsDir, "thinkarr-2026-03-23.log"), "day1-line1\nday1-line2\n");
+    fs.writeFileSync(path.join(logsDir, "thinkarr-2026-03-24.log"), "day2-line1\nday2-line2\n");
+
+    const GET = await getRoute();
+    const res = await GET(
+      makeRequest("http://localhost/api/internal/logs?tail=10", VALID_KEY),
+    );
+    const body = await res.json();
+    expect(body.data.lines).toEqual([
+      "day1-line1",
+      "day1-line2",
+      "day2-line1",
+      "day2-line2",
+    ]);
+  });
+});

--- a/src/app/api/internal/logs/route.ts
+++ b/src/app/api/internal/logs/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { getConfig } from "@/lib/config";
+import path from "path";
+import fs from "fs";
+import type { ApiResponse } from "@/types/api";
+
+const CONFIG_DIR =
+  process.env.CONFIG_DIR || (process.platform === "win32" ? "./.config" : "/config");
+const LOGS_DIR = path.join(CONFIG_DIR, "logs");
+
+const DEFAULT_TAIL = 300;
+const MAX_TAIL = 2000;
+
+export async function GET(request: Request) {
+  const providedKey = request.headers.get("x-api-key");
+  const storedKey = getConfig("internal_api_key");
+
+  if (!providedKey || !storedKey || providedKey !== storedKey) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const tailParam = searchParams.get("tail");
+  const parsed = parseInt(tailParam ?? "", 10);
+  const tail = Math.min(Math.max(1, isNaN(parsed) ? DEFAULT_TAIL : parsed), MAX_TAIL);
+
+  if (!fs.existsSync(LOGS_DIR)) {
+    return NextResponse.json<ApiResponse>({ success: true, data: { lines: [], tail: 0 } });
+  }
+
+  // Collect all log files in chronological order (lexicographic sort = date order for thinkarr-YYYY-MM-DD.log)
+  const logFiles = fs
+    .readdirSync(LOGS_DIR)
+    .filter((f) => f.endsWith(".log"))
+    .sort();
+
+  const allLines: string[] = [];
+  for (const filename of logFiles) {
+    const content = fs.readFileSync(path.join(LOGS_DIR, filename), "utf-8");
+    const lines = content.split("\n").filter((l) => l.trim() !== "");
+    allLines.push(...lines);
+  }
+
+  const lines = allLines.slice(-tail);
+
+  return NextResponse.json<ApiResponse>({
+    success: true,
+    data: { lines, tail: lines.length },
+  });
+}

--- a/src/app/api/settings/internal-api-key/route.ts
+++ b/src/app/api/settings/internal-api-key/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getConfig, setConfig } from "@/lib/config";
+import { randomBytes } from "crypto";
+import type { ApiResponse } from "@/types/api";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session || !session.user.isAdmin) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  const key = getConfig("internal_api_key") ?? "";
+  return NextResponse.json<ApiResponse>({ success: true, data: { key } });
+}
+
+export async function POST() {
+  const session = await getSession();
+  if (!session || !session.user.isAdmin) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  const key = randomBytes(32).toString("hex");
+  setConfig("internal_api_key", key, true);
+  return NextResponse.json<ApiResponse>({ success: true, data: { key } });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -142,6 +142,10 @@ export default function SettingsPage() {
   const [logTotalLines, setLogTotalLines] = useState(0);
   const [logShowing, setLogShowing] = useState(0);
 
+  // Internal API key state (admin only)
+  const [internalApiKey, setInternalApiKey] = useState<string>("");
+  const [internalApiKeyLoading, setInternalApiKeyLoading] = useState(false);
+
   // --- Load data ---
   useEffect(() => {
     // Always fetch session first to determine admin status
@@ -494,6 +498,33 @@ export default function SettingsPage() {
     }
   }
 
+  // --- Internal API key ---
+  async function loadInternalApiKey() {
+    setInternalApiKeyLoading(true);
+    try {
+      const res = await fetch("/api/settings/internal-api-key");
+      const data = await res.json();
+      if (data.success) setInternalApiKey(data.data.key);
+    } catch {
+      // Silent fail
+    } finally {
+      setInternalApiKeyLoading(false);
+    }
+  }
+
+  async function regenerateInternalApiKey() {
+    setInternalApiKeyLoading(true);
+    try {
+      const res = await fetch("/api/settings/internal-api-key", { method: "POST" });
+      const data = await res.json();
+      if (data.success) setInternalApiKey(data.data.key);
+    } catch {
+      // Silent fail
+    } finally {
+      setInternalApiKeyLoading(false);
+    }
+  }
+
   // --- User management ---
   async function updateUser(userId: number, updates: Partial<Pick<UserEntry, "isAdmin" | "defaultModel" | "canChangeModel" | "rateLimitMessages" | "rateLimitPeriod">>) {
     try {
@@ -615,7 +646,7 @@ export default function SettingsPage() {
           </div>
         )}
 
-        <Tabs defaultValue={isInitialSetup ? "llm" : "general"} onValueChange={(v) => { if (v === "logs") loadLogFiles(); }}>
+        <Tabs defaultValue={isInitialSetup ? "llm" : "general"} onValueChange={(v) => { if (v === "logs") { loadLogFiles(); loadInternalApiKey(); } }}>
           <TabsList>
             <TabsTrigger value="general">General</TabsTrigger>
             {currentUser?.isAdmin && <TabsTrigger value="llm">LLM Setup</TabsTrigger>}
@@ -1310,7 +1341,47 @@ export default function SettingsPage() {
           </TabsContent>
 
           {/* ===== TAB 5: Logs (admin only) ===== */}
-          <TabsContent value="logs" className="mt-4">
+          <TabsContent value="logs" className="mt-4 space-y-4">
+            {/* Internal API Key */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Internal API Key</CardTitle>
+                <CardDescription>
+                  Use this key with the <code className="font-mono text-xs">/beta-logs</code> Claude slash command to pull live diagnostic logs.
+                  Set it as <code className="font-mono text-xs">THINKARR_INTERNAL_KEY</code> in your Claude settings.json.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={internalApiKey}
+                    readOnly
+                    className="font-mono text-sm"
+                    placeholder={internalApiKeyLoading ? "Loading…" : "Click regenerate to reveal key"}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => copyToClipboard(internalApiKey)}
+                    disabled={!internalApiKey}
+                  >
+                    <Copy size={14} />
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="icon"
+                    onClick={regenerateInternalApiKey}
+                    disabled={internalApiKeyLoading}
+                  >
+                    {internalApiKeyLoading ? <Spinner size={14} /> : <RefreshCw size={14} />}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Regenerating issues a new key immediately — update your Claude settings.json after regenerating.
+                </p>
+              </CardContent>
+            </Card>
+
             <Card>
               <CardHeader>
                 <CardTitle className="text-lg">Application Logs</CardTitle>

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,11 +1,12 @@
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import { getTableColumns, getTableName, is } from "drizzle-orm";
+import { getTableColumns, getTableName, is, eq } from "drizzle-orm";
 import { SQLiteTable } from "drizzle-orm/sqlite-core";
 import * as schema from "./schema";
 import path from "path";
 import fs from "fs";
+import { randomBytes } from "crypto";
 import { logger } from "@/lib/logger";
 
 const DB_DIR = process.env.CONFIG_DIR || (process.platform === "win32" ? "./.config" : "/config");
@@ -176,6 +177,24 @@ export function getDb() {
     // Logs one line per table (OK / repaired / throws on NOT NULL drift).
     ensureSchemaIntegrity(sqlite);
     logger.info("Database ready");
+
+    // ── 5. Auto-generate internal API key ────────────────────────────────────
+    // Generated once on first boot; the operator copies it from
+    // Settings → Logs → Internal API Key and gives it to Claude for
+    // the /beta-logs diagnostic command.
+    const existingApiKey = _db
+      .select({ value: schema.appConfig.value })
+      .from(schema.appConfig)
+      .where(eq(schema.appConfig.key, "internal_api_key"))
+      .get();
+    if (!existingApiKey) {
+      const newKey = randomBytes(32).toString("hex");
+      _db
+        .insert(schema.appConfig)
+        .values({ key: "internal_api_key", value: newKey, encrypted: true, updatedAt: new Date() })
+        .run();
+      logger.info("Generated internal API key for diagnostic endpoint");
+    }
   }
   return _db;
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/internal/logs` protected by `X-Api-Key` header — returns the last N log lines (default 300) aggregated across all daily log files; no Plex session required
- `internal_api_key` is auto-generated on first boot via `crypto.randomBytes(32)` and stored in `app_config` with `encrypted: true` — zero operator config required
- `GET /POST /api/settings/internal-api-key` — admin-only endpoints for the UI to fetch and regenerate the key
- **Settings → Logs tab**: new Internal API Key card with copy + regenerate buttons (same UX pattern as the MCP token)
- `.claude/commands/beta-logs.md` — `/beta-logs` slash command that curls the endpoint using `$THINKARR_INTERNAL_KEY`
- `CLAUDE.md`: new rule "use /beta-logs before diagnosing runtime issues"

## Test plan

- [ ] `GET /api/internal/logs` with no header → 401
- [ ] `GET /api/internal/logs` with wrong key → 401
- [ ] `GET /api/internal/logs` with correct key → 200 + `{ lines: [...], tail: N }`
- [ ] `?tail=50` returns at most 50 lines
- [ ] Fresh DB: key is generated on startup, visible in Settings → Logs
- [ ] Regenerate button issues a new key; old key returns 401 after regeneration
- [ ] `/beta-logs` slash command works end-to-end with `THINKARR_INTERNAL_KEY` set in settings.json
- [ ] Unit tests pass: `npm test src/__tests__/api/internal-logs.test.ts`

Closes #132

https://claude.ai/code/session_01E6hBmtMiNjcrKaZGroWZSd