### PR TITLE
Fix #195, #196, #197: parallel tools, SSE heartbeat, series episodes, log cleanup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1529,3 +1529,35 @@ Bumped `package.json` version from `1.1.2` to `1.1.3-beta.1` in preparation for 
 | `src/app/api/chat/route.ts` | SSE heartbeat every 15s via `setInterval` (#195) |
 | `src/lib/llm/orchestrator.ts` | Parallel tool execution via `Promise.all` instead of sequential loop (#195) |
 | `src/__tests__/lib/plex.test.ts` | 7 new `getSeriesEpisodes` tests (#197) |
+
+### Phase 51: Tool History Trimming (token-bloat fix)
+
+#### Problem
+
+Long conversations accumulated tool-calling rounds unboundedly in the OpenAI message history. Even with `llmSummary` compressing individual tool results, each round added ~519 tokens (assistant tool-call message + compressed tool result). At 35+ turns, conversations reached 21k–27k tokens, approaching the TPM limit and causing 429 errors.
+
+#### Fix
+
+Added `trimToolHistory()` in `src/lib/llm/orchestrator.ts`, called from `loadHistory()` after the orphan-repair step.
+
+- Counts the number of assistant messages with `tool_calls` (= number of tool-calling rounds).
+- If the count exceeds `MAX_TOOL_ROUNDS_IN_HISTORY` (5), the oldest rounds are collapsed:
+  - `tool` result messages for dropped call IDs are removed entirely.
+  - The corresponding `assistant` message has its `tool_calls` array stripped and replaced with an inline text note: `[searched: plex_search_library]` (or a comma-separated list for multi-tool rounds).
+  - Any existing assistant text content is preserved prepended to the note.
+- All user messages and plain (non-tool-calling) assistant messages are kept intact.
+
+#### Effect
+
+Token cost of history is now capped. A conversation with 35 tool-calling rounds sends the same history size as one with 5, rather than growing linearly.
+
+#### Tests
+
+- [x] **`src/__tests__/lib/orchestrator.test.ts`** — 6 new `trimToolHistory — pure unit` tests covering: no-op under limit, trimming oldest rounds, `[searched:]` note injection, content preservation, user/plain-assistant survival count, boundary case at limit+1.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/llm/orchestrator.ts` | `trimToolHistory()` + `MAX_TOOL_ROUNDS_IN_HISTORY` exported; called from `loadHistory()` |
+| `src/__tests__/lib/orchestrator.test.ts` | 6 new pure unit tests for `trimToolHistory` |

--- a/PLAN.md
+++ b/PLAN.md
@@ -1485,3 +1485,47 @@ Bumped `package.json` version from `1.1.2` to `1.1.3-beta.1` in preparation for 
 | File | Change |
 |------|--------|
 | `package.json` | Version `1.1.2` → `1.1.3-beta.1` |
+
+---
+
+### Phase 50: LLM Optimizations & Plex Series Episodes Tool (#195, #196, #197)
+
+#### Bug Fixes
+
+- [x] **#196 — Tool calls logging full API responses** — `sonarrFetch()` and `radarrFetch()` were logging `body: JSON.stringify(data).slice(0, 5000)` on every successful response, flooding the logs with large JSON payloads. Removed the `body` field from the `Sonarr API response` and `Radarr API response` info logs. Plex and Overseerr were already correct (no body in success path). — `src/lib/services/sonarr.ts`, `src/lib/services/radarr.ts`
+
+#### Features
+
+- [x] **#197 — Plex series episodes tool with season/episode params** — New `getSeriesEpisodes(plexKey, season?, episode?)` function in `plex.ts` that fetches season or episode data for a TV show:
+  - No season/episode → returns one card per season ordered by season number (with `totalEpisodes` and `watchedEpisodes`); season 0 (specials) excluded
+  - Season only → returns episodes from that season ordered by episode number
+  - Season + episode → returns a single matching episode
+  - Uses the show's `plexKey` (from a prior `plex_search_library` result), fetches `/children` for seasons, then uses the season's `ratingKey` to fetch `/library/metadata/{ratingKey}/children` for episodes.
+
+  New `plex_get_series_episodes` MCP tool registered with `llmSummary` that preserves `seasonNumber`, `episodeNumber`, `totalEpisodes`, and `watchedEpisodes`. Tool description guides the LLM to prefer this tool over `plex_search_library` when the user asks about specific seasons or episodes. — `src/lib/services/plex.ts`, `src/lib/tools/plex-tools.ts`
+
+- [x] **#195 — SSE heartbeat to prevent client disconnects** — Added a `setInterval` that sends `: heartbeat\n\n` (SSE comment) every 15 seconds in `POST /api/chat`. Prevents mobile browsers and proxies from closing the connection while the backend is waiting for the LLM to finish tool execution. Interval is cleared in the `finally` block whether the stream succeeds or errors. — `src/app/api/chat/route.ts`
+
+- [x] **#195 — Parallel tool execution (request batching)** — Changed the sequential `for...of` tool execution loop in `orchestrator.ts` to use `Promise.all`. All tool calls in a single LLM round now execute concurrently rather than one-by-one. For queries that trigger 10 `overseerr_get_details` calls in a single round, the wall-clock time drops from ~10× individual latency to ~1× the slowest call. `tool_call_start` events are emitted for all tools before awaiting results; `tool_result` events and DB saves happen in original order after all results are available. — `src/lib/llm/orchestrator.ts`
+
+#### Tests
+
+- [x] **`src/__tests__/lib/plex.test.ts`** — 7 new `getSeriesEpisodes` tests: season overview (ordered, specials excluded, totalEpisodes/watchedEpisodes populated), episodes from a season (ordered by episode number, showTitle/seasonNumber preserved), single episode lookup, not-found episode, not-found season, and ratingKey URL assertion.
+
+#### MCP Tools table update
+
+| Server | Tools |
+|--------|-------|
+| Plex | plex_search_library, plex_get_on_deck, plex_get_recently_added, plex_check_availability, plex_search_collection, plex_search_by_tag, plex_get_title_tags, **plex_get_series_episodes** |
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/services/sonarr.ts` | Remove `body` from `Sonarr API response` info log (#196) |
+| `src/lib/services/radarr.ts` | Remove `body` from `Radarr API response` info log (#196) |
+| `src/lib/services/plex.ts` | New `getSeriesEpisodes(plexKey, season?, episode?)` function (#197) |
+| `src/lib/tools/plex-tools.ts` | New `plex_get_series_episodes` tool with `llmSummary` (#197) |
+| `src/app/api/chat/route.ts` | SSE heartbeat every 15s via `setInterval` (#195) |
+| `src/lib/llm/orchestrator.ts` | Parallel tool execution via `Promise.all` instead of sequential loop (#195) |
+| `src/__tests__/lib/plex.test.ts` | 7 new `getSeriesEpisodes` tests (#197) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.2",
+      "version": "1.1.3-beta.1",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "clsx": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10717,9 +10717,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11325,9 +11325,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11420,9 +11420,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -402,6 +402,146 @@ describe("orchestrator — LLM error sanitization", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// trimToolHistory — pure unit tests (no DB or LLM mock needed)
+// ---------------------------------------------------------------------------
+
+import type OpenAI from "openai";
+
+type AssistantMsg = OpenAI.ChatCompletionAssistantMessageParam;
+type ToolMsg = OpenAI.ChatCompletionToolMessageParam;
+type UserMsg = OpenAI.ChatCompletionUserMessageParam;
+
+/** Build a minimal assistant message that has tool_calls. */
+function assistantWithCalls(id: string, toolName: string, content?: string): AssistantMsg {
+  const msg: AssistantMsg = {
+    role: "assistant",
+    tool_calls: [{ id, type: "function", function: { name: toolName, arguments: "{}" } }],
+  };
+  if (content) msg.content = content;
+  return msg;
+}
+
+/** Build a tool result message. */
+function toolResult(toolCallId: string): ToolMsg {
+  return { role: "tool", tool_call_id: toolCallId, content: '{"ok":true}' };
+}
+
+/** Build a plain user message. */
+function userMsg(text: string): UserMsg {
+  return { role: "user", content: text };
+}
+
+/** Build N rounds of: user → assistant(tool_calls) → tool(result) → assistant(text). */
+function buildRounds(n: number) {
+  const msgs: (AssistantMsg | ToolMsg | UserMsg)[] = [];
+  for (let i = 0; i < n; i++) {
+    msgs.push(userMsg(`query ${i}`));
+    msgs.push(assistantWithCalls(`call_${i}`, "plex_search_library"));
+    msgs.push(toolResult(`call_${i}`));
+    msgs.push({ role: "assistant", content: `Response ${i}` });
+  }
+  return msgs;
+}
+
+describe("trimToolHistory — pure unit", () => {
+  // Import under test — no mocking needed for the pure function
+  let trim: typeof import("@/lib/llm/orchestrator").trimToolHistory;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ trimToolHistory: trim } = await import("@/lib/llm/orchestrator"));
+  });
+
+  it("returns messages unchanged when rounds ≤ MAX_TOOL_ROUNDS_IN_HISTORY", async () => {
+    const msgs = buildRounds(5);
+    const result = trim(msgs, "conv-1");
+    expect(result).toHaveLength(msgs.length);
+    const toolMsgs = result.filter((m) => m.role === "tool");
+    expect(toolMsgs).toHaveLength(5);
+    const assistantWithCalls = result.filter(
+      (m) => m.role === "assistant" && "tool_calls" in m && (m as AssistantMsg).tool_calls != null,
+    );
+    expect(assistantWithCalls).toHaveLength(5);
+  });
+
+  it("trims oldest rounds when count exceeds MAX_TOOL_ROUNDS_IN_HISTORY", async () => {
+    const msgs = buildRounds(7);
+    const result = trim(msgs, "conv-2");
+
+    // Only 5 tool messages should remain (2 oldest dropped)
+    const toolMsgs = result.filter((m) => m.role === "tool");
+    expect(toolMsgs).toHaveLength(5);
+
+    // Only 5 assistant messages with tool_calls should remain
+    const withCalls = result.filter(
+      (m) => m.role === "assistant" && "tool_calls" in m && (m as AssistantMsg).tool_calls != null,
+    );
+    expect(withCalls).toHaveLength(5);
+  });
+
+  it("replaces trimmed assistant tool_calls with a [searched: ...] note", async () => {
+    const msgs = buildRounds(6); // round 0 will be trimmed
+    const result = trim(msgs, "conv-3");
+
+    // Round 0's assistant message should have become plain text with a note
+    const trimmedAssistant = result.find(
+      (m) => m.role === "assistant" && typeof (m as AssistantMsg).content === "string" &&
+        ((m as AssistantMsg).content as string).includes("[searched:"),
+    ) as AssistantMsg | undefined;
+
+    expect(trimmedAssistant).toBeDefined();
+    expect(trimmedAssistant!.content).toContain("plex_search_library");
+    expect(trimmedAssistant!.tool_calls).toBeUndefined();
+  });
+
+  it("preserves existing assistant text content when replacing tool_calls", async () => {
+    const msgs: (AssistantMsg | ToolMsg | UserMsg)[] = [
+      userMsg("hi"),
+      assistantWithCalls("call_0", "plex_search_library", "Let me check that for you!"),
+      toolResult("call_0"),
+      { role: "assistant", content: "Found nothing." },
+      ...buildRounds(5), // push total tool rounds to 6, trimming round 0
+    ];
+
+    const result = trim(msgs, "conv-4");
+
+    const trimmedMsg = result.find(
+      (m) => m.role === "assistant" &&
+        typeof (m as AssistantMsg).content === "string" &&
+        ((m as AssistantMsg).content as string).includes("Let me check that for you!"),
+    ) as AssistantMsg | undefined;
+
+    expect(trimmedMsg).toBeDefined();
+    expect(trimmedMsg!.content).toBe("Let me check that for you! [searched: plex_search_library]");
+    expect(trimmedMsg!.tool_calls).toBeUndefined();
+  });
+
+  it("keeps all user and plain assistant messages when trimming", async () => {
+    const msgs = buildRounds(7);
+    const result = trim(msgs, "conv-5");
+
+    // All 7 user messages should survive
+    const userMsgs = result.filter((m) => m.role === "user");
+    expect(userMsgs).toHaveLength(7);
+
+    // All 7 plain-text assistant responses + 2 converted tool-calling messages = 9 plain assistants
+    const plainAssistant = result.filter(
+      (m) => m.role === "assistant" && !("tool_calls" in m && (m as AssistantMsg).tool_calls),
+    );
+    expect(plainAssistant).toHaveLength(9);
+  });
+
+  it("handles exactly MAX_TOOL_ROUNDS_IN_HISTORY+1 rounds (boundary case)", async () => {
+    const { MAX_TOOL_ROUNDS_IN_HISTORY } = await import("@/lib/llm/orchestrator");
+    const msgs = buildRounds(MAX_TOOL_ROUNDS_IN_HISTORY + 1);
+    const result = trim(msgs, "conv-6");
+
+    const toolMsgs = result.filter((m) => m.role === "tool");
+    expect(toolMsgs).toHaveLength(MAX_TOOL_ROUNDS_IN_HISTORY);
+  });
+});
+
 describe("orchestrator — 429 rate-limit retry", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/__tests__/lib/plex.test.ts
+++ b/src/__tests__/lib/plex.test.ts
@@ -551,3 +551,163 @@ describe("getTagsForTitle — issue #15", () => {
     expect(tags.contentRating).toBeUndefined();
   });
 });
+
+describe("getSeriesEpisodes — issue #197", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  const SEASON_CHILDREN = [
+    {
+      type: "season",
+      index: 1,
+      ratingKey: "200",
+      key: "/library/metadata/200/children",
+      parentTitle: "Breaking Bad",
+      title: "Season 1",
+      leafCount: 7,
+      viewedLeafCount: 3,
+      thumb: "/thumb/200",
+    },
+    {
+      type: "season",
+      index: 2,
+      ratingKey: "201",
+      key: "/library/metadata/201/children",
+      parentTitle: "Breaking Bad",
+      title: "Season 2",
+      leafCount: 13,
+      viewedLeafCount: 0,
+      thumb: "/thumb/201",
+    },
+  ];
+
+  const SEASON1_EPISODES = [
+    { type: "episode", index: 1, parentIndex: 1, ratingKey: "301", key: "/library/metadata/301", grandparentTitle: "Breaking Bad", title: "Pilot", thumb: "/thumb/301" },
+    { type: "episode", index: 2, parentIndex: 1, ratingKey: "302", key: "/library/metadata/302", grandparentTitle: "Breaking Bad", title: "Cat's in the Bag", thumb: "/thumb/302" },
+    { type: "episode", index: 3, parentIndex: 1, ratingKey: "303", key: "/library/metadata/303", grandparentTitle: "Breaking Bad", title: "And the Bag's in the River", thumb: "/thumb/303" },
+  ];
+
+  it("returns one card per season ordered by season number when no season given", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ MediaContainer: { Metadata: SEASON_CHILDREN } }),
+    }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    const { results, hasMore } = await getSeriesEpisodes("/library/metadata/100");
+    expect(results).toHaveLength(2);
+    expect(results[0].seasonNumber).toBe(1);
+    expect(results[1].seasonNumber).toBe(2);
+    expect(results[0].totalEpisodes).toBe(7);
+    expect(results[0].watchedEpisodes).toBe(3);
+    expect(results[0].mediaType).toBe("tv");
+    expect(hasMore).toBe(false);
+  });
+
+  it("excludes season 0 (specials) when no season given", async () => {
+    const withSpecials = [
+      { type: "season", index: 0, ratingKey: "199", key: "/library/metadata/199/children", parentTitle: "BB", title: "Specials", leafCount: 2, viewedLeafCount: 0 },
+      ...SEASON_CHILDREN,
+    ];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ MediaContainer: { Metadata: withSpecials } }),
+    }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    const { results } = await getSeriesEpisodes("/library/metadata/100");
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => (r.seasonNumber ?? 0) > 0)).toBe(true);
+  });
+
+  it("returns episodes from the requested season ordered by episode number", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce({
+        // GET /library/metadata/100/children → seasons
+        ok: true,
+        json: async () => ({ MediaContainer: { Metadata: SEASON_CHILDREN } }),
+      })
+      .mockResolvedValueOnce({
+        // GET /library/metadata/200/children → season 1 episodes
+        ok: true,
+        json: async () => ({ MediaContainer: { Metadata: SEASON1_EPISODES } }),
+      }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    const { results } = await getSeriesEpisodes("/library/metadata/100", 1);
+    expect(results).toHaveLength(3);
+    expect(results[0].title).toBe("Pilot");
+    expect(results[0].episodeNumber).toBe(1);
+    expect(results[1].episodeNumber).toBe(2);
+    expect(results[2].episodeNumber).toBe(3);
+    expect(results[0].mediaType).toBe("episode");
+    expect(results[0].showTitle).toBe("Breaking Bad");
+    expect(results[0].seasonNumber).toBe(1);
+  });
+
+  it("returns a single episode when both season and episode are given", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ MediaContainer: { Metadata: SEASON_CHILDREN } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ MediaContainer: { Metadata: SEASON1_EPISODES } }),
+      }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    const { results } = await getSeriesEpisodes("/library/metadata/100", 1, 2);
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Cat's in the Bag");
+    expect(results[0].episodeNumber).toBe(2);
+  });
+
+  it("returns empty array when episode number not found", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ MediaContainer: { Metadata: SEASON_CHILDREN } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ MediaContainer: { Metadata: SEASON1_EPISODES } }),
+      }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    const { results } = await getSeriesEpisodes("/library/metadata/100", 1, 99);
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns empty array when requested season not found", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ MediaContainer: { Metadata: SEASON_CHILDREN } }),
+    }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    const { results } = await getSeriesEpisodes("/library/metadata/100", 5);
+    expect(results).toHaveLength(0);
+  });
+
+  it("uses ratingKey to fetch season episodes", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ MediaContainer: { Metadata: SEASON_CHILDREN } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ MediaContainer: { Metadata: SEASON1_EPISODES } }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    await getSeriesEpisodes("/library/metadata/100", 1);
+
+    // Second fetch should use ratingKey=200 to get episodes
+    const secondUrl = fetchMock.mock.calls[1][0] as string;
+    expect(secondUrl).toContain("/library/metadata/200/children");
+  });
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -113,6 +113,12 @@ export async function POST(request: Request) {
         }
       };
 
