### PR TITLE
chore: merge dev → beta (v1.1.4-beta.1)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dev-to-beta.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dev-to-beta.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->
+
+-
+
+## Pre-merge checklist
+
+- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
+- [ ] `npm run security:audit` passes locally (exit 0)
+- [ ] Semgrep SAST passes locally (0 findings)
+- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)
+
+## Test plan
+
+<!-- What should be manually verified on the :beta image? -->
+
+- [ ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,29 @@ Only the human manages the release flow. All version bumps go through PRs — ne
 7. Merge `dev` → `beta` → `main` via PRs
 8. Apply `v1.1.0` tag to `main` → CI publishes `:latest` Docker image
 
+## Rule: version bump on every release PR
+
+**Always check and bump `package.json` before opening a `dev → beta` or `beta → main` PR.**
+
+### Version bump logic
+
+| Situation | Example current | Bump to |
+|-----------|----------------|---------|
+| Starting a new beta cycle | `1.1.3` | `1.1.4-beta.1` |
+| Additional beta iteration | `1.1.4-beta.1` | `1.1.4-beta.2` |
+| Full release (beta → main) | `1.1.4-beta.2` | `1.1.4` |
+
+### Workflow
+
+1. Compare `package.json` on `dev` vs `beta` (or `beta` vs `main` for a full release).
+2. If the versions match, raise a `claude/bump-version-*` PR to `dev` first and wait for it to be merged before opening the release PR.
+3. When raising the `dev → beta` PR, use `?template=dev-to-beta.md` so the checklist pre-fills.
+
+### Rules
+- Never open a `dev → beta` PR if `package.json` on `dev` still matches `beta`.
+- For a full release: strip the `-beta.x` suffix (e.g. `1.1.4-beta.2` → `1.1.4`) — do not just bump the patch number independently.
+- The bump always goes through a PR — never commit directly to `dev`, `beta`, or `main`.
+
 ## Rule: run local security checks before dev → beta
 
 Before opening a `dev → beta` PR, run all three checks locally and confirm they pass. This avoids wasted CI cycles on the beta pipeline.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.3",
+  "version": "1.1.4-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bumps `package.json` to `1.1.4-beta.1`
- Adds `.github/PULL_REQUEST_TEMPLATE/dev-to-beta.md` (version bump checklist for future release PRs)
- Adds version bump rule to `CLAUDE.md`

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

- [ ] Beta image boots and serves requests
- [ ] Voice mode: speak a query → confirm auto-sends after silence → response is read aloud
- [ ] **Ask again** during playback skips audio and reopens mic immediately
- [ ] **Exit voice** while listening clears mic indicator in browser address bar
- [ ] Settings → Test Connection on an OpenAI endpoint → `✓ TTS` badge and voice picker appear
- [ ] Smoke tests pass in CI