### PR TITLE
chore: bump version to 1.1.2-beta.1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1119,3 +1119,9 @@ running container without needing a Plex session or shell access.
 | `github_repo` | false | GitHub repository name (default: `thinkarr`) |
 
 Admin can now configure GitHub issue reporting credentials directly in **Settings → Logs** without needing environment variables. Token stored encrypted; owner/repo stored plain. Env vars (`GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`) still take precedence when set.
+
+
+### Phase: Version 1.1.2-beta.1
+
+#### Version bump
+- [x] Bumped `package.json` version from `1.1.1` to `1.1.2-beta.1`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.1",
+  "version": "1.1.2-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `1.1.1` to `1.1.2-beta.1`
- Updates `PLAN.md` to document the version bump

## Test plan

- [ ] Verify `package.json` version reads `1.1.2-beta.1`
- [ ] CI passes

https://claude.ai/code/session_01PGJtTtQvba1NUxrGitdFBc