+      // Send an SSE comment every 15 seconds so the client stays connected
+      // while the backend is waiting for the LLM or tool execution to finish.
+      const heartbeat = setInterval(() => {
+        enqueue(encoder.encode(": heartbeat\n\n"));
+      }, 15000);
+
       try {
         for await (const event of orchestrate({
           conversationId: body.conversationId,
@@ -137,6 +143,7 @@ export async function POST(request: Request) {
         const msg = e instanceof Error ? e.message : "Stream error";
         enqueue(encoder.encode(`data: ${JSON.stringify({ type: "error", message: msg })}\n\n`));
       } finally {
+        clearInterval(heartbeat);
         try { controller.close(); } catch { /* already closed by client disconnect */ }
       }
     },

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -255,7 +255,13 @@ export function trimToolHistory(messages: ChatMessage[], conversationId: string)
       if (msg.role !== "assistant") return msg;
       const assistantMsg = msg as OpenAI.ChatCompletionAssistantMessageParam;
       if (!assistantMsg.tool_calls?.some((tc) => dropToolCallIds.has(tc.id))) return msg;
-      const toolNames = [...new Set(assistantMsg.tool_calls.map((tc) => tc.function.name))].join(", ");
+      const toolNames = [
+        ...new Set(
+          assistantMsg.tool_calls
+            .filter((tc): tc is OpenAI.ChatCompletionMessageToolCall & { type: "function" } => tc.type === "function")
+            .map((tc) => tc.function.name),
+        ),
+      ].join(", ");
       const note = `[searched: ${toolNames}]`;
       const content = assistantMsg.content ? `${assistantMsg.content} ${note}` : note;
       return { role: "assistant" as const, content };

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -399,11 +399,17 @@ export async function* orchestrate(
       })),
     });
 
