### PR TITLE
dev → beta (v1.1.2)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1158,3 +1158,52 @@ Admin can now configure GitHub issue reporting credentials directly in **Setting
 |------|--------|
 | `src/lib/auth/session.ts` | Import `logger`; add `logger.warn("Session expired or not found", { sessionId })` before the existing `return null` at line 75 |
 | `src/__tests__/api/session.test.ts` | Add `logWarnSpy`; new test case: expired session cookie returns 401 and logs the warning with the sessionId |
+
+### Phase 41: Fix Overseerr search — parentheses in query cause HTTP 400
+
+#### Bug
+Log analysis of conversation `81f6c0cd` revealed `overseerr_search` returning HTTP 400 when the user searched for titles like `"Star Trek (2009)"`. Overseerr validates the decoded query value server-side and rejects RFC 3986 reserved characters including `(` and `)`. The existing `encodeURIComponent` encoding is insufficient because Overseerr decodes the value before validation.
+
+#### Fix
+- Strip RFC 3986 reserved characters (`( ) [ ] { } ! $ & ' * + , ; = ? # @ / \`) from the query string before encoding, collapsing extra whitespace. The movie/show is still found correctly — e.g. `"Star Trek (2009)"` → `"Star Trek 2009"`.
+
+#### Test
+- Added regression test: `"Star Trek (2009)"` must call `fetch` with a URL containing no `(` or `)` and must contain `Star%20Trek%202009`.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/services/overseerr.ts` | Strip reserved characters from query before `encodeURIComponent` in `search()` |
+| `src/__tests__/lib/overseerr.test.ts` | New test: parentheses stripped from query |
+
+### Phase 42: Fix stuck spinners and mobile SSE reconnection
+
+#### Bugs
+Two related issues observed in beta logs (conversation `81f6c0cd`):
+
+1. **Stuck spinner after SSE disconnect** — `buildHistoricalToolCalls` left incomplete tool calls with `status: "calling"` when rebuilding from the DB after a reload. Since `"calling"` renders a spinner, any tool call that never completed (e.g. because the stream dropped) showed an infinite spinner after reconnecting.
+
+2. **Mobile backgrounding silently kills stream** — When Chrome on mobile is backgrounded, the browser can silently suspend the SSE stream without throwing an error. The `finally` block (which reloads messages and clears state) never fired until the user manually retried.
+
+#### Fix
+- `message-list.tsx`: change the fallback status in `buildHistoricalToolCalls` from `"calling"` to `"error"` with message `"Connection was lost"` for tool calls that have no result record in the DB.
+- `use-chat.ts`: add a `visibilitychange` listener. When the page becomes visible after being hidden for > 3 s while a stream is active, abort the stream. The existing `finally` block then fires, reloads messages, and clears spinners.
+- `buildHistoricalToolCalls` is exported so it can be unit-tested directly.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/components/chat/message-list.tsx` | Export `buildHistoricalToolCalls`; change fallback status from `"calling"` to `"error"` with "Connection was lost" |
+| `src/hooks/use-chat.ts` | Add `visibilitychange` listener to abort stale streams on mobile foreground |
+| `src/__tests__/lib/build-historical-tool-calls.test.ts` | New — 3 unit tests: done, interrupted (no result), and error result |
+
+### Phase 42 (addendum): Background SSE resilience
+
+#### Root cause
+When mobile Chrome backgrounds the app, the client TCP connection drops. This causes `controller.enqueue()` to throw (WHATWG streams cancel the controller when the consumer disconnects). That throw propagated through `for await (const event of orchestrate(...))` in `route.ts`, abandoning the generator mid-execution — before tool results were saved to DB.
+
+#### Fix
+- `src/app/api/chat/route.ts`: Introduced `enqueue()` helper that catches `controller.enqueue()` errors and sets `clientConnected = false`. The `for await` loop continues iterating the orchestrator generator regardless — tool calls execute to completion and results are saved to DB. `controller.close()` in the `finally` block is also wrapped since it may also throw on an already-cancelled stream.
+- `src/hooks/use-chat.ts`: Added `visibilitychange` listener (after all `useCallback` hooks so `loadMessages` is in scope). When the page becomes visible and no stream is active, reloads messages from DB so server-side results that completed while the page was backgrounded are immediately shown.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.2-beta.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.2-beta.1",
+      "version": "1.1.2",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "clsx": "^2.1.1",

--- a/src/__tests__/lib/build-historical-tool-calls.test.ts
+++ b/src/__tests__/lib/build-historical-tool-calls.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { buildHistoricalToolCalls } from "@/components/chat/message-list";
+import type { Message } from "@/types";
+
+function makeMsg(overrides: Partial<Message>): Message {
+  return {
+    id: "msg-1",
+    conversationId: "conv-1",
+    role: "assistant",
+    content: null,
+    toolCalls: null,
+    toolCallId: null,
+    toolName: null,
+    durationMs: null,
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+const TOOL_CALLS_JSON = JSON.stringify([
+  { id: "tc-1", function: { name: "overseerr_search", arguments: '{"query":"Star Trek"}' } },
+]);
+
+describe("buildHistoricalToolCalls — spinner / reconnection fixes", () => {
+  it("marks tool call as 'done' when a result message exists", () => {
+    const assistantMsg = makeMsg({ id: "a-1", role: "assistant", toolCalls: TOOL_CALLS_JSON });
+    const resultMsg = makeMsg({
+      id: "r-1",
+      role: "tool",
+      toolCallId: "tc-1",
+      content: JSON.stringify({ results: [] }),
+      durationMs: 42,
+    });
+
+    const map = buildHistoricalToolCalls([assistantMsg, resultMsg]);
+    const displays = map.get("a-1")!;
+    expect(displays).toHaveLength(1);
+    expect(displays[0].status).toBe("done");
+    expect(displays[0].error).toBeUndefined();
+  });
+
+  it("marks tool call as 'error' (not 'calling') when no result exists — prevents stuck spinner", () => {
+    // Simulates an interrupted stream: assistant message saved to DB but tool
+    // result was never written (mobile disconnect / server crash).
+    const assistantMsg = makeMsg({ id: "a-1", role: "assistant", toolCalls: TOOL_CALLS_JSON });
+
+    const map = buildHistoricalToolCalls([assistantMsg]);
+    const displays = map.get("a-1")!;
+    expect(displays).toHaveLength(1);
+    expect(displays[0].status).toBe("error");
+    expect(displays[0].error).toBe("Connection was lost");
+  });
+
+  it("marks tool call as 'error' with error message when result contains an error", () => {
+    const assistantMsg = makeMsg({ id: "a-1", role: "assistant", toolCalls: TOOL_CALLS_JSON });
+    const resultMsg = makeMsg({
+      id: "r-1",
+      role: "tool",
+      toolCallId: "tc-1",
+      content: JSON.stringify({ error: "Overseerr API error: HTTP 400" }),
+      durationMs: 8,
+    });
+
+    const map = buildHistoricalToolCalls([assistantMsg, resultMsg]);
+    const displays = map.get("a-1")!;
+    expect(displays[0].status).toBe("error");
+    expect(displays[0].error).toBe("Overseerr API error: HTTP 400");
+  });
+});

--- a/src/__tests__/lib/overseerr.test.ts
+++ b/src/__tests__/lib/overseerr.test.ts
@@ -302,6 +302,25 @@ describe("search — issue #128: query URL encoding", () => {
     expect(calledUrl).not.toContain("Top Gun: Maverick");
     expect(calledUrl).toContain("Top%20Gun%3A%20Maverick");
   });
+
+  it("strips parentheses from query so Overseerr does not return HTTP 400", async () => {
+    // Overseerr validates the decoded query value and rejects RFC 3986 reserved
+    // characters such as '(' and ')' with HTTP 400. Queries like "Star Trek (2009)"
+    // must have parentheses removed before being sent to the API.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [], totalPages: 1 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { search } = await import("@/lib/services/overseerr");
+    await search("Star Trek (2009)");
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain("(");
+    expect(calledUrl).not.toContain(")");
+    expect(calledUrl).toContain("Star%20Trek%202009");
+  });
 });
 
 describe("search — issue #109: pagination and hasMore", () => {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -94,14 +94,32 @@ export async function POST(request: Request) {
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     async start(controller) {
+      // Track whether the SSE client is still connected. When the client
+      // disconnects (e.g. mobile app backgrounded), controller.enqueue()
+      // throws because the WHATWG stream is cancelled. We catch that error
+      // so the orchestrator keeps running and saves all tool results to the
+      // DB — the client can reload the conversation when it reconnects.
+      let clientConnected = true;
+
+      const enqueue = (line: Uint8Array) => {
+        if (!clientConnected) return;
+        try {
+          controller.enqueue(line);
+        } catch {
+          clientConnected = false;
+          logger.info("SSE client disconnected — continuing orchestration in background", {
+            conversationId: body.conversationId,
+          });
+        }
+      };
+
       try {
         for await (const event of orchestrate({
           conversationId: body.conversationId,
           userMessage: body.message,
           modelId: body.modelId,
         })) {
-          const line = `data: ${JSON.stringify(event)}\n\n`;
-          controller.enqueue(encoder.encode(line));
+          enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
         }
 
         // 6. Generate title for new chats and emit it before closing so the
@@ -110,17 +128,16 @@ export async function POST(request: Request) {
           const newTitle = await generateTitle(body.conversationId, body.message);
           if (newTitle) {
             const titleEvent = { type: "title_update", conversationId: body.conversationId, title: newTitle };
-            controller.enqueue(encoder.encode(`data: ${JSON.stringify(titleEvent)}\n\n`));
+            enqueue(encoder.encode(`data: ${JSON.stringify(titleEvent)}\n\n`));
           }
         }
 
-        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        enqueue(encoder.encode("data: [DONE]\n\n"));
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "Stream error";
-        const errorLine = `data: ${JSON.stringify({ type: "error", message: msg })}\n\n`;
-        controller.enqueue(encoder.encode(errorLine));
+        enqueue(encoder.encode(`data: ${JSON.stringify({ type: "error", message: msg })}\n\n`));
       } finally {
-        controller.close();
+        try { controller.close(); } catch { /* already closed by client disconnect */ }
       }
     },
   });

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -14,7 +14,7 @@ interface MessageListProps {
 }
 
 /** Build tool call displays from historical messages stored in DB. */
-function buildHistoricalToolCalls(messages: Message[]): Map<string, ToolCallDisplay[]> {
+export function buildHistoricalToolCalls(messages: Message[]): Map<string, ToolCallDisplay[]> {
   const result = new Map<string, ToolCallDisplay[]>();
 
   // Index tool result messages by their toolCallId
@@ -45,9 +45,9 @@ function buildHistoricalToolCalls(messages: Message[]): Map<string, ToolCallDisp
             name: call.function.name,
             arguments: call.function.arguments || "{}",
             result: resultMsg?.content || undefined,
-            status: resultMsg ? (hasError ? "error" : "done") : "calling",
+            status: resultMsg ? (hasError ? "error" : "done") : "error",
             durationMs: resultMsg?.durationMs ?? undefined,
-            error: errorMessage,
+            error: errorMessage ?? (resultMsg ? undefined : "Connection was lost"),
           });
         }
         if (displays.length > 0) {

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import type { Message } from "@/types";
 import type { ToolCallDisplay } from "@/types/chat";
 import { generateId } from "@/lib/utils";
@@ -210,6 +210,20 @@ export function useChat(conversationId: string | null, options?: UseChatOptions)
     setToolCalls(new Map());
     setError(null);
   }, []);
+
+  // When the user returns to the page (e.g. after backgrounding Chrome on
+  // mobile), reload messages so any tool results that completed server-side
+  // while the SSE connection was down are immediately visible.
+  // Only fires when not actively streaming — avoids racing with a live stream.
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible" && !streamingRef.current && conversationIdRef.current) {
+        void loadMessages(conversationIdRef.current);
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [loadMessages]);
 
   return {
     messages,

--- a/src/lib/services/overseerr.ts
+++ b/src/lib/services/overseerr.ts
@@ -97,8 +97,13 @@ export async function search(query: string, page = 1): Promise<{ results: Overse
   // Use encodeURIComponent to produce RFC 3986-compliant %20 encoding for spaces
   // and other reserved characters (#128). URLSearchParams uses + for spaces which
   // some servers do not decode as a space character.
+  //
+  // Overseerr validates the decoded query value server-side and rejects RFC 3986
+  // reserved characters such as '(' and ')' with HTTP 400. Strip them before
+  // encoding so queries like "Star Trek (2009)" succeed (#overseerr-paren-fix).
+  const sanitized = query.replace(/[()[\]{}!$&'*+,;=?#@/\\]/g, " ").replace(/\s+/g, " ").trim();
   const data = await overseerrFetch(
-    `/search?query=${encodeURIComponent(query)}&page=${encodeURIComponent(String(page))}&language=en`,
+    `/search?query=${encodeURIComponent(sanitized)}&page=${encodeURIComponent(String(page))}&language=en`,
   );
   const raw = (data?.results || []) as Record<string, unknown>[];
   const totalPages = (data?.totalPages as number | undefined) ?? 1;


### PR DESCRIPTION
## Summary

Promotes `dev` → `beta` for release v1.1.2.

### Included fixes (from PR #173)

- **Overseerr HTTP 400 on parentheses in query** — strip RFC 3986 reserved chars before encoding; `"Star Trek (2009)"` → `"Star Trek 2009"`
- **Stuck spinner after disconnect** — `buildHistoricalToolCalls` now returns `status: "error"` (not `"calling"`) for tool calls with no DB result
- **Mobile backgrounding kills orchestration** — `controller.enqueue()` no longer kills the orchestrator on client disconnect; tool results complete and are saved to DB; `visibilitychange` listener reloads messages on foreground

## Security checks

- [x] `npm run security:audit` — exits 0 (4 moderate vulns in `drizzle-kit` dev dep only, no HIGH/CRITICAL)
- [ ] Semgrep SAST — run locally from WSL2 before merging
- [ ] Trivy Docker image scan — run locally from WSL2 before merging

## Test plan

- [x] 317 unit tests pass
- [ ] Search `"Star Trek (2009)"` on beta — should return results without 400
- [ ] Background Chrome on mobile mid-response, return — results should appear, no spinner/error

https://claude.ai/code/session_016tQg9VWtpFNTz1augWTCCR