### PR TITLE
fix(#227): move version and base URL to top of issue report header

### DIFF
--- a/src/app/api/report-issue/route.ts
+++ b/src/app/api/report-issue/route.ts
@@ -162,6 +162,8 @@ export async function POST(request: Request) {
 
 **Reported by:** ${session.user.plexUsername}
 **Reported at:** ${reportedAt}
+**Version:** ${version}
+**Base URL:** ${baseUrl}
 **Conversation ID:** \`${conversationId}\`
 
 ---
@@ -179,8 +181,6 @@ ${description.trim()}
 | Title | ${conversation.title ?? "Untitled"} |
 | Created | ${conversation.createdAt instanceof Date ? conversation.createdAt.toISOString() : new Date(conversation.createdAt).toISOString()} |
 | Messages | ${nonSystemMessages.length} |
-| Version | ${version} |
-| Base URL | ${baseUrl} |
 
 ---
 


### PR DESCRIPTION
## Summary

Moves **Version** and **Base URL** from the Conversation Details table to the report header, alongside Reported by / Reported at / Conversation ID. They're deployment-level metadata, not conversation-specific detail, so they belong at the top where they're immediately visible.

Issue reports will now open like:

```
## User-Reported Issue

**Reported by:** chrisrothwell476
**Reported at:** 2026-03-28T...
**Version:** 1.1.4-beta.3
**Base URL:** https://ai-beta.plexorcist.synology.me
**Conversation ID:** `dadf91ee-...`
```

## Test plan

- [ ] CI passes
- [ ] Report an issue — Version and Base URL appear at the top of the GitHub issue body

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)