-    // 4. Execute each tool call
+    // 4. Execute tool calls in parallel — multiple tool calls in a single round
+    //    (e.g. 10 overseerr_get_details calls) run concurrently rather than
+    //    sequentially, reducing the total round-trip time significantly.
     const TOOL_TIMEOUT_MS = 30_000;
+
+    // Emit tool_call_start events immediately (before awaiting results)
+    const startedAts: Map<string, number> = new Map();
     for (const tc of toolCalls) {
-      logger.info("Tool call", { conversationId, toolName: tc.function.name, toolCallId: tc.id });
       const startedAt = Date.now();
+      startedAts.set(tc.id, startedAt);
+      logger.info("Tool call", { conversationId, toolName: tc.function.name, toolCallId: tc.id });
       yield {
         type: "tool_call_start",
         toolCallId: tc.id,
@@ -411,26 +417,35 @@ export async function* orchestrate(
         arguments: tc.function.arguments,
         startedAt,
       };
+    }
 
-      let result: string;
-      let isError = false;
-      try {
-        const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`Tool call timed out after ${TOOL_TIMEOUT_MS / 1000}s`)), TOOL_TIMEOUT_MS),
-        );
-        result = await Promise.race([
-          executeTool(tc.function.name, tc.function.arguments),
-          timeoutPromise,
-        ]);
-      } catch (e: unknown) {
-        isError = true;
-        const timedOut = e instanceof Error && e.message.startsWith("Tool call timed out");
-        result = JSON.stringify({ error: e instanceof Error ? e.message : "Tool execution failed" });
-        logger.warn("Tool call error", { conversationId, toolName: tc.function.name, toolCallId: tc.id, error: result, timedOut, durationMs: Date.now() - startedAt });
-      }
+    // Execute all tools concurrently
+    const toolResults = await Promise.all(
+      toolCalls.map(async (tc) => {
+        const startedAt = startedAts.get(tc.id) ?? Date.now();
+        let result: string;
+        let isError = false;
+        try {
+          const timeoutPromise = new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error(`Tool call timed out after ${TOOL_TIMEOUT_MS / 1000}s`)), TOOL_TIMEOUT_MS),
+          );
+          result = await Promise.race([
+            executeTool(tc.function.name, tc.function.arguments),
+            timeoutPromise,
+          ]);
+        } catch (e: unknown) {
+          isError = true;
+          const timedOut = e instanceof Error && e.message.startsWith("Tool call timed out");
+          result = JSON.stringify({ error: e instanceof Error ? e.message : "Tool execution failed" });
+          logger.warn("Tool call error", { conversationId, toolName: tc.function.name, toolCallId: tc.id, error: result, timedOut, durationMs: Date.now() - startedAt });
+        }
+        const durationMs = Date.now() - startedAt;
+        return { tc, result: result!, isError, durationMs };
+      }),
+    );
 
