### PR TITLE
fix(e2e): use aria-label selector for send button test

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -141,6 +141,7 @@ export function ChatInput({
                 size="icon"
                 onClick={handleSubmit}
                 disabled={disabled || !value.trim()}
+                aria-label="Send"
                 className="shrink-0"
               >
                 <SendHorizontal size={16} />

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -24,9 +24,9 @@ test.describe("Chat interface", () => {
   test("send button is disabled when the input is empty", async ({ page }) => {
     await page.goto("/chat");
     // The send button is only enabled when there is text in the textarea.
-    // It renders as an icon-only button, so we check its disabled state.
-    const sendBtn = page.locator("button[disabled]").last();
+    const sendBtn = page.getByRole("button", { name: "Send" });
     await expect(sendBtn).toBeVisible();
+    await expect(sendBtn).toBeDisabled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Next.js 16.2.1's Turbopack dev overlay injects a hidden, disabled `docs-link-button` that caused the E2E test's `button[disabled].last()` to resolve to the wrong element (the hidden overlay button rather than the send button)
- Add `aria-label="Send"` to the send button in `chat-input.tsx` (also improves accessibility for screen readers)
- Update the test to use `getByRole("button", { name: "Send" })` with an explicit `toBeDisabled()` assertion — more specific and resilient to future DOM changes

## Test plan

- [ ] E2E `Chat interface › send button is disabled when the input is empty` passes
- [ ] PR #155 (next 16.2.1 bump) E2E passes once this is merged and it rebases

https://claude.ai/code/session_01CYktSXsJwbcQ9UkFZ5F4MK