### PR TITLE
feat(voice): TTS read-back loop for voice mode (issue #120)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -352,6 +352,7 @@ src/
 │       └── textarea.tsx             # Multi-line text input
 ├── hooks/
 │   ├── use-audio-level.ts           # Web Audio AnalyserNode → 7 normalised bar heights for visualizer
+│   ├── use-silence-detection.ts     # VAD: auto-stops recording on 1.5s silence or 60s hard timeout
 │   ├── use-auto-scroll.ts           # Auto-scroll on new messages, respects manual scroll
 │   ├── use-chat.ts                  # Messages state, SSE streaming, send/stop, model override
 │   ├── use-conversations.ts         # Conversation CRUD (list, create, delete, rename, viewAll)

--- a/PLAN.md
+++ b/PLAN.md
@@ -245,6 +245,20 @@ Build an LLM-powered chat frontend for media management (*arr stack). Users log 
 - [x] **`src/__tests__/api/voice-transcribe.test.ts`** — Tests for 401 (unauth), 400 (missing audio), 200 (success with mocked Whisper), 500 (API error)
 - [x] **`src/__tests__/api/realtime-session.test.ts`** — Tests for 401 (unauth), 400 (no realtime support), 400 (unknown endpoint), 200 (success with mock fetch), 502 (OpenAI returns error)
 
+### Phase 20: Voice TTS Read-back (issue #120)
+
+#### Features
+- [x] **TTS read-back in voice mode (#120)** — Non-realtime voice mode now completes a full speak-listen loop: after the LLM response finishes streaming, the assistant's text is automatically read aloud using the OpenAI TTS API (`/v1/audio/speech`). Markdown is stripped before synthesis so asterisks, headings, code fences etc. are not spoken. Input is truncated to 4096 chars (OpenAI limit). `POST /api/voice/tts` mirrors the existing `/api/voice/transcribe` route: requires auth, checks rate limit, resolves the endpoint client via `getLlmClientForEndpoint(modelId)`, and returns raw `audio/mpeg` bytes. — `src/app/api/voice/tts/route.ts` (new)
+- [x] **`useTts` hook** — `speakText(text, voice)` fetches `/api/voice/tts`, decodes the blob to an object URL, plays it with `new Audio()`, and resolves the returned promise when playback ends (or errors). `stop()` immediately pauses and revokes the URL. `speaking: boolean` state lets the UI react to playback. — `src/hooks/use-tts.ts` (new)
+- [x] **`useAudioLevel` hook** — During recording, pipes the live `MediaStream` through a Web Audio `AnalyserNode` (fftSize 64) sampled at ~20 fps (every 3rd rAF frame). Returns an array of 7 normalised bar heights (0–1) for the real-time visualizer. — `src/hooks/use-audio-level.ts` (new)
+- [x] **`useVoiceInput` exposes live stream** — Added `stream: MediaStream | null` state field (set on recording start, cleared on stop) so `VoiceConversation` can pass it to `useAudioLevel`. — `src/hooks/use-voice-input.ts`
+- [x] **`VoiceConversation` component** — Replaces `VoiceInput` in voice mode. Owns a 4-state machine: `idle → listening → processing → speaking → idle`. `idle`: secondary mic button, "Tap to speak". `listening`: destructive mic button + `animate-ping` outer ring + 7 real-time audio level bars (CSS height driven by `useAudioLevel`). `processing`: spinner, "Thinking…". `speaking`: primary `Volume2` icon + `animate-ping` ring, "Speaking…" + "Ask again" button (stops TTS and restarts mic) + "Cancel" link (exits to text mode). No longer auto-switches to text mode after sending. — `src/components/chat/voice-conversation.tsx` (new)
+- [x] **`supportsTts` capability probe** — `probeTtsSupport()` sends `POST /audio/speech` with an empty `input` (triggers 400 from the endpoint, proving the route exists, without generating audio). Runs in parallel with existing `probeVoiceSupport` and `probeRealtimeSupport`. Settings UI shows a `✓ TTS` / `✗ No TTS` badge per endpoint; a TTS voice selector (Alloy/Echo/Fable/Onyx/Nova/Shimmer) is shown when `supportsTts` is true. — `src/lib/services/test-connection.ts`, `src/types/api.ts`, `src/app/settings/page.tsx`
+- [x] **`ttsVoice` field on endpoints** — `LlmEndpointConfig`, `/api/models`, and `endpointCaps` in `chat/page.tsx` all carry `ttsVoice` (default `"alloy"`). Passed through `ChatInput` → `VoiceConversation` → `useTts`. — `src/lib/llm/client.ts`, `src/app/api/models/route.ts`, `src/app/chat/page.tsx`, `src/components/chat/chat-input.tsx`
+
+#### Tests
+- [x] **`src/__tests__/api/voice-tts.test.ts`** — 9 tests: 401 (unauth), 400 (missing text), 400 (empty text), 400 (invalid JSON), 200 success with default voice, 200 success with specified voice, alloy fallback for invalid voice, markdown stripping, 500 on API error
+
 ### Phase 13: React 19 Upgrade Fix
 
 #### Bug Fixes
@@ -294,7 +308,8 @@ src/
 │   │   │   ├── session/route.ts     # POST create ephemeral OpenAI Realtime session (WebRTC)
 │   │   │   └── tool/route.ts        # POST execute tool server-side during realtime session
 │   │   ├── voice/
-│   │   │   └── transcribe/route.ts  # POST audio → Whisper STT → transcript
+│   │   │   ├── transcribe/route.ts  # POST audio → Whisper STT → transcript
+│   │   │   └── tts/route.ts         # POST text + voice → OpenAI TTS → audio/mpeg
 │   │   └── setup/
 │   │       ├── route.ts             # GET status + POST save config
 │   │       └── test-connection/
@@ -323,7 +338,8 @@ src/
 │   │   ├── title-card.tsx           # Rich title card (thumbnail, status, cast, Watch Now / Request / More Info buttons)
 │   │   ├── title-carousel.tsx       # Single card or horizontal snap-scroll carousel with arrow buttons
 │   │   ├── tool-call.tsx            # "Running {Action} on {Service}" + expandable details
-│   │   └── voice-input.tsx          # Mic record/transcribe UI (click-to-toggle, spinner)
+│   │   ├── voice-conversation.tsx   # 4-state voice loop (idle→listening→processing→speaking) with TTS read-back
+│   │   └── voice-input.tsx          # Mic record/transcribe UI (legacy, kept for reference)
 │   └── ui/
 │       ├── avatar.tsx               # Image/fallback avatar (sm/md/lg)
 │       ├── badge.tsx                # 4 variants
@@ -335,11 +351,13 @@ src/
 │       ├── tabs.tsx                 # Tabs/TabsList/TabsTrigger/TabsContent
 │       └── textarea.tsx             # Multi-line text input
 ├── hooks/
+│   ├── use-audio-level.ts           # Web Audio AnalyserNode → 7 normalised bar heights for visualizer
 │   ├── use-auto-scroll.ts           # Auto-scroll on new messages, respects manual scroll
 │   ├── use-chat.ts                  # Messages state, SSE streaming, send/stop, model override
 │   ├── use-conversations.ts         # Conversation CRUD (list, create, delete, rename, viewAll)
 │   ├── use-realtime-chat.ts         # WebRTC realtime hook (connect, SDP, data channel, tool calls)
-│   └── use-voice-input.ts           # MediaRecorder hook (record, stop, POST to transcribe)
+│   ├── use-tts.ts                   # OpenAI TTS playback hook (speakText, stop, speaking state)
+│   └── use-voice-input.ts           # MediaRecorder hook (record, stop, POST to transcribe, exposes live stream)
 ├── lib/
 │   ├── auth/
 │   │   └── session.ts               # Session create/validate/destroy + cookie management
@@ -443,6 +461,7 @@ src/
 | GET | /api/settings/logs/[filename] | Read last 500 lines or full log; `?download=true` streams file (admin) |
 | POST | /api/request | Submit Overseerr media request (movie or TV with optional seasons array) |
 | POST | /api/voice/transcribe | Transcribe audio file via Whisper STT (auth required) |
+| POST | /api/voice/tts | Synthesise speech from text via OpenAI TTS (auth required) |
 | POST | /api/realtime/session | Create ephemeral OpenAI Realtime session token for WebRTC (auth required) |
 | POST | /api/realtime/tool | Execute a tool server-side during a realtime voice session (auth required) |
 | GET | /api/plex/avatar/[userId] | Server-side proxy for Plex user avatar images (auth required; fetches stored Plex.tv URL with token) |

--- a/src/__tests__/api/voice-tts.test.ts
+++ b/src/__tests__/api/voice-tts.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for POST /api/voice/tts
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/lib/db/schema";
+import path from "path";
+
+let sqlite: Database.Database;
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+
+vi.mock("@/lib/db", () => ({ getDb: () => testDb, schema }));
+
+const mockSession = {
+  sessionId: "test-session",
+  user: { id: 1, plexId: "p1", plexUsername: "user", plexEmail: null, plexAvatarUrl: null, isAdmin: false },
+};
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth/session", () => ({ getSession: () => mockGetSession() }));
+
+const mockSpeechCreate = vi.fn();
+vi.mock("@/lib/llm/client", () => ({
+  getLlmClientForEndpoint: vi.fn(() => ({
+    client: { audio: { speech: { create: mockSpeechCreate } } },
+    model: "gpt-4.1",
+  })),
+  getEndpointConfig: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/security/api-rate-limit", () => ({
+  checkUserApiRateLimit: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import { POST } from "@/app/api/voice/tts/route";
+
+function makeAudioBuffer(): ArrayBuffer {
+  return new Uint8Array([0x49, 0x44, 0x33]).buffer; // Fake MP3 header bytes
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  testDb = drizzle(sqlite, { schema });
+  migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
+  mockGetSession.mockResolvedValue(mockSession);
+  mockSpeechCreate.mockResolvedValue({ arrayBuffer: async () => makeAudioBuffer() });
+});
+
+afterEach(() => {
+  sqlite.close();
+  vi.clearAllMocks();
+});
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/voice/tts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/voice/tts", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await POST(makeRequest({ text: "hello", modelId: "ep1:gpt-4.1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when text is missing", async () => {
+    const res = await POST(makeRequest({ modelId: "ep1:gpt-4.1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/text/i);
+  });
+
+  it("returns 400 when text is empty string", async () => {
+    const res = await POST(makeRequest({ text: "   ", modelId: "ep1:gpt-4.1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new Request("http://localhost/api/voice/tts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns audio/mpeg on success with default voice", async () => {
+    const res = await POST(makeRequest({ text: "Hello world", modelId: "ep1:gpt-4.1" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("audio/mpeg");
+    expect(mockSpeechCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ voice: "alloy", model: "tts-1" }),
+    );
+  });
+
+  it("uses specified voice when valid", async () => {
+    const res = await POST(makeRequest({ text: "Hello", modelId: "ep1:gpt-4.1", voice: "nova" }));
+    expect(res.status).toBe(200);
+    expect(mockSpeechCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ voice: "nova" }),
+    );
+  });
+
+  it("falls back to alloy for an invalid voice value", async () => {
+    await POST(makeRequest({ text: "Hello", modelId: "ep1:gpt-4.1", voice: "invalid-voice" }));
+    expect(mockSpeechCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ voice: "alloy" }),
+    );
+  });
+
+  it("strips markdown from text before sending to TTS", async () => {
+    await POST(
+      makeRequest({ text: "**Bold** and `code`\n# Heading", modelId: "ep1:gpt-4.1" }),
+    );
+    const call = mockSpeechCreate.mock.calls[0][0];
+    expect(call.input).not.toContain("**");
+    expect(call.input).not.toContain("`");
+    expect(call.input).not.toContain("# ");
+    expect(call.input).toContain("Bold");
+    expect(call.input).toContain("code");
+    expect(call.input).toContain("Heading");
+  });
+
+  it("returns 500 when TTS API throws", async () => {
+    mockSpeechCreate.mockRejectedValue(new Error("API error"));
+    const res = await POST(makeRequest({ text: "Hello", modelId: "ep1:gpt-4.1" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+});

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -10,6 +10,8 @@ export interface ModelOption {
   model: string;
   label: string;
   supportsVoice: boolean;
+  supportsTts: boolean;
+  ttsVoice: string;
   supportsRealtime: boolean;
 }
 
@@ -21,6 +23,8 @@ interface LlmEndpoint {
   enabled: boolean;
   isDefault?: boolean;
   supportsVoice?: boolean;
+  supportsTts?: boolean;
+  ttsVoice?: string;
   supportsRealtime?: boolean;
 }
 
@@ -66,6 +70,8 @@ export async function GET() {
       model: ep.model,
       label: endpoints.length > 1 ? `${ep.name} — ${ep.model}` : ep.model,
       supportsVoice: ep.supportsVoice ?? false,
+      supportsTts: ep.supportsTts ?? false,
+      ttsVoice: ep.ttsVoice ?? "alloy",
       supportsRealtime: ep.supportsRealtime ?? false,
     }));
 

--- a/src/app/api/voice/tts/route.ts
+++ b/src/app/api/voice/tts/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getLlmClientForEndpoint } from "@/lib/llm/client";
+import { checkUserApiRateLimit } from "@/lib/security/api-rate-limit";
+import { logger } from "@/lib/logger";
+import type { ApiResponse } from "@/types/api";
+
+const TTS_VOICES = ["alloy", "echo", "fable", "onyx", "nova", "shimmer"] as const;
+type TtsVoice = (typeof TTS_VOICES)[number];
+
+// OpenAI TTS input limit
+const MAX_TTS_CHARS = 4096;
+
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Not authenticated" },
+      { status: 401 },
+    );
+  }
+
+  if (!checkUserApiRateLimit(session.user.id)) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Too many requests. Please slow down." },
+      { status: 429 },
+    );
+  }
+
+  let body: { text?: unknown; modelId?: unknown; voice?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Invalid JSON" },
+      { status: 400 },
+    );
+  }
+
+  const rawText = typeof body.text === "string" ? body.text.trim() : "";
+  const modelId = typeof body.modelId === "string" ? body.modelId : "";
+  const voiceRaw = typeof body.voice === "string" ? body.voice : "alloy";
+  const voice: TtsVoice = (TTS_VOICES as readonly string[]).includes(voiceRaw)
+    ? (voiceRaw as TtsVoice)
+    : "alloy";
+
+  if (!rawText) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "text is required" },
+      { status: 400 },
+    );
+  }
+
+  // Strip markdown so TTS doesn't read out symbols, then truncate
+  const text = stripMarkdown(rawText).slice(0, MAX_TTS_CHARS);
+
+  try {
+    const { client } = getLlmClientForEndpoint(modelId);
+
+    const audioResponse = await client.audio.speech.create({
+      model: "tts-1",
+      voice,
+      input: text,
+    });
+
+    const arrayBuffer = await audioResponse.arrayBuffer();
+    logger.info("VOICE_TTS", { userId: session.user.id, chars: text.length, voice });
+
+    return new Response(arrayBuffer, {
+      headers: {
+        "Content-Type": "audio/mpeg",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "TTS failed";
+    logger.error("VOICE_TTS_ERROR", { userId: session.user.id, error: msg });
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: msg },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * Strip common markdown so TTS reads natural prose instead of symbols.
+ */
+function stripMarkdown(text: string): string {
+  return text
+    // Fenced code blocks — replace with "code:" + content
+    .replace(/```[\w]*\n?([\s\S]*?)```/g, "code: $1")
+    // Inline code
+    .replace(/`([^`]+)`/g, "$1")
+    // Bold / italic (*** ** * ___ __ _)
+    .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
+    .replace(/_{1,3}([^_]+)_{1,3}/g, "$1")
+    // ATX headings (# ## ###)
+    .replace(/^#{1,6}\s+/gm, "")
+    // Links [text](url) → text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    // Images ![alt](url) → alt
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    // Horizontal rules
+    .replace(/^[-*_]{3,}\s*$/gm, "")
+    // Unordered list bullets
+    .replace(/^[\s]*[-*+]\s+/gm, "")
+    // Ordered list numbers
+    .replace(/^[\s]*\d+\.\s+/gm, "")
+    // Blockquotes
+    .replace(/^>\s*/gm, "")
+    // Collapse multiple blank lines
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -122,10 +122,12 @@ export default function ChatPage() {
   const handleNewChat = useCallback(() => {
     setActiveConversationId(null);
     clearMessages();
+    setChatMode("text");
   }, [clearMessages]);
 
   const handleSelectConversation = useCallback((id: string) => {
     setActiveConversationId(id);
+    setChatMode("text");
     if (window.innerWidth < 768) setSidebarCollapsed(true);
   }, []);
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -19,6 +19,7 @@ interface ModelOption {
   label: string;
   supportsVoice?: boolean;
   supportsRealtime?: boolean;
+  ttsVoice?: string;
 }
 
 export default function ChatPage() {
@@ -37,7 +38,11 @@ export default function ChatPage() {
 
   // Chat mode (text / voice / realtime)
   const [chatMode, setChatMode] = useState<ChatMode>("text");
-  const [endpointCaps, setEndpointCaps] = useState({ supportsVoice: false, supportsRealtime: false });
+  const [endpointCaps, setEndpointCaps] = useState({
+    supportsVoice: false,
+    supportsRealtime: false,
+    ttsVoice: "alloy",
+  });
   const [reportIssueOpen, setReportIssueOpen] = useState(false);
 
   const {
@@ -88,6 +93,7 @@ export default function ChatPage() {
             setEndpointCaps({
               supportsVoice: defaultOpt.supportsVoice ?? false,
               supportsRealtime: defaultOpt.supportsRealtime ?? false,
+              ttsVoice: defaultOpt.ttsVoice ?? "alloy",
             });
           }
         }
@@ -194,6 +200,7 @@ export default function ChatPage() {
                     const caps = {
                       supportsVoice: opt?.supportsVoice ?? false,
                       supportsRealtime: opt?.supportsRealtime ?? false,
+                      ttsVoice: opt?.ttsVoice ?? "alloy",
                     };
                     setEndpointCaps(caps);
                     setChatMode((prev) => {
@@ -270,6 +277,8 @@ export default function ChatPage() {
           supportsVoice={endpointCaps.supportsVoice}
           supportsRealtime={endpointCaps.supportsRealtime}
           selectedModel={selectedModel}
+          ttsVoice={endpointCaps.ttsVoice}
+          lastResponse={messages.findLast((m) => m.role === "assistant")?.content ?? ""}
         />
       </main>
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -38,6 +38,8 @@ interface LlmEndpoint {
   enabled: boolean;
   isDefault: boolean;
   supportsVoice: boolean;
+  supportsTts: boolean;
+  ttsVoice: string;
   supportsRealtime: boolean;
   realtimeModel: string;
   realtimeSystemPrompt: string;
@@ -174,6 +176,8 @@ export default function SettingsPage() {
               (d.llmEndpoints || []).map((ep: LlmEndpoint) => ({
                 ...ep,
                 supportsVoice: ep.supportsVoice ?? false,
+                supportsTts: ep.supportsTts ?? false,
+                ttsVoice: ep.ttsVoice ?? "alloy",
                 supportsRealtime: ep.supportsRealtime ?? false,
                 realtimeModel: ep.realtimeModel ?? "",
                 realtimeSystemPrompt: ep.realtimeSystemPrompt ?? "",
@@ -378,7 +382,11 @@ export default function SettingsPage() {
       }));
       // If LLM test succeeded and capabilities were detected, update the endpoint
       if (sectionKey === "llm" && endpointId && result?.success && result?.capabilities) {
-        const caps = result.capabilities as { supportsVoice: boolean; realtimeModel: string | null };
+        const caps = result.capabilities as {
+          supportsVoice: boolean;
+          supportsTts: boolean;
+          realtimeModel: string | null;
+        };
         setEndpoints((prev) =>
           prev.map((ep) => {
             if (ep.id !== endpointId) return ep;
@@ -386,6 +394,7 @@ export default function SettingsPage() {
             return {
               ...ep,
               supportsVoice: caps.supportsVoice,
+              supportsTts: caps.supportsTts,
               supportsRealtime: realtimeModel !== "",
               realtimeModel,
             };
@@ -416,6 +425,8 @@ export default function SettingsPage() {
         enabled: true,
         isDefault: prev.length === 0,
         supportsVoice: false,
+        supportsTts: false,
+        ttsVoice: "alloy",
         supportsRealtime: false,
         realtimeModel: "",
         realtimeSystemPrompt: "",
@@ -824,12 +835,32 @@ export default function SettingsPage() {
                       <span className={`rounded-full px-2 py-0.5 font-medium ${ep.supportsVoice ? "bg-green-500/15 text-green-600 dark:text-green-400" : "bg-muted text-muted-foreground"}`}>
                         {ep.supportsVoice ? "✓ Voice (Whisper)" : "✗ No voice"}
                       </span>
+                      <span className={`rounded-full px-2 py-0.5 font-medium ${ep.supportsTts ? "bg-green-500/15 text-green-600 dark:text-green-400" : "bg-muted text-muted-foreground"}`}>
+                        {ep.supportsTts ? "✓ TTS" : "✗ No TTS"}
+                      </span>
                       <span className={`rounded-full px-2 py-0.5 font-medium ${ep.supportsRealtime ? "bg-green-500/15 text-green-600 dark:text-green-400" : "bg-muted text-muted-foreground"}`}>
                         {ep.supportsRealtime ? `✓ Realtime (${ep.realtimeModel || "configured"})` : "✗ No realtime"}
                       </span>
                     </div>
                     <p className="text-xs text-muted-foreground">Click Test to auto-detect capabilities.</p>
                   </div>
+
+                  {/* TTS voice selector — only shown when TTS is supported */}
+                  {ep.supportsTts && (
+                    <div className="space-y-1.5">
+                      <Label>TTS Voice</Label>
+                      <select
+                        value={ep.ttsVoice || "alloy"}
+                        onChange={(e) => updateEndpoint(ep.id, "ttsVoice", e.target.value)}
+                        className="rounded border bg-background px-2 py-1.5 text-sm w-full"
+                      >
+                        {["alloy", "echo", "fable", "onyx", "nova", "shimmer"].map((v) => (
+                          <option key={v} value={v}>{v.charAt(0).toUpperCase() + v.slice(1)}</option>
+                        ))}
+                      </select>
+                      <p className="text-xs text-muted-foreground">Voice used when reading responses aloud in voice mode.</p>
+                    </div>
+                  )}
 
                   {/* Realtime model override */}
                   <div className="space-y-1.5">

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { SendHorizontal, Square } from "lucide-react";
 import type { ChatMode } from "@/app/chat/page";
-import { VoiceInput } from "@/components/chat/voice-input";
+import { VoiceConversation } from "@/components/chat/voice-conversation";
 import { RealtimeChat } from "@/components/chat/realtime-chat";
 
 interface ChatInputProps {
@@ -17,6 +17,8 @@ interface ChatInputProps {
   supportsVoice: boolean;
   supportsRealtime: boolean;
   selectedModel: string;
+  ttsVoice?: string;
+  lastResponse?: string;
 }
 
 export function ChatInput({
@@ -29,6 +31,8 @@ export function ChatInput({
   supportsVoice,
   supportsRealtime,
   selectedModel,
+  ttsVoice = "alloy",
+  lastResponse = "",
 }: ChatInputProps) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -108,13 +112,13 @@ export function ChatInput({
 
         {/* Input area */}
         {chatMode === "voice" ? (
-          <VoiceInput
+          <VoiceConversation
             modelId={selectedModel}
-            onTranscript={(text) => {
-              onSend(text);
-              onModeChange("text");
-            }}
-            disabled={disabled}
+            ttsVoice={ttsVoice}
+            onSend={onSend}
+            onCancel={() => onModeChange("text")}
+            streaming={streaming ?? false}
+            lastResponse={lastResponse}
           />
         ) : chatMode === "realtime" ? (
           <RealtimeChat modelId={selectedModel} />

--- a/src/components/chat/voice-conversation.tsx
+++ b/src/components/chat/voice-conversation.tsx
@@ -9,7 +9,9 @@ import { useAudioLevel } from "@/hooks/use-audio-level";
 import { useSilenceDetection } from "@/hooks/use-silence-detection";
 import { useTts } from "@/hooks/use-tts";
 
-type VoicePhase = "idle" | "listening" | "processing" | "speaking";
+// "speaking" is derived from useTts rather than tracked as explicit phase state,
+// so the state machine only needs three stored values.
+type VoicePhase = "idle" | "listening" | "processing";
 
 interface VoiceConversationProps {
   modelId: string;
@@ -34,17 +36,26 @@ export function VoiceConversation({
 }: VoiceConversationProps) {
   const [phase, setPhase] = useState<VoicePhase>("idle");
 
-  const { recording, transcribing, startRecording, stopAndTranscribe, cancelRecording, error, stream } =
+  const { recording, startRecording, stopAndTranscribe, cancelRecording, error, stream } =
     useVoiceInput();
   const bars = useAudioLevel(recording ? stream : null);
   const { speaking, speakText, stop: stopTts } = useTts(modelId);
 
-  // Shared stop-listening logic used by both the manual button and auto-stop
+  // Derive the full 4-value phase for the UI without storing "speaking" in state.
+  // This avoids calling setPhase synchronously inside effects (react-hooks/set-state-in-effect).
+  const effectivePhase = speaking ? "speaking" : phase;
+
+  // Track what we've already spoken so we don't replay the same response
+  const lastSpokenRef = useRef<string>("");
+
+  // Shared stop-listening logic for both the manual button tap and silence-detection auto-stop.
+  // Sets phase to "processing" immediately (before the async transcription) so the UI
+  // transitions away from the listening state without needing a separate effect.
   const handleStopListening = useCallback(async () => {
+    setPhase("processing");
     const text = await stopAndTranscribe(modelId);
     if (text) {
       onSend(text);
-      // phase transitions to "processing" via the transcribing useEffect
     } else {
       setPhase("idle");
     }
@@ -55,17 +66,9 @@ export function VoiceConversation({
     onAutoStop: handleStopListening,
   });
 
-  // Track what we've already spoken so we don't replay the same response
-  const lastSpokenRef = useRef<string>("");
-  // Track previous speaking value to detect the natural end of playback
-  const prevSpeakingRef = useRef(false);
-
-  // Transition from listening → processing when transcription starts
-  useEffect(() => {
-    if (transcribing && phase === "listening") setPhase("processing");
-  }, [transcribing, phase]);
-
-  // When streaming ends and we're waiting for a response, trigger TTS
+  // When the LLM finishes streaming while we're waiting for a response, read it aloud.
+  // setPhase("idle") is called inside the promise .then() callback (async, not synchronous
+  // in the effect body) to satisfy react-hooks/set-state-in-effect.
   useEffect(() => {
     if (
       !streaming &&
@@ -74,18 +77,15 @@ export function VoiceConversation({
       lastResponse !== lastSpokenRef.current
     ) {
       lastSpokenRef.current = lastResponse;
-      setPhase("speaking");
-      speakText(lastResponse, ttsVoice);
+      let cancelled = false;
+      speakText(lastResponse, ttsVoice).then(() => {
+        if (!cancelled) setPhase("idle");
+      });
+      return () => {
+        cancelled = true;
+      };
     }
   }, [streaming, phase, lastResponse, ttsVoice, speakText]);
-
-  // When TTS finishes naturally, return to idle ready for next question
-  useEffect(() => {
-    if (prevSpeakingRef.current && !speaking && phase === "speaking") {
-      setPhase("idle");
-    }
-    prevSpeakingRef.current = speaking;
-  }, [speaking, phase]);
 
   const handleMicToggle = useCallback(async () => {
     if (phase === "idle") {
@@ -98,9 +98,8 @@ export function VoiceConversation({
 
   // Skip current TTS and start a new recording immediately
   const handleAskAgain = useCallback(async () => {
-    // Move phase first so the speaking-end effect doesn't fire and override
-    setPhase("listening");
-    stopTts();
+    setPhase("listening"); // show listening UI before mic opens
+    stopTts();             // sets speaking=false; effectivePhase becomes "listening"
     await startRecording();
   }, [stopTts, startRecording]);
 
@@ -110,9 +109,9 @@ export function VoiceConversation({
     onCancel();
   }, [recording, cancelRecording, stopTts, onCancel]);
 
-  const isListening = phase === "listening";
-  const isProcessing = phase === "processing";
-  const isSpeaking = phase === "speaking";
+  const isListening = effectivePhase === "listening";
+  const isProcessing = effectivePhase === "processing";
+  const isSpeaking = effectivePhase === "speaking";
 
   return (
     <div className="flex flex-col items-center gap-4 py-4">
@@ -158,14 +157,14 @@ export function VoiceConversation({
 
       {/* Status label */}
       <p className="text-sm text-muted-foreground">
-        {phase === "idle" && "Tap to speak"}
-        {phase === "listening" && (
+        {effectivePhase === "idle" && "Tap to speak"}
+        {effectivePhase === "listening" && (
           secondsRemaining !== null
             ? `Sending in ${secondsRemaining}s\u2026`
             : "Listening\u2026 tap to stop"
         )}
-        {phase === "processing" && "Thinking\u2026"}
-        {phase === "speaking" && "Speaking\u2026"}
+        {effectivePhase === "processing" && "Thinking\u2026"}
+        {effectivePhase === "speaking" && "Speaking\u2026"}
       </p>
 
       {/* Action buttons */}

--- a/src/components/chat/voice-conversation.tsx
+++ b/src/components/chat/voice-conversation.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { useVoiceInput } from "@/hooks/use-voice-input";
 import { useAudioLevel } from "@/hooks/use-audio-level";
+import { useSilenceDetection } from "@/hooks/use-silence-detection";
 import { useTts } from "@/hooks/use-tts";
 
 type VoicePhase = "idle" | "listening" | "processing" | "speaking";
@@ -37,6 +38,22 @@ export function VoiceConversation({
     useVoiceInput();
   const bars = useAudioLevel(recording ? stream : null);
   const { speaking, speakText, stop: stopTts } = useTts(modelId);
+
+  // Shared stop-listening logic used by both the manual button and auto-stop
+  const handleStopListening = useCallback(async () => {
+    const text = await stopAndTranscribe(modelId);
+    if (text) {
+      onSend(text);
+      // phase transitions to "processing" via the transcribing useEffect
+    } else {
+      setPhase("idle");
+    }
+  }, [stopAndTranscribe, modelId, onSend]);
+
+  const { secondsRemaining } = useSilenceDetection({
+    stream: recording ? stream : null,
+    onAutoStop: handleStopListening,
+  });
 
   // Track what we've already spoken so we don't replay the same response
   const lastSpokenRef = useRef<string>("");
@@ -75,15 +92,9 @@ export function VoiceConversation({
       await startRecording();
       if (!error) setPhase("listening");
     } else if (phase === "listening") {
-      const text = await stopAndTranscribe(modelId);
-      if (text) {
-        onSend(text);
-        // phase will move to "processing" via the transcribing effect above
-      } else {
-        setPhase("idle");
-      }
+      await handleStopListening();
     }
-  }, [phase, startRecording, stopAndTranscribe, modelId, onSend, error]);
+  }, [phase, startRecording, error, handleStopListening]);
 
   // Skip current TTS and start a new recording immediately
   const handleAskAgain = useCallback(async () => {
@@ -148,7 +159,11 @@ export function VoiceConversation({
       {/* Status label */}
       <p className="text-sm text-muted-foreground">
         {phase === "idle" && "Tap to speak"}
-        {phase === "listening" && "Listening\u2026 tap to stop"}
+        {phase === "listening" && (
+          secondsRemaining !== null
+            ? `Sending in ${secondsRemaining}s\u2026`
+            : "Listening\u2026 tap to stop"
+        )}
         {phase === "processing" && "Thinking\u2026"}
         {phase === "speaking" && "Speaking\u2026"}
       </p>

--- a/src/components/chat/voice-conversation.tsx
+++ b/src/components/chat/voice-conversation.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import { Mic, Volume2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { useVoiceInput } from "@/hooks/use-voice-input";
+import { useAudioLevel } from "@/hooks/use-audio-level";
+import { useTts } from "@/hooks/use-tts";
+
+type VoicePhase = "idle" | "listening" | "processing" | "speaking";
+
+interface VoiceConversationProps {
+  modelId: string;
+  ttsVoice?: string;
+  /** Called when transcription completes — sends the query to the chat */
+  onSend: (text: string) => void;
+  /** Called when the user explicitly exits voice mode */
+  onCancel: () => void;
+  /** True while the LLM is streaming its response */
+  streaming: boolean;
+  /** Full text of the latest assistant message — triggers TTS when streaming ends */
+  lastResponse: string;
+}
+
+export function VoiceConversation({
+  modelId,
+  ttsVoice = "alloy",
+  onSend,
+  onCancel,
+  streaming,
+  lastResponse,
+}: VoiceConversationProps) {
+  const [phase, setPhase] = useState<VoicePhase>("idle");
+
+  const { recording, transcribing, startRecording, stopAndTranscribe, error, stream } =
+    useVoiceInput();
+  const bars = useAudioLevel(recording ? stream : null);
+  const { speaking, speakText, stop: stopTts } = useTts(modelId);
+
+  // Track what we've already spoken so we don't replay the same response
+  const lastSpokenRef = useRef<string>("");
+  // Track previous speaking value to detect the natural end of playback
+  const prevSpeakingRef = useRef(false);
+
+  // Transition from listening → processing when transcription starts
+  useEffect(() => {
+    if (transcribing && phase === "listening") setPhase("processing");
+  }, [transcribing, phase]);
+
+  // When streaming ends and we're waiting for a response, trigger TTS
+  useEffect(() => {
+    if (
+      !streaming &&
+      phase === "processing" &&
+      lastResponse &&
+      lastResponse !== lastSpokenRef.current
+    ) {
+      lastSpokenRef.current = lastResponse;
+      setPhase("speaking");
+      speakText(lastResponse, ttsVoice);
+    }
+  }, [streaming, phase, lastResponse, ttsVoice, speakText]);
+
+  // When TTS finishes naturally, return to idle ready for next question
+  useEffect(() => {
+    if (prevSpeakingRef.current && !speaking && phase === "speaking") {
+      setPhase("idle");
+    }
+    prevSpeakingRef.current = speaking;
+  }, [speaking, phase]);
+
+  const handleMicToggle = useCallback(async () => {
+    if (phase === "idle") {
+      await startRecording();
+      if (!error) setPhase("listening");
+    } else if (phase === "listening") {
+      const text = await stopAndTranscribe(modelId);
+      if (text) {
+        onSend(text);
+        // phase will move to "processing" via the transcribing effect above
+      } else {
+        setPhase("idle");
+      }
+    }
+  }, [phase, startRecording, stopAndTranscribe, modelId, onSend, error]);
+
+  // Skip current TTS and start a new recording immediately
+  const handleAskAgain = useCallback(async () => {
+    // Move phase first so the speaking-end effect doesn't fire and override
+    setPhase("listening");
+    stopTts();
+    await startRecording();
+  }, [stopTts, startRecording]);
+
+  const handleCancel = useCallback(() => {
+    stopTts();
+    onCancel();
+  }, [stopTts, onCancel]);
+
+  const isListening = phase === "listening";
+  const isProcessing = phase === "processing";
+  const isSpeaking = phase === "speaking";
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-4">
+      {/* Central visual element */}
+      <div className="relative flex items-center justify-center">
+        {/* Animated ping ring for listening / speaking states */}
+        {(isListening || isSpeaking) && (
+          <span className="absolute h-20 w-20 rounded-full animate-ping opacity-20 bg-primary" />
+        )}
+
+        {isProcessing ? (
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+            <Spinner size={32} />
+          </div>
+        ) : isSpeaking ? (
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary text-primary-foreground">
+            <Volume2 size={28} />
+          </div>
+        ) : (
+          <Button
+            size="lg"
+            variant={isListening ? "destructive" : "secondary"}
+            onClick={handleMicToggle}
+            className="relative z-10 h-16 w-16 rounded-full"
+          >
+            <Mic size={28} />
+          </Button>
+        )}
+      </div>
+
+      {/* Real-time audio level bars — only shown while recording */}
+      {isListening && (
+        <div className="flex h-8 items-end gap-1">
+          {bars.map((level, i) => (
+            <div
+              key={i}
+              className="w-1.5 rounded-full bg-primary transition-all duration-75"
+              style={{ height: `${Math.max(4, level * 32)}px` }}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Status label */}
+      <p className="text-sm text-muted-foreground">
+        {phase === "idle" && "Tap to speak"}
+        {phase === "listening" && "Listening\u2026 tap to stop"}
+        {phase === "processing" && "Thinking\u2026"}
+        {phase === "speaking" && "Speaking\u2026"}
+      </p>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-4">
+        {isSpeaking && (
+          <Button size="sm" variant="secondary" onClick={handleAskAgain} className="gap-1.5">
+            <Mic size={14} />
+            Ask again
+          </Button>
+        )}
+        <button
+          onClick={handleCancel}
+          className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {isSpeaking ? "Cancel" : "Exit voice"}
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/chat/voice-conversation.tsx
+++ b/src/components/chat/voice-conversation.tsx
@@ -33,7 +33,7 @@ export function VoiceConversation({
 }: VoiceConversationProps) {
   const [phase, setPhase] = useState<VoicePhase>("idle");
 
-  const { recording, transcribing, startRecording, stopAndTranscribe, error, stream } =
+  const { recording, transcribing, startRecording, stopAndTranscribe, cancelRecording, error, stream } =
     useVoiceInput();
   const bars = useAudioLevel(recording ? stream : null);
   const { speaking, speakText, stop: stopTts } = useTts(modelId);
@@ -94,9 +94,10 @@ export function VoiceConversation({
   }, [stopTts, startRecording]);
 
   const handleCancel = useCallback(() => {
+    if (recording) cancelRecording();
     stopTts();
     onCancel();
-  }, [stopTts, onCancel]);
+  }, [recording, cancelRecording, stopTts, onCancel]);
 
   const isListening = phase === "listening";
   const isProcessing = phase === "processing";

--- a/src/hooks/use-audio-level.ts
+++ b/src/hooks/use-audio-level.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const BAR_COUNT = 7;
+// Sample every 3rd animation frame (~20 fps) to avoid excessive React renders
+const FRAME_SKIP = 3;
+
+/**
+ * Returns an array of BAR_COUNT normalised bar heights (0–1) driven by a live
+ * MediaStream's audio frequency data. All bars are 0 when stream is null.
+ */
+export function useAudioLevel(stream: MediaStream | null): number[] {
+  const [bars, setBars] = useState<number[]>(Array(BAR_COUNT).fill(0));
+  const rafRef = useRef<number | null>(null);
+  const frameCountRef = useRef(0);
+
+  useEffect(() => {
+    if (!stream) {
+      setBars(Array(BAR_COUNT).fill(0));
+      return;
+    }
+
+    const ctx = new AudioContext();
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 64;
+
+    const source = ctx.createMediaStreamSource(stream);
+    source.connect(analyser);
+
+    const dataArray = new Uint8Array(analyser.frequencyBinCount);
+    const bucketSize = Math.max(1, Math.floor(dataArray.length / BAR_COUNT));
+    frameCountRef.current = 0;
+
+    function tick() {
+      rafRef.current = requestAnimationFrame(tick);
+      if (++frameCountRef.current % FRAME_SKIP !== 0) return;
+
+      analyser.getByteFrequencyData(dataArray);
+      const newBars: number[] = [];
+      for (let i = 0; i < BAR_COUNT; i++) {
+        let sum = 0;
+        const start = i * bucketSize;
+        const end = Math.min(start + bucketSize, dataArray.length);
+        for (let j = start; j < end; j++) sum += dataArray[j];
+        newBars.push((sum / bucketSize) / 255);
+      }
+      setBars(newBars);
+    }
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      source.disconnect();
+      void ctx.close();
+    };
+  }, [stream]);
+
+  return bars;
+}

--- a/src/hooks/use-audio-level.ts
+++ b/src/hooks/use-audio-level.ts
@@ -16,10 +16,7 @@ export function useAudioLevel(stream: MediaStream | null): number[] {
   const frameCountRef = useRef(0);
 
   useEffect(() => {
-    if (!stream) {
-      setBars(Array(BAR_COUNT).fill(0));
-      return;
-    }
+    if (!stream) return;
 
     const ctx = new AudioContext();
     const analyser = ctx.createAnalyser();
@@ -57,5 +54,6 @@ export function useAudioLevel(stream: MediaStream | null): number[] {
     };
   }, [stream]);
 
-  return bars;
+  // When stream is null return flat bars directly — avoids setState in effect body
+  return stream ? bars : (Array(BAR_COUNT).fill(0) as number[]);
 }

--- a/src/hooks/use-silence-detection.ts
+++ b/src/hooks/use-silence-detection.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const SILENCE_THRESHOLD = 0.05; // normalised amplitude below which we consider it silent
+const SILENCE_DURATION_MS = 1500; // sustained silence before auto-stop
+const MIN_RECORDING_MS = 500; // don't trigger silence detection before this
+const MAX_RECORDING_MS = 60_000; // hard timeout regardless of noise
+const COUNTDOWN_START_S = 10; // show countdown label in the last N seconds
+
+interface UseSilenceDetectionOptions {
+  /** Pass the live MediaStream while recording; null to disable. */
+  stream: MediaStream | null;
+  /** Called once when either silence or the hard timeout fires. */
+  onAutoStop: () => void;
+}
+
+interface UseSilenceDetectionResult {
+  /**
+   * Non-null (and counting down) only during the last COUNTDOWN_START_S
+   * seconds of the hard timeout. Use this to show "Sending in Xs…".
+   */
+  secondsRemaining: number | null;
+}
+
+export function useSilenceDetection({
+  stream,
+  onAutoStop,
+}: UseSilenceDetectionOptions): UseSilenceDetectionResult {
+  const [secondsRemaining, setSecondsRemaining] = useState<number | null>(null);
+  // Keep a stable ref to the latest callback so the rAF loop never captures
+  // a stale closure without needing to be recreated.
+  const onAutoStopRef = useRef(onAutoStop);
+  onAutoStopRef.current = onAutoStop;
+
+  useEffect(() => {
+    if (!stream) {
+      setSecondsRemaining(null);
+      return;
+    }
+
+    const ctx = new AudioContext();
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 256;
+    const source = ctx.createMediaStreamSource(stream);
+    source.connect(analyser);
+
+    const dataArray = new Uint8Array(analyser.frequencyBinCount);
+    const startTime = performance.now();
+    let silenceSince: number | null = null;
+    let rafId: number;
+    let fired = false;
+
+    function fire() {
+      if (fired) return;
+      fired = true;
+      onAutoStopRef.current();
+    }
+
+    // Hard timeout — fires even in a noisy room
+    const maxTimer = setTimeout(fire, MAX_RECORDING_MS);
+
+    // Countdown ticker — updates state every 500ms so the label stays accurate
+    const countdownInterval = setInterval(() => {
+      const elapsed = performance.now() - startTime;
+      const remaining = Math.ceil((MAX_RECORDING_MS - elapsed) / 1000);
+      setSecondsRemaining(remaining > 0 && remaining <= COUNTDOWN_START_S ? remaining : null);
+    }, 500);
+
+    function tick() {
+      rafId = requestAnimationFrame(tick);
+
+      analyser.getByteFrequencyData(dataArray);
+      let sum = 0;
+      for (let i = 0; i < dataArray.length; i++) sum += dataArray[i];
+      const level = sum / dataArray.length / 255;
+
+      const now = performance.now();
+
+      // Ignore silence during the initial minimum window
+      if (now - startTime < MIN_RECORDING_MS) {
+        silenceSince = null;
+        return;
+      }
+
+      if (level < SILENCE_THRESHOLD) {
+        if (silenceSince === null) silenceSince = now;
+        else if (now - silenceSince >= SILENCE_DURATION_MS) fire();
+      } else {
+        silenceSince = null;
+      }
+    }
+
+    rafId = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      clearTimeout(maxTimer);
+      clearInterval(countdownInterval);
+      source.disconnect();
+      void ctx.close();
+      setSecondsRemaining(null);
+    };
+  }, [stream]);
+
+  return { secondsRemaining };
+}

--- a/src/hooks/use-silence-detection.ts
+++ b/src/hooks/use-silence-detection.ts
@@ -31,13 +31,12 @@ export function useSilenceDetection({
   // Keep a stable ref to the latest callback so the rAF loop never captures
   // a stale closure without needing to be recreated.
   const onAutoStopRef = useRef(onAutoStop);
-  onAutoStopRef.current = onAutoStop;
+  useEffect(() => {
+    onAutoStopRef.current = onAutoStop;
+  }, [onAutoStop]);
 
   useEffect(() => {
-    if (!stream) {
-      setSecondsRemaining(null);
-      return;
-    }
+    if (!stream) return;
 
     const ctx = new AudioContext();
     const analyser = ctx.createAnalyser();
@@ -103,5 +102,6 @@ export function useSilenceDetection({
     };
   }, [stream]);
 
-  return { secondsRemaining };
+  // When stream is null return null directly — avoids setState in effect body
+  return { secondsRemaining: stream ? secondsRemaining : null };
 }

--- a/src/hooks/use-tts.ts
+++ b/src/hooks/use-tts.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { clientLog } from "@/lib/client-logger";
+
+export function useTts(modelId: string) {
+  const [speaking, setSpeaking] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+
+  const stop = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.onended = null;
+      audioRef.current.onerror = null;
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+    setSpeaking(false);
+  }, []);
+
+  const speakText = useCallback(
+    async (text: string, voice = "alloy"): Promise<void> => {
+      if (!text.trim()) return;
+      stop();
+
+      setSpeaking(true);
+      try {
+        const res = await fetch("/api/voice/tts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text, modelId, voice }),
+        });
+
+        if (!res.ok) {
+          setSpeaking(false);
+          return;
+        }
+
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        objectUrlRef.current = url;
+
+        const audio = new Audio(url);
+        audioRef.current = audio;
+
+        await new Promise<void>((resolve) => {
+          audio.onended = () => {
+            if (objectUrlRef.current === url) {
+              URL.revokeObjectURL(url);
+              objectUrlRef.current = null;
+            }
+            audioRef.current = null;
+            setSpeaking(false);
+            resolve();
+          };
+          audio.onerror = () => {
+            if (objectUrlRef.current === url) {
+              URL.revokeObjectURL(url);
+              objectUrlRef.current = null;
+            }
+            audioRef.current = null;
+            setSpeaking(false);
+            resolve();
+          };
+          audio.play().catch(() => {
+            setSpeaking(false);
+            resolve();
+          });
+        });
+      } catch (e: unknown) {
+        clientLog.error("TTS playback failure", {
+          errorName: e instanceof Error ? e.name : "UnknownError",
+          errorMessage: e instanceof Error ? e.message : "Unknown error",
+        });
+        setSpeaking(false);
+      }
+    },
+    [modelId, stop],
+  );
+
+  return { speaking, speakText, stop };
+}

--- a/src/hooks/use-voice-input.ts
+++ b/src/hooks/use-voice-input.ts
@@ -7,6 +7,7 @@ export function useVoiceInput() {
   const [recording, setRecording] = useState(false);
   const [transcribing, setTranscribing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [stream, setStream] = useState<MediaStream | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
@@ -26,9 +27,10 @@ export function useVoiceInput() {
     }
 
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      streamRef.current = stream;
-      const mediaRecorder = new MediaRecorder(stream);
+      const liveStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = liveStream;
+      setStream(liveStream);
+      const mediaRecorder = new MediaRecorder(liveStream);
       mediaRecorderRef.current = mediaRecorder;
       chunksRef.current = [];
 
@@ -67,6 +69,7 @@ export function useVoiceInput() {
         // Stop all mic tracks
         streamRef.current?.getTracks().forEach((t) => t.stop());
         streamRef.current = null;
+        setStream(null);
 
         const blob = new Blob(chunksRef.current, { type: "audio/webm" });
         chunksRef.current = [];
@@ -101,5 +104,5 @@ export function useVoiceInput() {
     });
   }, []);
 
-  return { recording, transcribing, startRecording, stopAndTranscribe, error };
+  return { recording, transcribing, startRecording, stopAndTranscribe, error, stream };
 }

--- a/src/hooks/use-voice-input.ts
+++ b/src/hooks/use-voice-input.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { clientLog } from "@/lib/client-logger";
 
 export function useVoiceInput() {
@@ -104,5 +104,26 @@ export function useVoiceInput() {
     });
   }, []);
 
-  return { recording, transcribing, startRecording, stopAndTranscribe, error, stream };
+  const cancelRecording = useCallback(() => {
+    const mediaRecorder = mediaRecorderRef.current;
+    if (mediaRecorder && mediaRecorder.state !== "inactive") {
+      mediaRecorder.onstop = null; // discard any pending transcription
+      mediaRecorder.stop();
+    }
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    setStream(null);
+    chunksRef.current = [];
+    setRecording(false);
+  }, []);
+
+  // Stop the mic if the component using this hook is unmounted while recording
+  useEffect(() => {
+    return () => {
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    };
+  }, []);
+
+  return { recording, transcribing, startRecording, stopAndTranscribe, cancelRecording, error, stream };
 }

--- a/src/lib/llm/client.ts
+++ b/src/lib/llm/client.ts
@@ -39,6 +39,8 @@ export interface LlmEndpointConfig {
   systemPrompt: string;
   enabled: boolean;
   supportsVoice?: boolean;
+  supportsTts?: boolean;
+  ttsVoice?: string;
   supportsRealtime?: boolean;
   realtimeModel?: string;
   realtimeSystemPrompt?: string;

--- a/src/lib/services/test-connection.ts
+++ b/src/lib/services/test-connection.ts
@@ -34,6 +34,27 @@ async function probeVoiceSupport(url: string, apiKey: string): Promise<boolean> 
   }
 }
 
+async function probeTtsSupport(url: string, apiKey: string): Promise<boolean> {
+  try {
+    const check = validateServiceUrl(url);
+    if (!check.valid) return false;
+    // Reconstruct from parsed URL to prevent SSRF taint propagation
+    const parsed = new URL(url);
+    const base = parsed.origin + parsed.pathname.replace(/\/$/, "");
+    const res = await fetch(`${base}/audio/speech`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      // Empty input triggers a 400 from the endpoint without generating audio
+      body: JSON.stringify({ model: "tts-1", voice: "alloy", input: "" }),
+      signal: AbortSignal.timeout(8000),
+    });
+    // 400 = endpoint exists but rejected empty input; 200 = success; both mean TTS is supported
+    return res.status === 200 || res.status === 400 || res.status === 422;
+  } catch {
+    return false;
+  }
+}
+
 async function probeRealtimeSupport(url: string, apiKey: string): Promise<string | null> {
   // Realtime (WebRTC) is an OpenAI-exclusive API — skip probing for any other provider.
   if (!isOpenAIEndpoint(url)) return null;
@@ -87,15 +108,16 @@ async function testLlm(url: string, apiKey: string, model?: string): Promise<Tes
     }
 
     // Probe capabilities in parallel (best-effort — failures don't affect connection result)
-    const [supportsVoice, realtimeModel] = await Promise.all([
+    const [supportsVoice, supportsTts, realtimeModel] = await Promise.all([
       probeVoiceSupport(url, apiKey),
+      probeTtsSupport(url, apiKey),
       probeRealtimeSupport(url, apiKey),
     ]);
 
     return {
       success: true,
       message: `Connected to ${model}`,
-      capabilities: { supportsVoice, realtimeModel },
+      capabilities: { supportsVoice, supportsTts, realtimeModel },
     };
   } catch (e: unknown) {
     const { APIError } = await import("openai");

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -26,6 +26,7 @@ export interface TestConnectionResponse {
   message: string;
   capabilities?: {
     supportsVoice: boolean;
+    supportsTts: boolean;
     realtimeModel: string | null;
   };
 }


### PR DESCRIPTION
Closes #120

## Summary

- **TTS read-back**: After the LLM finishes streaming, the response is automatically read aloud via OpenAI TTS (`/v1/audio/speech`). Markdown is stripped before synthesis. Replaces the old single-tap `VoiceInput` with a full 4-state conversation loop.
- **Voice conversation loop**: `idle → listening → processing → speaking → idle`. User can tap **Ask again** during playback to skip audio and restart the mic immediately, or **Exit voice** to return to text mode at any point.
- **Silence detection**: Recording stops automatically after 1.5s of sustained silence (after a 500ms minimum window). A 60s hard timeout fires in noisy environments, with a "Sending in Xs…" countdown label in the last 10 seconds.
- **Audio level visualizer**: 7 animated bars driven by a Web Audio `AnalyserNode` during the listening phase — gives clear feedback that the mic is picking up sound.
- **`supportsTts` capability probe**: `POST /audio/speech` with empty input probes the endpoint on Test Connection. Settings shows `✓ TTS` / `✗ No TTS` badge and a voice picker (Alloy/Echo/Fable/Onyx/Nova/Shimmer) per endpoint.
- **Mic stream safety**: `cancelRecording()` stops tracks without transcribing (used by Exit voice while listening). `useVoiceInput` has an unmount cleanup effect. Switching conversation or starting a new chat resets voice mode, unmounting the component and releasing the mic immediately.

## New files

| File | Purpose |
|------|---------|
| `src/app/api/voice/tts/route.ts` | POST endpoint — auth, rate limit, markdown strip, OpenAI TTS, returns `audio/mpeg` |
| `src/hooks/use-tts.ts` | `speakText` / `stop` / `speaking` hook with object URL lifecycle |
| `src/hooks/use-audio-level.ts` | Web Audio `AnalyserNode` → 7 normalised bar heights at ~20fps |
| `src/hooks/use-silence-detection.ts` | VAD: silence threshold + 60s hard timeout + countdown |
| `src/components/chat/voice-conversation.tsx` | 4-state machine component replacing `VoiceInput` in voice mode |
| `src/__tests__/api/voice-tts.test.ts` | 9 unit tests for the TTS route |

## Test plan

- [ ] Run unit tests: `./node_modules/.bin/vitest run`
- [ ] In voice mode: speak a query, confirm it auto-sends after silence, confirm response is read aloud
- [ ] Tap **Ask again** during playback — audio stops, mic opens immediately
- [ ] Tap **Exit voice** while listening — mic indicator clears in browser address bar
- [ ] Switch conversation while in listening phase — mic clears, voice mode exits
- [ ] In a noisy environment (or mute the silence threshold in devtools): confirm "Sending in Xs…" countdown appears and auto-sends at 0
- [ ] Settings → Test Connection on an OpenAI endpoint → confirm `✓ TTS` badge appears and voice picker is shown

https://claude.ai/code/session_01Ubz6tGj37ZxrwDWPwiEycb