-      const durationMs = Date.now() - startedAt;
-
+    // Save results and emit events in original tool_calls order
+    for (const { tc, result, isError, durationMs } of toolResults) {
       // Save tool result to DB (even on error — ensures the API message sequence stays valid)
       try {
         saveMessage(conversationId, "tool", result, {

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -199,7 +199,67 @@ function loadHistory(conversationId: string): ChatMessage[] {
     }
   }
 
-  return repaired;
+  return trimToolHistory(repaired, conversationId);
+}
+
+export const MAX_TOOL_ROUNDS_IN_HISTORY = 5;
+
+/**
+ * Cap the number of tool-calling rounds kept in conversation history.
+ * For rounds beyond the most recent MAX_TOOL_ROUNDS_IN_HISTORY, the
+ * tool result messages are dropped and the assistant message's tool_calls
+ * array is replaced with a compact inline note (e.g. "[searched: plex_search_library]").
+ * This prevents unbounded token growth in long conversations while keeping
+ * all assistant text responses intact.
+ */
+export function trimToolHistory(messages: ChatMessage[], conversationId: string): ChatMessage[] {
+  // Find the index of every assistant message that has tool_calls
+  const toolRoundIndices: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "assistant" && "tool_calls" in msg && (msg as OpenAI.ChatCompletionAssistantMessageParam).tool_calls?.length) {
+      toolRoundIndices.push(i);
+    }
+  }
+
+  if (toolRoundIndices.length <= MAX_TOOL_ROUNDS_IN_HISTORY) return messages;
+
+  const dropCount = toolRoundIndices.length - MAX_TOOL_ROUNDS_IN_HISTORY;
+  const dropIndices = new Set(toolRoundIndices.slice(0, dropCount));
+
+  // Collect all tool_call_ids that belong to dropped rounds
+  const dropToolCallIds = new Set<string>();
+  for (const idx of dropIndices) {
+    const msg = messages[idx] as OpenAI.ChatCompletionAssistantMessageParam;
+    for (const tc of msg.tool_calls ?? []) dropToolCallIds.add(tc.id);
+  }
+
+  logger.info("Trimming old tool rounds from history", {
+    conversationId,
+    totalRounds: toolRoundIndices.length,
+    droppingRounds: dropCount,
+    keptRounds: MAX_TOOL_ROUNDS_IN_HISTORY,
+  });
+
+  return messages
+    .filter((msg) => {
+      // Drop tool result messages whose call was in a trimmed round
+      if (msg.role === "tool") {
+        const toolMsg = msg as OpenAI.ChatCompletionToolMessageParam;
+        return !dropToolCallIds.has(toolMsg.tool_call_id);
+      }
+      return true;
+    })
+    .map((msg) => {
+      // For assistant messages in trimmed rounds: replace tool_calls with an inline note
+      if (msg.role !== "assistant") return msg;
+      const assistantMsg = msg as OpenAI.ChatCompletionAssistantMessageParam;
+      if (!assistantMsg.tool_calls?.some((tc) => dropToolCallIds.has(tc.id))) return msg;
+      const toolNames = [...new Set(assistantMsg.tool_calls.map((tc) => tc.function.name))].join(", ");
+      const note = `[searched: ${toolNames}]`;
+      const content = assistantMsg.content ? `${assistantMsg.content} ${note}` : note;
+      return { role: "assistant" as const, content };
+    });
 }
 
 /** Save a message to the DB. */

