### PR TITLE
chore: bump version to 1.1.3-beta.1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1431,3 +1431,14 @@ In `loadHistory()`, after parsing stored `tool_calls`, `display_titles` call arg
 | `src/lib/tools/radarr-tools.ts` | Add `llmSummary` to `radarr_search_movie`; import `RadarrMovie` type |
 | `src/lib/llm/orchestrator.ts` | Compact `display_titles` tool call args in `loadHistory()` |
 | `src/__tests__/lib/token-reduction.test.ts` | 9 new tests (15 total) covering all new summaries and call-arg compression |
+
+
+---
+
+## Phase 49 — Version bump to 1.1.3-beta.1
+
+Bumped `package.json` version from `1.1.2` to `1.1.3-beta.1` in preparation for the next beta release.
+
+| File | Change |
+|------|--------|
+| `package.json` | Version `1.1.2` → `1.1.3-beta.1` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `1.1.2` to `1.1.3-beta.1` in preparation for the next beta release
- Updates `PLAN.md` to document the version bump (Phase 49)

## Test plan

- [ ] Confirm `package.json` version reads `1.1.3-beta.1`
- [ ] CI passes

https://claude.ai/code/session_01CYktSXsJwbcQ9UkFZ5F4MK