### PR TITLE
fix: getSeriesEpisodes returns empty when AI reuses season-level plexKey (#211)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1627,3 +1627,20 @@ Token cost of history is now capped. A conversation with 35 tool-calling rounds 
 | `src/lib/llm/default-prompt.ts` | Redirect genre/trending queries to `overseerr_discover`; clarify `partial` status (#207) |
 | `src/__tests__/lib/plex.test.ts` | Tests for episode filtering and `/children` key stripping |
 | `src/__tests__/lib/overseerr.test.ts` | Tests for new `discover()` function |
+
+---
+
+### Phase N+1 — Bug fix: season-level plexKey returns no episodes (#211)
+
+#### Bug fixes
+
+- **#211 `plex_get_series_episodes` returns empty when AI reuses a season-level plexKey**: When `plex_get_series_episodes` is called with no `season` param it returns season cards whose `plexKey` values point to the season's `/children` endpoint (e.g. `/library/metadata/5532/children`). If the AI then re-calls the tool with one of those season-level keys *plus* a `season` number, the function was stripping `/children`, fetching that path's children (which are episodes, not seasons), filtering for `type === "season"` — getting an empty array — and returning no results.
+
+  **Fix**: after fetching children, detect whether the plexKey already points at a season (any child has `type === "episode"`). If so, return the episode list directly without trying to locate a sub-season. A `season` or `episode` filter param still narrows the result to a single episode as expected.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/services/plex.ts` | `getSeriesEpisodes` detects season-level key and returns episodes directly (#211) |
+| `src/__tests__/lib/plex.test.ts` | 3 new tests: season-level key with season param, season-level key with episode param, empty season (#211) |

--- a/src/__tests__/lib/plex.test.ts
+++ b/src/__tests__/lib/plex.test.ts
@@ -733,6 +733,47 @@ describe("getSeriesEpisodes — issue #197", () => {
     // Must NOT double-up to /library/metadata/100/children/children
     expect(firstUrl).not.toContain("/children/children");
   });
+
+  it("returns episodes when a season-level plexKey is passed with a season number — issue #211", async () => {
+    // Simulates the AI reusing the season plexKey (/library/metadata/200/children)
+    // from a prior plex_get_series_episodes result and calling again with season=1.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ MediaContainer: { Metadata: SEASON1_EPISODES } }),
+    }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    const { results } = await getSeriesEpisodes("/library/metadata/200/children", 1);
+    expect(results).toHaveLength(3);
+    expect(results[0].title).toBe("Pilot");
+    expect(results[0].episodeNumber).toBe(1);
+    expect(results[0].mediaType).toBe("episode");
+  });
+
+  it("returns empty array when season-level plexKey is passed but no episodes present — issue #211", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ MediaContainer: { Metadata: [] } }),
+    }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    // Empty season — should fall through to normal show path and return empty seasons
+    const { results } = await getSeriesEpisodes("/library/metadata/200", 1);
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns single episode when season-level plexKey is passed with season and episode — issue #211", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ MediaContainer: { Metadata: SEASON1_EPISODES } }),
+    }));
+
+    const { getSeriesEpisodes } = await import("@/lib/services/plex");
+    const { results } = await getSeriesEpisodes("/library/metadata/200/children", 1, 2);
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe("Cat's in the Bag");
+    expect(results[0].episodeNumber).toBe(2);
+  });
 });
 
 describe("searchLibrary — episode filtering — issue #206", () => {

--- a/src/lib/services/plex.ts
+++ b/src/lib/services/plex.ts
@@ -372,9 +372,28 @@ export async function getSeriesEpisodes(
   const normalizedKey = plexKey.replace(/\/children\/?$/, "");
   const showPath = normalizedKey.startsWith("/") ? normalizedKey : `/${normalizedKey}`;
 
-  // Fetch the show's direct children (seasons)
-  const seasonsData = await plexFetch(`${showPath}/children`);
-  const rawSeasons = ((seasonsData?.MediaContainer?.Metadata || []) as Record<string, unknown>[])
+  // Fetch the direct children of the given key
+  const childrenData = await plexFetch(`${showPath}/children`);
+  const allChildren = ((childrenData?.MediaContainer?.Metadata || []) as Record<string, unknown>[]);
+
+  // If the key already points at a season (its children are episodes), fetch episodes directly.
+  // This happens when the AI re-uses a season-level plexKey from a prior plex_get_series_episodes
+  // result and passes it back alongside a season number — issue #211.
+  const isSeasonKey = allChildren.some((c) => (c.type as string) === "episode");
+  if (isSeasonKey) {
+    const mapped: PlexSearchResult[] = allChildren
+      .filter((e) => (e.type as string) === "episode")
+      .sort((a, b) => (a.index as number) - (b.index as number))
+      .map((e) => mapMetadata(e, "episode"));
+
+    if (episode !== undefined) {
+      const single = mapped.find((e) => e.episodeNumber === episode);
+      return { results: single ? [single] : [], hasMore: false };
+    }
+    return { results: mapped, hasMore: false };
+  }
+
+  const rawSeasons = allChildren
     .filter((s) => (s.type as string) === "season" && (s.index as number) > 0)
     .sort((a, b) => (a.index as number) - (b.index as number));
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `plex_get_series_episodes` was returning empty results when the AI reused a season-level `plexKey` (e.g. `/library/metadata/5532/children`) alongside a `season` number
- Root cause: the function fetched the season's children (episodes), filtered for `type === "season"` (got nothing), then returned an empty array
- Fix: detect whether the fetched children are already episodes and return them directly, bypassing the season-lookup path

## Test plan

- [ ] All existing `getSeriesEpisodes` tests pass (35 total)
- [ ] 3 new tests added: season-level key returns all episodes, season-level key with episode filter returns single episode, empty season returns empty array
- [ ] Reproduces the Gogglebox scenario from issue #211: first call returns season cards, second call with a season-level key + season number now returns episodes correctly

Closes #211

https://claude.ai/code/session_01FjDcwXoQiWVYvfzac6QC9i
EOF
)