--- a/src/lib/services/plex.ts
+++ b/src/lib/services/plex.ts
@@ -344,6 +344,62 @@ export interface PlexTitleTags {
  * When a season or episode key is passed, this function automatically fetches
  * the parent show's metadata instead.
  */
+export interface PlexSeriesEpisodesResult {
+  results: PlexSearchResult[];
+  hasMore: boolean;
+}
+
+/**
+ * Return season or episode data for a Plex TV series.
+ *
+ * - No season/episode: returns one card per season ordered by season number.
+ *   Each card has totalEpisodes and watchedEpisodes from the season metadata.
+ * - season only: returns episodes from that season ordered by episode number.
+ * - season + episode: returns a single matching episode.
+ *
+ * plexKey must be the show-level metadata key (e.g. "/library/metadata/123").
+ */
+export async function getSeriesEpisodes(
+  plexKey: string,
+  season?: number,
+  episode?: number,
+): Promise<PlexSeriesEpisodesResult> {
+  const showPath = plexKey.startsWith("/") ? plexKey : `/${plexKey}`;
+
+  // Fetch the show's direct children (seasons)
+  const seasonsData = await plexFetch(`${showPath}/children`);
+  const rawSeasons = ((seasonsData?.MediaContainer?.Metadata || []) as Record<string, unknown>[])
+    .filter((s) => (s.type as string) === "season" && (s.index as number) > 0)
+    .sort((a, b) => (a.index as number) - (b.index as number));
+
+  if (season === undefined) {
+    // Return one card per season ordered by season number
+    return { results: rawSeasons.map((s) => mapMetadata(s, "season")), hasMore: false };
+  }
+
+  // Find the matching season
+  const matchingSeason = rawSeasons.find((s) => (s.index as number) === season);
+  if (!matchingSeason) {
+    return { results: [], hasMore: false };
+  }
+
+  // The season's ratingKey lets us fetch its children (episodes)
+  const seasonRatingKey = matchingSeason.ratingKey as string | number;
+  const seasonPath = `/library/metadata/${seasonRatingKey}/children`;
+  const episodesData = await plexFetch(seasonPath);
+  const mapped: PlexSearchResult[] = ((episodesData?.MediaContainer?.Metadata || []) as Record<string, unknown>[])
+    .filter((e) => (e.type as string) === "episode")
+    .sort((a, b) => (a.index as number) - (b.index as number))
+    .map((e) => mapMetadata(e, "episode"));
+
+  if (episode !== undefined) {
+    const single = mapped.find((e) => e.episodeNumber === episode);
+    return { results: single ? [single] : [], hasMore: false };
+  }
+
+  return { results: mapped, hasMore: false };
+}
+
 export async function getTagsForTitle(metadataKey: string): Promise<PlexTitleTags> {
   // Plex metadata keys start with /library/metadata/ — strip leading slash for fetch
   const path = metadataKey.startsWith("/") ? metadataKey : `/${metadataKey}`;

--- a/src/lib/services/radarr.ts
+++ b/src/lib/services/radarr.ts
@@ -21,7 +21,7 @@ async function radarrFetch(path: string) {
     throw new Error(`Radarr API error: HTTP ${res.status}`);
   }
   const data = await res.json();
-  logger.info("Radarr API response", { url: fullUrl, status: res.status, body: JSON.stringify(data).slice(0, 5000) });
+  logger.info("Radarr API response", { url: fullUrl, status: res.status });
   return data;
 }
 

--- a/src/lib/services/sonarr.ts
+++ b/src/lib/services/sonarr.ts
@@ -21,7 +21,7 @@ async function sonarrFetch(path: string) {
     throw new Error(`Sonarr API error: HTTP ${res.status}`);
   }
   const data = await res.json();
-  logger.info("Sonarr API response", { url: fullUrl, status: res.status, body: JSON.stringify(data).slice(0, 5000) });
+  logger.info("Sonarr API response", { url: fullUrl, status: res.status });
   return data;
 }
 

