### PR TITLE
fix(#119): voice/realtime client logging, SW phantom-GET fix, DB endpoint migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ secrets.txt
 
 # Claude Code local settings (may contain API keys / internal tokens)
 .claude/settings.local.json
+.claude/settings.json
 
 #dev config
 .config/

--- a/PLAN.md
+++ b/PLAN.md
@@ -1689,3 +1689,27 @@ Bumped `package.json` version from `1.1.3-beta.1` to `1.1.3` for stable release.
 | `playwright.docker.config.ts` | Added `title-cards` project (#146) |
 | `tests/e2e/global-setup-docker.ts` | Added `overseerr` to `POST /api/setup` payload; added `API_RATE_LIMIT_MAX=1000` env var to container (#146) |
 | `src/app/chat/page.tsx` | Toolbar left padding conditionally expands to `pl-12` when sidebar is collapsed (#217) |
+
+### Phase N+4 — Voice/Realtime diagnostics & SW phantom-GET fix (#119)
+
+Two connected issues investigated:
+
+- **#119 Realtime 'failed to fetch'**: Server log showed `REALTIME_SESSION_CREATED` but client received "failed to fetch" with no further detail. Root cause unknown without client-side logging. Added phase-tracked `clientLog.error` to `useRealtimeChat.connect()` covering four phases (`session`, `microphone`, `rtc-setup`, `sdp-exchange`). Also added `clientLog.error` for silent tool-call failures. Friendly "Failed to fetch" message handling mirrors `use-chat.ts`.
+
+- **Voice TTS audio not playing (#119)**: POST to `/api/voice/tts` returned 200 with 428 KB `audio/mpeg` but audio did not play; UI returned to idle after ~3 s (exactly the TTS download time). `audio.play()` rejection was silently swallowed — no logging. Most likely cause: browser autoplay policy (`NotAllowedError`) since TTS play is triggered asynchronously after LLM stream completes, not directly from a user gesture. Added `clientLog.error` to `play().catch()`, `audio.onerror`, empty-blob guard, and `!res.ok` path so the next failure will be logged and diagnosable.
+
+- **SW phantom GET → 405**: Browser DevTools showed `anonymous @ sw.js:8` issuing a GET to `/api/voice/tts` ~8 minutes after the TTS POST, returning 405. The service worker (`public/sw.js`) was unconditionally re-issuing every intercepted request via `fetch(event.request)`, including replayed navigations to previously-seen API URLs as GET. Fixed: SW now only intercepts `GET`/`HEAD` non-API requests — the minimum needed for PWA installability.
+
+- **DB data migration for `llm.endpoints`**: `ensureSchemaIntegrity` handles column-level drift but not JSON blob drift inside `app_config`. Endpoints saved before `supportsRealtime`/`supportsVoice`/`realtimeModel` fields were added had those fields missing, causing the realtime UI button to never appear. Added `migrateLlmEndpoints()` that runs at startup after `ensureSchemaIntegrity`, normalises missing fields, and enforces the invariant `supportsRealtime = (realtimeModel !== "")`. 8 unit tests added.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/hooks/use-realtime-chat.ts` | Added `clientLog` with phase tracking for `connect()` failures; added `clientLog.error` in tool-call catch |
+| `src/hooks/use-tts.ts` | Added `clientLog.error` to `play().catch()`, `audio.onerror`, empty-blob guard, and `!res.ok` path |
+| `public/sw.js` | SW now only intercepts `GET`/`HEAD` non-API requests — prevents phantom API replays |
+| `src/lib/db/index.ts` | Added exported `migrateLlmEndpoints()` — startup data migration for `llm.endpoints` JSON blob |
+| `src/__tests__/db/migrate-llm-endpoints.test.ts` | 8 unit tests for `migrateLlmEndpoints` |
+| `.gitignore` | Added `.claude/settings.json` (may contain internal API key) |
+| `package.json` | Version `1.1.4-beta.1` → `1.1.4-beta.2` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.4-beta.1",
+  "version": "1.1.4-beta.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,5 +5,12 @@ self.addEventListener("activate", (event) => {
   event.waitUntil(self.clients.claim());
 });
 self.addEventListener("fetch", (event) => {
+  // Only intercept GET/HEAD navigation requests — let non-GET requests (POST, etc.)
+  // and API calls bypass the SW entirely so the browser handles them natively.
+  // Re-issuing non-GET requests via fetch(event.request) can cause the SW to replay
+  // API calls (e.g. POST /api/voice/tts) as GET on subsequent visits, producing 405s.
+  const { method, url } = event.request;
+  if (method !== "GET" && method !== "HEAD") return;
+  if (url.includes("/api/")) return;
   event.respondWith(fetch(event.request));
 });

--- a/src/__tests__/db/migrate-llm-endpoints.test.ts
+++ b/src/__tests__/db/migrate-llm-endpoints.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { eq } from "drizzle-orm";
+import * as schema from "@/lib/db/schema";
+import { migrateLlmEndpoints } from "@/lib/db";
+import path from "path";
+
+const MIGRATIONS_DIR = path.join(process.cwd(), "drizzle");
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+function setEndpoints(endpoints: object[]): void {
+  db.insert(schema.appConfig)
+    .values({ key: "llm.endpoints", value: JSON.stringify(endpoints), encrypted: false, updatedAt: new Date() })
+    .onConflictDoUpdate({
+      target: schema.appConfig.key,
+      set: { value: JSON.stringify(endpoints), updatedAt: new Date() },
+    })
+    .run();
+}
+
+function getEndpoints(): object[] {
+  const row = db
+    .select({ value: schema.appConfig.value })
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, "llm.endpoints"))
+    .get();
+  return row ? JSON.parse(row.value) : [];
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+describe("migrateLlmEndpoints", () => {
+  it("is a no-op when llm.endpoints does not exist", () => {
+    migrateLlmEndpoints(db);
+    const row = db
+      .select()
+      .from(schema.appConfig)
+      .where(eq(schema.appConfig.key, "llm.endpoints"))
+      .get();
+    expect(row).toBeUndefined();
+  });
+
+  it("is a no-op when all endpoints already have all fields consistent", () => {
+    const endpoints = [
+      {
+        id: "ep1",
+        realtimeModel: "gpt-4o-realtime-preview",
+        realtimeSystemPrompt: "",
+        supportsVoice: true,
+        supportsRealtime: true,
+      },
+    ];
+    setEndpoints(endpoints);
+    migrateLlmEndpoints(db);
+    expect(getEndpoints()).toEqual(endpoints);
+  });
+
+  it("sets supportsRealtime=true when realtimeModel is non-empty but supportsRealtime=false", () => {
+    setEndpoints([
+      {
+        id: "ep1",
+        realtimeModel: "gpt-4o-realtime-preview",
+        realtimeSystemPrompt: "",
+        supportsVoice: false,
+        supportsRealtime: false,
+      },
+    ]);
+    migrateLlmEndpoints(db);
+    const result = getEndpoints() as { supportsRealtime: boolean }[];
+    expect(result[0].supportsRealtime).toBe(true);
+  });
+
+  it("sets supportsRealtime=false when realtimeModel is empty but supportsRealtime=true", () => {
+    setEndpoints([
+      {
+        id: "ep1",
+        realtimeModel: "",
+        realtimeSystemPrompt: "",
+        supportsVoice: false,
+        supportsRealtime: true,
+      },
+    ]);
+    migrateLlmEndpoints(db);
+    const result = getEndpoints() as { supportsRealtime: boolean }[];
+    expect(result[0].supportsRealtime).toBe(false);
+  });
+
+  it("adds missing realtimeModel, realtimeSystemPrompt, supportsVoice, supportsRealtime fields", () => {
+    setEndpoints([{ id: "ep1", name: "Default", baseUrl: "http://api.openai.com", model: "gpt-4.1" }]);
+    migrateLlmEndpoints(db);
+    const result = getEndpoints() as Record<string, unknown>[];
+    expect(result[0]).toMatchObject({
+      realtimeModel: "",
+      realtimeSystemPrompt: "",
+      supportsVoice: false,
+      supportsRealtime: false,
+    });
+  });
+
+  it("normalizes multiple endpoints independently", () => {
+    setEndpoints([
+      { id: "ep1", realtimeModel: "gpt-4o-realtime-preview", supportsRealtime: false },
+      { id: "ep2", realtimeModel: "", supportsRealtime: false },
+    ]);
+    migrateLlmEndpoints(db);
+    const result = getEndpoints() as { id: string; supportsRealtime: boolean }[];
+    expect(result.find((e) => e.id === "ep1")?.supportsRealtime).toBe(true);
+    expect(result.find((e) => e.id === "ep2")?.supportsRealtime).toBe(false);
+  });
+
+  it("does not modify unrelated fields", () => {
+    setEndpoints([
+      {
+        id: "ep1",
+        name: "MyEndpoint",
+        baseUrl: "http://example.com",
+        apiKey: "secret",
+        model: "gpt-4.1",
+        systemPrompt: "custom prompt",
+        enabled: true,
+        isDefault: true,
+        supportsVoice: true,
+        supportsRealtime: true,
+        realtimeModel: "gpt-4o-realtime-preview",
+        realtimeSystemPrompt: "realtime prompt",
+      },
+    ]);
+    migrateLlmEndpoints(db);
+    const result = getEndpoints() as Record<string, unknown>[];
+    expect(result[0]).toMatchObject({
+      name: "MyEndpoint",
+      baseUrl: "http://example.com",
+      apiKey: "secret",
+      model: "gpt-4.1",
+      systemPrompt: "custom prompt",
+      enabled: true,
+      isDefault: true,
+    });
+  });
+
+  it("handles invalid JSON gracefully without throwing", () => {
+    db.insert(schema.appConfig)
+      .values({ key: "llm.endpoints", value: "not-valid-json", encrypted: false, updatedAt: new Date() })
+      .run();
+    expect(() => migrateLlmEndpoints(db)).not.toThrow();
+  });
+});

--- a/src/hooks/use-realtime-chat.ts
+++ b/src/hooks/use-realtime-chat.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
+import { clientLog } from "@/lib/client-logger";
 
 export interface RealtimeTurn {
   role: "user" | "assistant";
@@ -87,7 +88,13 @@ export function useRealtimeChat(modelId: string) {
           });
           // Ask the model to respond
           sendEvent({ type: "response.create" });
-        } catch {
+        } catch (e) {
+          clientLog.error("Realtime tool execution failed", {
+            toolName: name,
+            callId,
+            errorName: e instanceof Error ? e.name : "UnknownError",
+            errorMessage: e instanceof Error ? e.message : "Unknown error",
+          });
           // Send error as tool result
           sendEvent({
             type: "conversation.item.create",
@@ -123,6 +130,7 @@ export function useRealtimeChat(modelId: string) {
       return;
     }
 
+    let phase: "session" | "microphone" | "rtc-setup" | "sdp-exchange" = "session";
     try {
       // 1. Get ephemeral session token from our server
       const sessionRes = await fetch("/api/realtime/session", {
@@ -138,6 +146,7 @@ export function useRealtimeChat(modelId: string) {
       sessionRef.current = session;
 
       // 2. Create RTCPeerConnection
+      phase = "rtc-setup";
       const pc = new RTCPeerConnection();
       pcRef.current = pc;
 
@@ -150,10 +159,12 @@ export function useRealtimeChat(modelId: string) {
       };
 
       // 4. Add local microphone track
+      phase = "microphone";
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       stream.getTracks().forEach((track) => pc.addTrack(track, stream));
 
       // 5. Create data channel for events
+      phase = "rtc-setup";
       const dc = pc.createDataChannel("oai-events");
       dcRef.current = dc;
 
@@ -174,6 +185,7 @@ export function useRealtimeChat(modelId: string) {
       await pc.setLocalDescription(offer);
 
       // 7. Exchange SDP with OpenAI Realtime API
+      phase = "sdp-exchange";
       const sdpRes = await fetch(
         `${session.rtcBaseUrl}/realtime?model=${encodeURIComponent(session.realtimeModel)}`,
         {
@@ -195,6 +207,10 @@ export function useRealtimeChat(modelId: string) {
 
       setConnected(true);
     } catch (e) {
+      const errName = e instanceof Error ? e.name : "UnknownError";
+      const errMsg = e instanceof Error ? e.message : "Unknown error";
+      const online = typeof navigator !== "undefined" ? navigator.onLine : null;
+
       let msg: string;
       if (e instanceof DOMException) {
         if (e.name === "NotAllowedError" || e.name === "PermissionDeniedError") {
@@ -205,9 +221,19 @@ export function useRealtimeChat(modelId: string) {
         } else {
           msg = `Microphone error: ${e.message}`;
         }
+      } else if (errMsg === "Failed to fetch" || errMsg === "NetworkError when attempting to fetch resource.") {
+        msg = online === false ? "Network error: you appear to be offline" : "Network error: could not reach the server";
       } else {
-        msg = e instanceof Error ? e.message : "Connection failed";
+        msg = errMsg;
       }
+
+      clientLog.error("Realtime connect failed", {
+        phase,
+        errorName: errName,
+        errorMessage: errMsg,
+        online,
+        modelId,
+      });
       setError(msg);
       pcRef.current?.close();
       pcRef.current = null;

--- a/src/hooks/use-tts.ts
+++ b/src/hooks/use-tts.ts
@@ -36,11 +36,32 @@ export function useTts(modelId: string) {
         });
 
         if (!res.ok) {
+          const errText = await res.text().catch(() => "(unreadable)");
+          clientLog.error("TTS request failed", {
+            status: res.status,
+            statusText: res.statusText,
+            responseBody: errText.slice(0, 500),
+            modelId,
+            voice,
+          });
           setSpeaking(false);
           return;
         }
 
         const blob = await res.blob();
+        clientLog.info("TTS audio received", {
+          blobSize: blob.size,
+          mimeType: blob.type,
+          modelId,
+          voice,
+        });
+
+        if (blob.size === 0) {
+          clientLog.error("TTS audio blob is empty", { modelId, voice });
+          setSpeaking(false);
+          return;
+        }
+
         const url = URL.createObjectURL(blob);
         objectUrlRef.current = url;
 
@@ -57,7 +78,13 @@ export function useTts(modelId: string) {
             setSpeaking(false);
             resolve();
           };
-          audio.onerror = () => {
+          audio.onerror = (e) => {
+            clientLog.error("TTS audio element error", {
+              errorType: e instanceof ErrorEvent ? e.message : "MediaError",
+              mediaError: audio.error ? { code: audio.error.code, message: audio.error.message } : null,
+              blobSize: blob.size,
+              mimeType: blob.type,
+            });
             if (objectUrlRef.current === url) {
               URL.revokeObjectURL(url);
               objectUrlRef.current = null;
@@ -66,7 +93,15 @@ export function useTts(modelId: string) {
             setSpeaking(false);
             resolve();
           };
-          audio.play().catch(() => {
+          audio.play().catch((e: unknown) => {
+            clientLog.error("TTS audio play() rejected", {
+              errorName: e instanceof Error ? e.name : "UnknownError",
+              errorMessage: e instanceof Error ? e.message : "Unknown error",
+              blobSize: blob.size,
+              mimeType: blob.type,
+              modelId,
+              voice,
+            });
             setSpeaking(false);
             resolve();
           });

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -102,6 +102,79 @@ export function ensureSchemaIntegrity(sqlite: Database.Database): void {
   }
 }
 
+type StoredEndpoint = {
+  id?: string;
+  realtimeModel?: string;
+  realtimeSystemPrompt?: string;
+  supportsVoice?: boolean;
+  supportsRealtime?: boolean;
+  [key: string]: unknown;
+};
+
+/**
+ * Normalizes the `llm.endpoints` JSON blob in app_config to ensure fields
+ * added after initial release (`supportsVoice`, `supportsRealtime`,
+ * `realtimeModel`, `realtimeSystemPrompt`) are present and consistent.
+ *
+ * Key invariant: `supportsRealtime` must equal `realtimeModel !== ""`.
+ * If an endpoint was saved with a realtimeModel but supportsRealtime=false
+ * (or vice-versa), this corrects it on startup without operator intervention.
+ *
+ * Exported for unit testing.
+ */
+export function migrateLlmEndpoints(db: ReturnType<typeof drizzle<typeof schema>>): void {
+  const row = db
+    .select({ value: schema.appConfig.value })
+    .from(schema.appConfig)
+    .where(eq(schema.appConfig.key, "llm.endpoints"))
+    .get();
+
+  if (!row) return;
+
+  let endpoints: StoredEndpoint[];
+  try {
+    endpoints = JSON.parse(row.value) as StoredEndpoint[];
+  } catch {
+    logger.warn("Data migration: llm.endpoints is not valid JSON — skipping normalization");
+    return;
+  }
+
+  if (!Array.isArray(endpoints)) return;
+
+  let dirty = false;
+  const normalized = endpoints.map((ep) => {
+    const result = { ...ep };
+    const realtimeModel = typeof ep.realtimeModel === "string" ? ep.realtimeModel : "";
+    const expectedRealtime = realtimeModel !== "";
+
+    if (ep.realtimeModel === undefined) { result.realtimeModel = ""; dirty = true; }
+    if (ep.realtimeSystemPrompt === undefined) { result.realtimeSystemPrompt = ""; dirty = true; }
+    if (ep.supportsVoice === undefined) { result.supportsVoice = false; dirty = true; }
+    if (ep.supportsRealtime !== expectedRealtime) { result.supportsRealtime = expectedRealtime; dirty = true; }
+
+    return result;
+  });
+
+  if (!dirty) return;
+
+  const changedIds = endpoints
+    .filter((ep, i) => JSON.stringify(ep) !== JSON.stringify(normalized[i]))
+    .map((ep) => ep.id ?? "(unknown)");
+
+  db.insert(schema.appConfig)
+    .values({ key: "llm.endpoints", value: JSON.stringify(normalized), encrypted: false, updatedAt: new Date() })
+    .onConflictDoUpdate({
+      target: schema.appConfig.key,
+      set: { value: JSON.stringify(normalized), updatedAt: new Date() },
+    })
+    .run();
+
+  logger.info("Data migration: normalized llm.endpoints", {
+    endpointCount: normalized.length,
+    correctedEndpoints: changedIds,
+  });
+}
+
 export function getDb() {
   if (!_db) {
     fs.mkdirSync(DB_DIR, { recursive: true });
@@ -178,7 +251,15 @@ export function getDb() {
     ensureSchemaIntegrity(sqlite);
     logger.info("Database ready");
 
-    // ── 5. Auto-generate internal API key ────────────────────────────────────
+    // ── 5. Data migration: normalize llm.endpoints JSON ─────────────────────
+    // Endpoints stored before supportsRealtime/supportsVoice/realtimeModel
+    // fields were introduced may have inconsistent or absent values.
+    // Rule: supportsRealtime = (realtimeModel !== "").
+    // This is a data-level migration — ensureSchemaIntegrity only handles
+    // column-level drift and cannot reach inside JSON config blobs.
+    migrateLlmEndpoints(_db);
+
+    // ── 6. Auto-generate internal API key ────────────────────────────────────
     // Generated once on first boot; the operator copies it from
     // Settings → Logs → Internal API Key and gives it to Claude for
     // the /beta-logs diagnostic command.


### PR DESCRIPTION
## Summary

- **Realtime logging**: `useRealtimeChat.connect()` now logs phase-tracked errors (`session` / `microphone` / `rtc-setup` / `sdp-exchange`) via `clientLog.error` so failures are visible in beta logs. Silent tool-call catch also logged.
- **Voice TTS logging**: `audio.play().catch()` was silently swallowed — the most likely cause of audio not playing (browser autoplay `NotAllowedError`). Added `clientLog.error` to `play().catch()`, `audio.onerror`, empty-blob guard, and `!res.ok` path.
- **SW phantom GET → 405**: `public/sw.js` was unconditionally re-issuing every intercepted request via `fetch(event.request)`, causing phantom GET replays to API endpoints ~8 mins after POST calls. SW now only intercepts `GET`/`HEAD` non-API requests — the minimum needed for PWA installability.
- **DB data migration**: `ensureSchemaIntegrity` handles column drift but not JSON blob drift. Endpoints saved before `supportsRealtime`/`supportsVoice`/`realtimeModel` existed had those fields missing, hiding the realtime UI button. Added `migrateLlmEndpoints()` — runs at startup, normalises missing fields, enforces `supportsRealtime = (realtimeModel !== "")`. 8 unit tests added.
- **Version bump**: `1.1.4-beta.1` → `1.1.4-beta.2`

## Test plan

- [ ] CI unit tests pass (includes 8 new `migrateLlmEndpoints` tests)
- [ ] Deploy beta and reproduce voice TTS — check beta logs for `TTS audio play() rejected` with `errorName` to confirm autoplay policy as root cause
- [ ] Confirm SW phantom GET → 405 no longer appears in DevTools after voice TTS interaction
- [ ] Confirm realtime connect failure logs `Realtime connect failed` with `phase` field in beta logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)