### PR TITLE
chore: bump version to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.2-beta.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Promotes `1.1.2-beta.1` → `1.1.2` stable release

## Security checks
- `npm audit --audit-level=high`: ✅ pass (4 moderate, 0 high/critical)
- Semgrep SAST: requires WSL2 — run locally before merging `dev → beta`
- Trivy Docker scan: requires WSL2 — run locally before merging `dev → beta`

## Test plan
- [ ] CI passes on this PR
- [ ] Merge into `dev`
- [ ] Run Semgrep + Trivy locally in WSL2, confirm clean
- [ ] Open `dev → beta` PR

https://claude.ai/code/session_01JWQKCLDbQ4xSysSDmB61kr