--- a/src/lib/tools/plex-tools.ts
+++ b/src/lib/tools/plex-tools.ts
@@ -102,6 +102,44 @@ export function registerPlexTools() {
   });
 
   defineTool({
+    name: "plex_get_series_episodes",
+    description:
+      "Get season or episode data for a specific Plex TV series. " +
+      "Pass the show-level plexKey from a previous plex_search_library result. " +
+      "If neither season nor episode is provided: returns one card per season (ordered by season number) with episode counts — use this to show an overview of all seasons. " +
+      "If season is provided: returns all episodes from that season ordered by episode number. " +
+      "If season and episode are both provided: returns the single matching episode. " +
+      "Use this tool instead of plex_search_library when the user asks about a specific season or episode of a show.",
+    schema: z.object({
+      plexKey: z
+        .string()
+        .describe("Plex metadata key for the TV show (e.g. '/library/metadata/123' from a prior search result)"),
+      season: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe("Season number (1-based). Omit to get an overview of all seasons."),
+      episode: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe("Episode number within the season (1-based). Requires season to be set."),
+    }),
+    handler: async (args) => plex.getSeriesEpisodes(args.plexKey, args.season, args.episode),
+    llmSummary: (result: unknown) => {
+      const r = result as { results: plex.PlexSearchResult[]; hasMore: boolean };
+      return {
+        results: r.results.map(({ title, year, mediaType, plexKey, thumbPath, rating, showTitle, seasonNumber, episodeNumber, totalEpisodes, watchedEpisodes }) => ({
+          title, year, mediaType, plexKey, thumbPath, rating, showTitle, seasonNumber, episodeNumber, totalEpisodes, watchedEpisodes,
+        })),
+        hasMore: r.hasMore,
+      };
+    },
+  });
+
+  defineTool({
     name: "plex_get_title_tags",
     description:
       "Retrieve all tags associated with a specific Plex title (genres, directors, actors, countries, studio, content rating, labels). " +


### PR DESCRIPTION
## Summary

- **#196** — Remove full API response body from Sonarr/Radarr success logs (`sonarrFetch`/`radarrFetch` were logging up to 5000 chars of JSON on every call)
- **#197** — New `plex_get_series_episodes` tool: pass `plexKey` + optional `season`/`episode` to get season overviews, episode lists, or a single episode — fixes mixed season/episode display
- **#195 (heartbeat)** — `POST /api/chat` now sends `: heartbeat\n\n` every 15s to keep the SSE connection alive during long tool-execution waits
- **#195 (batching)** — Tool calls in a single LLM round now execute with `Promise.all` (parallel) instead of sequentially — 10 `overseerr_get_details` calls now take ~1× latency instead of ~10×

## Test plan

- [ ] All 29 plex unit tests pass (7 new `getSeriesEpisodes` tests added)
- [ ] All 8 orchestrator tests pass (parallel execution preserves order)
- [ ] Ask about a specific season of a TV show — `plex_get_series_episodes` should be called with correct `season` param
- [ ] Ask about a specific episode — `plex_get_series_episodes` should return single result
- [ ] Ask about a show with no season param — should get one card per season ordered by season number
- [ ] On mobile, verify the SSE stream doesn't drop during long LLM responses
- [ ] Check logs — no more large JSON blobs from Sonarr/Radarr responses

https://claude.ai/code/session_014SPRyBcsw6LkCK5LbbSqUT