### PR TITLE
fix: resolve #137, #166, #178, #192, #194

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1561,3 +1561,40 @@ Token cost of history is now capped. A conversation with 35 tool-calling rounds 
 |------|--------|
 | `src/lib/llm/orchestrator.ts` | `trimToolHistory()` + `MAX_TOOL_ROUNDS_IN_HISTORY` exported; called from `loadHistory()` |
 | `src/__tests__/lib/orchestrator.test.ts` | 6 new pure unit tests for `trimToolHistory` |
+
+
+---
+
+### Phase 52: Bug Fixes & UX Polish (#137, #166, #178, #192, #194)
+
+#### Bug Fixes
+
+- [x] **#137 — No trash icon on mobile** — The delete-chat button was only rendered when `hoveredId === conv.id` (JS hover state), which is never triggered on touch devices. Replaced the conditional render with always-visible rendering, using Tailwind responsive classes (`md:opacity-0 md:group-hover:opacity-100`) so the button is always shown on mobile and appears on hover on desktop. Removed the now-unused `hoveredId` state. — `src/components/chat/sidebar.tsx`
+
+- [x] **#194 — Request button drops to next line** — When the Request button changed from "Request" → "Requesting…" (with spinner) or "Requested", the wider content caused it to wrap below "More Info". Wrapped the More Info anchor and Request/Requested elements in a `flex flex-nowrap gap-2` sub-group so they stay on the same line. Added `whitespace-nowrap` to prevent individual button text from wrapping. — `src/components/chat/title-card.tsx`
+
+#### Features / Enhancements
+
+- [x] **#166 — Report Issue button moved to right side** — Moved the Report Issue button from the left of the top toolbar to the right, placing the model selector on the left. This ensures it doesn't overlap the sidebar toggle or model selector dropdown. — `src/app/chat/page.tsx`
+
+- [x] **#178 — LLM date awareness + Overseerr recent-release hints** — Injected the current date (`{{currentDate}}` placeholder, resolved at runtime via `buildCurrentDate()`) into both the text and realtime default system prompts. Added a guideline hint instructing the LLM to search Overseerr with the current year when users ask about new/recent releases, since Overseerr indexes TMDB and is the best source for titles not yet in Plex. — `src/lib/llm/system-prompt.ts`, `src/lib/llm/default-prompt.ts`
+
+- [x] **#192 (1) — Service status indicators update on model change** — `services/status/route.ts` now iterates all enabled LLM endpoints from `llm.endpoints` (one `ServiceStatus` entry per endpoint, named after the endpoint) instead of a single "LLM" entry from the legacy single-config keys. `ServiceStatus` component accepts a `selectedModel` prop and triggers an immediate re-poll via `useEffect` when the model changes. `Sidebar` forwards the new `selectedModel` prop to `ServiceStatus`. `ChatPage` passes `selectedModel` to `Sidebar`. — `src/app/api/services/status/route.ts`, `src/components/chat/service-status.tsx`, `src/components/chat/sidebar.tsx`, `src/app/chat/page.tsx`
+
+- [x] **#192 (2) — Per-endpoint test result state** — In settings, testing one LLM endpoint was storing the result under the shared key `"llm"`, causing both endpoints' UI to show the same result. Changed to use a per-endpoint key `"llm-{endpointId}"` in `testResults` state, and updated the endpoint card UI to read from `testResults[\`llm-${ep.id}\`]`. — `src/app/settings/page.tsx`
+
+- [x] **#192 (3) — Test connection logging** — Added `logger.info` / `logger.warn` calls in the `POST /api/setup/test-connection` route so every test attempt is written to the application log with endpoint URL, service type, model, endpointId, hasApiKey, success, and message fields for troubleshooting failures. — `src/app/api/setup/test-connection/route.ts`
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/components/chat/sidebar.tsx` | Always-visible delete button via CSS opacity; removed `hoveredId` state; new `selectedModel` prop forwarded to `ServiceStatus` (#137, #192) |
+| `src/components/chat/title-card.tsx` | More Info + Request/Requested buttons grouped in `flex-nowrap` sub-container (#194) |
+| `src/app/chat/page.tsx` | Model selector moved left, Report Issue button moved right; `selectedModel` passed to `Sidebar` (#166, #192) |
+| `src/lib/llm/system-prompt.ts` | `buildCurrentDate()` helper; `{{currentDate}}` substitution in `buildSystemPrompt` and `buildRealtimeSystemPrompt` (#178) |
+| `src/lib/llm/default-prompt.ts` | `{{currentDate}}` placeholder added; Overseerr recent-release discovery hint added to both prompts (#178) |
+| `src/app/api/services/status/route.ts` | `checkLlmEndpoints()` checks all enabled endpoints from `llm.endpoints`; returns one entry per endpoint; legacy single-config fallback retained (#192) |
+| `src/components/chat/service-status.tsx` | New `selectedModel` prop; immediate re-poll on model change via `useEffect` (#192) |
+| `src/app/settings/page.tsx` | Per-endpoint test result key `"llm-{endpointId}"`; UI reads from endpoint-specific slot (#192) |
+| `src/app/api/setup/test-connection/route.ts` | `logger.info` / `logger.warn` on test outcome with endpoint/model/result details (#192) |

--- a/src/app/api/services/status/route.ts
+++ b/src/app/api/services/status/route.ts
@@ -11,15 +11,12 @@ export interface ServiceStatus {
   message: string;
 }
 
-async function checkLlm(): Promise<ServiceStatus> {
-  const baseUrl = getConfig("llm.baseUrl");
-  const apiKey = getConfig("llm.apiKey");
-  const model = getConfig("llm.model");
-
-  if (!baseUrl || !apiKey) {
-    return { name: "LLM", status: "red", message: "Not configured" };
-  }
-
+async function checkSingleLlmEndpoint(
+  name: string,
+  baseUrl: string,
+  apiKey: string,
+  model: string | undefined,
+): Promise<ServiceStatus> {
   try {
     const { default: OpenAI } = await import("openai");
     const client = new OpenAI({ baseURL: baseUrl, apiKey });
@@ -37,14 +34,50 @@ async function checkLlm(): Promise<ServiceStatus> {
           messages: [{ role: "user", content: "Hi" }],
         });
       }
-      return { name: "LLM", status: "green", message: `Connected (${model})` };
+      return { name, status: "green", message: `Connected (${model})` };
     }
     const models = await client.models.list();
     const count = (await Array.fromAsync(models)).length;
-    return { name: "LLM", status: "green", message: `Connected (${count} models)` };
+    return { name, status: "green", message: `Connected (${count} models)` };
   } catch {
-    return { name: "LLM", status: "amber", message: "Reachable but request failed" };
+    return { name, status: "amber", message: "Reachable but request failed" };
   }
+}
+
+async function checkLlmEndpoints(): Promise<ServiceStatus[]> {
+  // Multi-endpoint config
+  const raw = getConfig("llm.endpoints");
+  if (raw) {
+    try {
+      const endpoints: Array<{
+        id: string;
+        name: string;
+        baseUrl: string;
+        apiKey: string;
+        model: string;
+        enabled: boolean;
+      }> = JSON.parse(raw);
+      const enabled = endpoints.filter((ep) => ep.enabled && ep.baseUrl && ep.apiKey);
+      if (enabled.length > 0) {
+        return Promise.all(
+          enabled.map((ep) =>
+            checkSingleLlmEndpoint(ep.name || "LLM", ep.baseUrl, ep.apiKey, ep.model || undefined),
+          ),
+        );
+      }
+    } catch {
+      // Fall through to legacy single-endpoint check
+    }
+  }
+
+  // Legacy single-endpoint fallback
+  const baseUrl = getConfig("llm.baseUrl");
+  const apiKey = getConfig("llm.apiKey");
+  const model = getConfig("llm.model");
+  if (!baseUrl || !apiKey) {
+    return [{ name: "LLM", status: "red", message: "Not configured" }];
+  }
+  return [await checkSingleLlmEndpoint("LLM", baseUrl, apiKey, model || undefined)];
 }
 
 async function checkPlex(): Promise<ServiceStatus> {
@@ -109,8 +142,8 @@ export async function GET() {
     );
   }
 
-  const [llm, plex, sonarr, radarr, overseerr] = await Promise.all([
-    checkLlm(),
+  const [llmStatuses, plex, sonarr, radarr, overseerr] = await Promise.all([
+    checkLlmEndpoints(),
     checkPlex(),
     checkArr("Sonarr", "sonarr.url", "sonarr.apiKey"),
     checkArr("Radarr", "radarr.url", "radarr.apiKey"),
@@ -119,6 +152,6 @@ export async function GET() {
 
   return NextResponse.json<ApiResponse>({
     success: true,
-    data: { services: [llm, plex, sonarr, radarr, overseerr] },
+    data: { services: [...llmStatuses, plex, sonarr, radarr, overseerr] },
   });
 }

--- a/src/app/api/setup/test-connection/route.ts
+++ b/src/app/api/setup/test-connection/route.ts
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth/session";
 import { testConnection } from "@/lib/services/test-connection";
 import { getConfig } from "@/lib/config";
 import { validateServiceUrl } from "@/lib/security/url-validation";
+import { logger } from "@/lib/logger";
 import type { TestConnectionRequest, TestConnectionResponse, ApiResponse } from "@/types/api";
 
 const MASK = "••••••••";
@@ -81,6 +82,22 @@ export async function POST(request: Request) {
   }
 
   const result: TestConnectionResponse = await testConnection({ ...body, apiKey });
+
+  // Log the outcome so failures are diagnosable from the logs
+  const logMeta = {
+    type: body.type,
+    endpoint: body.url,
+    model: body.model ?? null,
+    endpointId: body.endpointId ?? null,
+    hasApiKey: !!apiKey,
+    success: result.success,
+    message: result.message,
+  };
+  if (result.success) {
+    logger.info("Test connection succeeded", logMeta);
+  } else {
+    logger.warn("Test connection failed", logMeta);
+  }
 
   return NextResponse.json<ApiResponse<TestConnectionResponse>>({
     success: result.success,

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -170,6 +170,7 @@ export default function ChatPage() {
         onDelete={handleDeleteConversation}
         collapsed={sidebarCollapsed}
         onToggle={() => setSidebarCollapsed(true)}
+        selectedModel={selectedModel}
       />
 
       {sidebarCollapsed && <SidebarToggle onClick={() => setSidebarCollapsed(false)} />}
@@ -177,25 +178,11 @@ export default function ChatPage() {
       <main className="flex flex-1 flex-col min-w-0">
         <PwaInstallBanner />
 
-        {/* Top toolbar: model selector + report issue button */}
+        {/* Top toolbar: model selector (left) + report issue button (right) */}
         {(canChangeModel && models.length > 1) || activeConversationId ? (
           <div className="flex items-center justify-between border-b px-4 py-1.5">
-            {/* Report Issue button — only shown when a conversation is active */}
-            {activeConversationId ? (
-              <button
-                onClick={() => setReportIssueOpen(true)}
-                className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                title="Report an issue with this conversation"
-              >
-                <Flag size={13} />
-                Report Issue
-              </button>
-            ) : (
-              <span />
-            )}
-
-            {/* Model selector */}
-            {canChangeModel && models.length > 1 && (
+            {/* Model selector — left side */}
+            {canChangeModel && models.length > 1 ? (
               <label className="flex items-center gap-2 text-xs text-muted-foreground">
                 Model:
                 <select
@@ -225,6 +212,22 @@ export default function ChatPage() {
                   ))}
                 </select>
               </label>
+            ) : (
+              <span />
+            )}
+
+            {/* Report Issue button — right side, only shown when a conversation is active */}
+            {activeConversationId ? (
+              <button
+                onClick={() => setReportIssueOpen(true)}
+                className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                title="Report an issue with this conversation"
+              >
+                <Flag size={13} />
+                Report Issue
+              </button>
+            ) : (
+              <span />
             )}
           </div>
         ) : null}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -367,9 +367,11 @@ export default function SettingsPage() {
       });
       const data = await res.json();
       const result = data.data;
+      // Use a per-endpoint key for LLM results so each endpoint shows its own test outcome
+      const resultKey = sectionKey === "llm" && endpointId ? `llm-${endpointId}` : sectionKey;
       setTestResults((prev) => ({
         ...prev,
-        [sectionKey]: {
+        [resultKey]: {
           success: result?.success ?? false,
           message: result?.message || data.error,
         },
@@ -892,8 +894,8 @@ export default function SettingsPage() {
                   >
                     Test
                   </Button>
-                  {testResults.llm && (
-                    <TestResult result={testResults.llm} />
+                  {testResults[`llm-${ep.id}`] && (
+                    <TestResult result={testResults[`llm-${ep.id}`]} />
                   )}
                 </CardFooter>
               </Card>

--- a/src/components/chat/service-status.tsx
+++ b/src/components/chat/service-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 interface ServiceStatusItem {
@@ -21,9 +21,14 @@ async function fetchServiceStatus(): Promise<ServiceStatusItem[]> {
   return data.success ? data.data.services : [];
 }
 
-export function ServiceStatus() {
+interface ServiceStatusProps {
+  selectedModel?: string;
+}
+
+export function ServiceStatus({ selectedModel }: ServiceStatusProps) {
   const [services, setServices] = useState<ServiceStatusItem[]>([]);
   const [expanded, setExpanded] = useState(false);
+  const prevModelRef = useRef<string | undefined>(selectedModel);
 
   useEffect(() => {
     const poll = () => fetchServiceStatus().then(setServices).catch(() => {});
@@ -31,6 +36,14 @@ export function ServiceStatus() {
     const interval = setInterval(poll, 60000); // Poll every 60s
     return () => clearInterval(interval);
   }, []);
+
+  // Immediately re-poll when selected model changes
+  useEffect(() => {
+    if (prevModelRef.current !== selectedModel) {
+      prevModelRef.current = selectedModel;
+      fetchServiceStatus().then(setServices).catch(() => {});
+    }
+  }, [selectedModel]);
 
   if (services.length === 0) return null;
 

--- a/src/components/chat/sidebar.tsx
+++ b/src/components/chat/sidebar.tsx
@@ -19,6 +19,7 @@ interface SidebarProps {
   onDelete: (id: string) => void;
   collapsed: boolean;
   onToggle: () => void;
+  selectedModel?: string;
 }
 
 export function Sidebar({
@@ -30,9 +31,9 @@ export function Sidebar({
   onDelete,
   collapsed,
   onToggle,
+  selectedModel,
 }: SidebarProps) {
   const router = useRouter();
-  const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [publicIp, setPublicIp] = useState<string | null>(null);
 
   useEffect(() => {
@@ -108,21 +109,18 @@ export function Sidebar({
                     : "text-sidebar-foreground hover:bg-accent/50",
                 )}
                 onClick={() => onSelect(conv.id)}
-                onMouseEnter={() => setHoveredId(conv.id)}
-                onMouseLeave={() => setHoveredId(null)}
               >
                 <span className="flex-1 truncate">{conv.title || "New Chat"}</span>
-                {hoveredId === conv.id && (
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onDelete(conv.id);
-                    }}
-                    className="ml-1 rounded p-1 text-muted-foreground hover:text-destructive"
-                  >
-                    <Trash2 size={14} />
-                  </button>
-                )}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(conv.id);
+                  }}
+                  className="ml-1 rounded p-1 text-muted-foreground hover:text-destructive md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                  aria-label="Delete chat"
+                >
+                  <Trash2 size={14} />
+                </button>
               </div>
             ))}
           </div>
@@ -130,7 +128,7 @@ export function Sidebar({
       </div>
 
       {/* Service status traffic lights */}
-      <ServiceStatus />
+      <ServiceStatus selectedModel={selectedModel} />
 
       {/* Version */}
       {process.env.NEXT_PUBLIC_APP_VERSION && (

--- a/src/components/chat/title-card.tsx
+++ b/src/components/chat/title-card.tsx
@@ -154,47 +154,52 @@ export function TitleCard({ title }: TitleCardProps) {
             </a>
           )}
 
-          {showRequestButton && (title.imdbId || (title.overseerrId && title.overseerrMediaType)) && (
-            <a
-              href={
-                title.imdbId
-                  ? `https://www.imdb.com/title/${title.imdbId}`
-                  : `https://www.themoviedb.org/${title.overseerrMediaType === "movie" ? "movie" : "tv"}/${title.overseerrId}`
-              }
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs px-3 py-1 rounded-lg bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors font-medium"
-            >
-              More Info
-            </a>
-          )}
-
-          {showRequestButton && requestStatus === "idle" && (
-            <button
-              onClick={handleRequest}
-              disabled={requesting}
-              className="text-xs px-3 py-1 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium disabled:opacity-50 flex items-center gap-1"
-              data-testid="request-button"
-            >
-              {requesting ? (
-                <>
-                  <span className="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                  Requesting…
-                </>
-              ) : (
-                "Request"
+          {/* More Info + Request/Requested kept together so they never split across lines */}
+          {showRequestButton && (
+            <div className="flex gap-2 flex-nowrap">
+              {(title.imdbId || (title.overseerrId && title.overseerrMediaType)) && (
+                <a
+                  href={
+                    title.imdbId
+                      ? `https://www.imdb.com/title/${title.imdbId}`
+                      : `https://www.themoviedb.org/${title.overseerrMediaType === "movie" ? "movie" : "tv"}/${title.overseerrId}`
+                  }
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs px-3 py-1 rounded-lg bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors font-medium whitespace-nowrap"
+                >
+                  More Info
+                </a>
               )}
-            </button>
-          )}
 
-          {requestStatus === "success" && (
-            <span className="text-xs px-3 py-1 rounded-lg bg-green-500/20 text-green-400 border border-green-500/30 font-medium" data-testid="request-success">
-              Requested
-            </span>
-          )}
+              {requestStatus === "idle" && (
+                <button
+                  onClick={handleRequest}
+                  disabled={requesting}
+                  className="text-xs px-3 py-1 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium disabled:opacity-50 flex items-center gap-1 whitespace-nowrap"
+                  data-testid="request-button"
+                >
+                  {requesting ? (
+                    <>
+                      <span className="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                      Requesting…
+                    </>
+                  ) : (
+                    "Request"
+                  )}
+                </button>
+              )}
 
-          {requestStatus === "error" && (
-            <span className="text-xs text-destructive">{errorMsg}</span>
+              {requestStatus === "success" && (
+                <span className="text-xs px-3 py-1 rounded-lg bg-green-500/20 text-green-400 border border-green-500/30 font-medium whitespace-nowrap" data-testid="request-success">
+                  Requested
+                </span>
+              )}
+
+              {requestStatus === "error" && (
+                <span className="text-xs text-destructive whitespace-nowrap">{errorMsg}</span>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/src/lib/llm/default-prompt.ts
+++ b/src/lib/llm/default-prompt.ts
@@ -5,6 +5,8 @@
  */
 export const DEFAULT_SYSTEM_PROMPT = `You are Thinkarr, a friendly and helpful media management assistant. You help users manage their media libraries and discover new content.
 
+Today's date is {{currentDate}}.
+
 {{serviceList}}
 
 Security:
@@ -17,6 +19,7 @@ Guidelines:
 - Be concise and helpful. Prefer short, direct answers.
 - Do not make assumptions about the availability of content. Always check the Media Library. To check availability, use the plex_check_availability tool.
 - If a title is not available, search Overseerr using the overseerr_search tool to check request status, then call display_titles so the user can request it themselves via the card button.
+- When users ask about new, recent, or upcoming movies/shows (e.g. "what's new", "recent releases", "what came out this year"), search Overseerr using the current year as part of your query. Overseerr indexes new releases from TMDB, so it is the best source for titles not yet in the Plex library. Always follow with display_titles.
 - If the user asks what movies or series are leaving soon (or expiring, or leaving the library), search the relevant collection: use plex_search_collection('Movies leaving soon') for movies, plex_search_collection('Series leaving soon') for TV shows. If the question is ambiguous or covers both, search both collections.
 - Never request media on behalf of the user — always display a title card and let the user click the Request button.
 - If a title is requested but not available, you can offer to search for it in the queue using the radarr_search_queue tool or sonarr_search_queue tool to see if it is in the queue.
@@ -46,6 +49,8 @@ Displaying title cards:
  */
 export const DEFAULT_REALTIME_SYSTEM_PROMPT = `You are Thinkarr, a friendly and helpful media management assistant. You help users manage their media libraries and discover new content. You are speaking with the user via voice, so keep your responses concise and conversational.
 
+Today's date is {{currentDate}}.
+
 {{serviceList}}
 
 Security:
@@ -60,6 +65,7 @@ Guidelines:
 - Be concise. Prefer short answers. For lists of results, mention the most relevant two or three items.
 - Do not make assumptions about the availability of content. Always check the Media Library using the plex_check_availability tool.
 - If a title is not available, check Overseerr using the overseerr_search tool and let the user know they can request it.
+- When users ask about new, recent, or upcoming movies/shows, search Overseerr using the current year — it indexes new releases from TMDB and is the best source for titles not yet in Plex.
 - Never request media on behalf of the user — always let the user confirm first.
 - When users ask about movies or TV shows, speak the title, year, and a brief description when available.
 - Stay focused on media management — you can give opinions about movies or TV shows to help the user decide what to watch, but do not entertain off-topic questions.

--- a/src/lib/llm/system-prompt.ts
+++ b/src/lib/llm/system-prompt.ts
@@ -2,6 +2,16 @@ import { getConfig } from "@/lib/config";
 import { DEFAULT_SYSTEM_PROMPT, DEFAULT_REALTIME_SYSTEM_PROMPT } from "./default-prompt";
 export { DEFAULT_SYSTEM_PROMPT, DEFAULT_REALTIME_SYSTEM_PROMPT };
 
+/** Return the current date formatted as a readable string (e.g. "Thursday, 26 March 2026"). */
+function buildCurrentDate(): string {
+  return new Date().toLocaleDateString("en-GB", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
 /** Build the live {{serviceList}} block based on currently-configured services. */
 function buildServiceList(): string {
   const services: string[] = [];
@@ -23,7 +33,9 @@ function buildServiceList(): string {
  */
 export function buildSystemPrompt(customPrompt?: string): string {
   const template = customPrompt?.trim() || DEFAULT_SYSTEM_PROMPT;
-  return template.replace("{{serviceList}}", buildServiceList());
+  return template
+    .replace("{{serviceList}}", buildServiceList())
+    .replace("{{currentDate}}", buildCurrentDate());
 }
 
 /**
@@ -32,5 +44,7 @@ export function buildSystemPrompt(customPrompt?: string): string {
  */
 export function buildRealtimeSystemPrompt(customPrompt?: string): string {
   const template = customPrompt?.trim() || DEFAULT_REALTIME_SYSTEM_PROMPT;
-  return template.replace("{{serviceList}}", buildServiceList());
+  return template
+    .replace("{{serviceList}}", buildServiceList())
+    .replace("{{currentDate}}", buildCurrentDate());
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#137** — Trash icon always visible on mobile: replaced JS `hoveredId` hover state with CSS (`md:opacity-0 md:group-hover:opacity-100`) so the delete button is always shown below the `md` breakpoint and only appears on hover on desktop.
- **#166** — Report Issue button moved to the right of the top toolbar; model selector moved to the left, so they no longer overlap each other or the sidebar toggle.
- **#178** — Current date injected into both text and realtime system prompts via a `{{currentDate}}` placeholder resolved at request time by `buildCurrentDate()`. Added a guideline instructing the LLM to search Overseerr with the current year when users ask about new/recent releases.
- **#192 (1)** — `services/status/route.ts` now iterates all enabled LLM endpoints from `llm.endpoints` and returns one status entry per endpoint (with per-endpoint name). `ServiceStatus` accepts `selectedModel` and immediately re-polls when the model changes. Wired through `Sidebar` → `ChatPage`.
- **#192 (2)** — Settings: test results are now stored under a per-endpoint key (`"llm-{id}"`) so testing one LLM endpoint no longer overwrites the status shown for another.
- **#192 (3)** — `POST /api/setup/test-connection` now logs every test attempt via `logger.info`/`logger.warn` with endpoint URL, service type, model, endpointId, hasApiKey, and result message.
- **#194** — More Info + Request/Requested buttons wrapped in a `flex flex-nowrap` sub-group so they always stay on the same line regardless of button text/state changes.

## Test plan

- [ ] On mobile, open the sidebar — confirm the trash icon is visible on every chat item without needing to hover
- [ ] With a single model configured, open a chat — confirm Report Issue button appears on the right of the toolbar
- [ ] With two models configured, open a chat — confirm model selector is on the left, Report Issue on the right, no overlap
- [ ] Ask the LLM "what year is it?" — confirm it responds with the correct current year
- [ ] Ask the LLM "what movies came out this year?" — confirm it searches Overseerr
- [ ] With two LLM endpoints configured in settings, test each separately — confirm only the tested endpoint's result updates
- [ ] Trigger a test connection success and failure — confirm both appear in application logs with endpoint/model details
- [ ] On a title card (not_requested or partial status), click Request — confirm More Info and Requesting… stay on the same line; confirm Requested badge stays on the same line as More Info

https://claude.ai/code/session_01NZCdMoscTWsbmQ7DPYBomq
EOF
)