### PR TITLE
fix: resolve CodeQL unvalidated dynamic method call in client-log route

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1291,3 +1291,41 @@ Added `sanitizeLlmError()` helper in `orchestrator.ts`. Raw error is preserved i
 |------|--------|
 | `src/lib/llm/orchestrator.ts` | Add `sanitizeLlmError()`; use it in the LLM catch block instead of forwarding raw error |
 | `src/__tests__/lib/orchestrator.test.ts` | 2 new tests: 429 yields friendly rate-limit message; generic error yields friendly fallback |
+
+### Phase 46: Fix CodeQL unvalidated dynamic method call in client-log route
+
+#### Issue
+GitHub Code Scanning (CodeQL) alert #25 flagged `src/app/api/client-log/route.ts` line 53:
+
+```typescript
+logger[level](`[client] ${message}`, ...);
+```
+
+Even though `level` is validated to only be `"warn"`, `"error"`, or `"info"`, CodeQL cannot trace through the ternary expression and flags the dynamic property access as an "unvalidated dynamic method call" — a real pattern that can cause unexpected dispatch or prototype pollution in less controlled code.
+
+#### Fix
+Replaced the dynamic bracket access with an explicit `if/else if/else` dispatch:
+
+```typescript
+if (level === "warn") { logger.warn(...); }
+else if (level === "error") { logger.error(...); }
+else { logger.info(...); }
+```
+
+This eliminates the bracket notation entirely, satisfying CodeQL without changing runtime behaviour.
+
+#### Test
+New unit test suite `src/__tests__/api/client-log.test.ts` covering:
+- 401 when unauthenticated
+- 400 for invalid JSON
+- Correct logger method called for `info`, `warn`, `error` levels
+- Default to `info` for unknown or missing level
+- Message truncation at 500 characters
+- Default message for non-string input
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/app/api/client-log/route.ts` | Replace `logger[level](...)` with explicit `if/else if/else` dispatch |
+| `src/__tests__/api/client-log.test.ts` | New unit test suite (10 tests) |

--- a/src/__tests__/api/client-log.test.ts
+++ b/src/__tests__/api/client-log.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for POST /api/client-log
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth/session", () => ({ getSession: () => mockGetSession() }));
+
+const mockLogger = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
+
+// ── Route (imported after mocks) ──────────────────────────────────────────────
+
+import { POST } from "@/app/api/client-log/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const mockSession = {
+  sessionId: "test-session",
+  user: { id: 42, plexId: "plex1", plexUsername: "tester", plexEmail: "t@t.com", plexAvatarUrl: null, isAdmin: false },
+};
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/client-log", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSession.mockResolvedValue(mockSession);
+});
+
+// ── Auth ───────────────────────────────────────────────────────────────────────
+
+describe("POST /api/client-log — authentication", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await POST(makeRequest({ message: "hi" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+});
+
+// ── Input validation ───────────────────────────────────────────────────────────
+
+describe("POST /api/client-log — input validation", () => {
+  it("returns 400 for invalid JSON", async () => {
+    const req = new Request("http://localhost/api/client-log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 200 and succeeds with valid body", async () => {
+    const res = await POST(makeRequest({ message: "hello", level: "info" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+});
+
+// ── Log level dispatch ─────────────────────────────────────────────────────────
+
+describe("POST /api/client-log — log level dispatch", () => {
+  it("calls logger.info for level=info", async () => {
+    await POST(makeRequest({ message: "info msg", level: "info" }));
+    expect(mockLogger.info).toHaveBeenCalledOnce();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.info.mock.calls[0][0]).toContain("info msg");
+  });
+
+  it("calls logger.warn for level=warn", async () => {
+    await POST(makeRequest({ message: "warn msg", level: "warn" }));
+    expect(mockLogger.warn).toHaveBeenCalledOnce();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.warn.mock.calls[0][0]).toContain("warn msg");
+  });
+
+  it("calls logger.error for level=error", async () => {
+    await POST(makeRequest({ message: "error msg", level: "error" }));
+    expect(mockLogger.error).toHaveBeenCalledOnce();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error.mock.calls[0][0]).toContain("error msg");
+  });
+
+  it("defaults to logger.info for unknown level", async () => {
+    await POST(makeRequest({ message: "unknown", level: "debug" }));
+    expect(mockLogger.info).toHaveBeenCalledOnce();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("defaults to logger.info when level is omitted", async () => {
+    await POST(makeRequest({ message: "no level" }));
+    expect(mockLogger.info).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Message sanitisation ───────────────────────────────────────────────────────
+
+describe("POST /api/client-log — message sanitisation", () => {
+  it("truncates messages longer than 500 characters", async () => {
+    const longMsg = "a".repeat(600);
+    await POST(makeRequest({ message: longMsg, level: "info" }));
+    expect(mockLogger.info).toHaveBeenCalledOnce();
+    const logged: string = mockLogger.info.mock.calls[0][0];
+    expect(logged.length).toBeLessThanOrEqual(510); // "[client] " + 500 chars
+  });
+
+  it("uses default message when message is not a string", async () => {
+    await POST(makeRequest({ message: 123, level: "info" }));
+    expect(mockLogger.info.mock.calls[0][0]).toContain("client log");
+  });
+});

--- a/src/app/api/client-log/route.ts
+++ b/src/app/api/client-log/route.ts
@@ -50,7 +50,17 @@ export async function POST(request: Request) {
   const message = typeof body.message === "string" ? body.message.slice(0, 500) : "client log";
   const context = body.context && typeof body.context === "object" ? body.context : {};
 
-  logger[level](`[client] ${message}`, { userId: session.user.id, ...context });
+  const logArgs: [string, Record<string, unknown>] = [
+    `[client] ${message}`,
+    { userId: session.user.id, ...context },
+  ];
+  if (level === "warn") {
+    logger.warn(...logArgs);
+  } else if (level === "error") {
+    logger.error(...logArgs);
+  } else {
+    logger.info(...logArgs);
+  }
 
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary

- CodeQL alert #25 flagged `logger[level](...)` in `src/app/api/client-log/route.ts` as an unvalidated dynamic method call
- Replace bracket notation with explicit `if/else if/else` dispatching to `logger.warn` / `logger.error` / `logger.info`
- No runtime behaviour change — `level` was already validated to one of the three values

## Test plan

- [x] 10 new unit tests in `src/__tests__/api/client-log.test.ts` covering auth (401), invalid JSON (400), all three log level dispatches, default-to-info for unknown/missing level, message truncation, and non-string message fallback
- [x] All tests pass locally
- [ ] CodeQL check passes in CI (alert #25 should no longer fire)

https://claude.ai/code/session_014kaYz5UqcxUTrnjqaoPFCg