### PR TITLE
fix(#232): persist realtime turns, fix transcript ordering, disconnect on unmount

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -223,6 +223,18 @@ Build an LLM-powered chat frontend for media management (*arr stack). Users log 
 - [x] **`src/__tests__/lib/services/is-openai-endpoint.test.ts`** — Unit tests for `isOpenAIEndpoint`: true for `api.openai.com`, false for Gemini/Anthropic/localhost/invalid URLs
 - [x] **`src/__tests__/api/realtime-session.test.ts`** — Two new cases: Gemini-compatible endpoint (non-openai.com host) and Anthropic endpoint both return HTTP 400 even when `supportsRealtime: true`
 
+### Phase 21: Realtime Mode Persistence & Cleanup (issue #232)
+
+#### Bug Fixes
+- [x] **Realtime turns not saved to conversation history (#232)** — Realtime mode ran in complete isolation from the main conversation system: turns were displayed in a local transcript div but never written to the DB, so they vanished on reload and were excluded from `report-issue` transcripts. Fixed with a new `POST /api/conversations/[id]/messages` endpoint that accepts `{ role, content }` and writes a message row. `useRealtimeChat` now accepts an `onTurnComplete` callback; it fires for each complete turn using `response.audio_transcript.done` (assistant) and `conversation.item.input_audio_transcription.completed` (user). `RealtimeChat` component passes this to the hook via `onTurn` prop. `chat/page.tsx` provides `handleRealtimeTurn`, which creates a conversation on demand (same pattern as `handleSend`) then POSTs each turn and reloads messages so they appear in `MessageList`. — `src/app/api/conversations/[id]/messages/route.ts` (new), `src/hooks/use-realtime-chat.ts`, `src/components/chat/realtime-chat.tsx`, `src/components/chat/chat-input.tsx`, `src/app/chat/page.tsx`
+
+- [x] **User transcript ordering issue (#232)** — In the OpenAI Realtime flow, `response.audio_transcript.delta` events (assistant response) often arrive before `conversation.item.input_audio_transcription.completed` (user speech-to-text). The old code appended the user turn at the end, so the transcript showed assistant text before the user's question. Fixed: when user transcription arrives and the last transcript entry is an assistant turn, the user entry is inserted before it. — `src/hooks/use-realtime-chat.ts`
+
+- [x] **Session leak on navigation (#232)** — Clicking "New Chat", switching conversations, or changing mode all unmount `RealtimeChat` but previously left the WebRTC peer connection and audio element open (no disconnect called). Fixed with a `useEffect` cleanup in `RealtimeChat` that calls `disconnect()` on unmount, covering all exit paths. — `src/components/chat/realtime-chat.tsx`
+
+#### Tests
+- [x] **`src/__tests__/api/conversation-messages.test.ts`** — New: 9 tests covering 401 (unauth), 400 (invalid role), 400 (missing/blank content), 404 (nonexistent conversation), 404 (other user's conversation), 200 user message saved to DB, 200 assistant message saved to DB, whitespace trimming
+
 ### Phase 14: Coordinated Dependency Upgrades (issue #68)
 
 #### Dependency Upgrades
@@ -292,6 +304,7 @@ src/
 │   │   │   ├── route.ts             # GET list (?all=true for admin) / POST create
 │   │   │   └── [id]/
 │   │   │       ├── route.ts         # GET with messages (admin can view any) / DELETE
+│   │   │       ├── messages/route.ts # POST save realtime turn (user or assistant)
 │   │   │       └── title/route.ts   # PATCH rename
 │   │   ├── mcp/route.ts             # GET list tools / POST execute tool (bearer auth)
 │   │   ├── models/route.ts          # GET available models for current user
@@ -444,6 +457,7 @@ src/
 | GET | /api/conversations/[id] | Get conversation with messages (admin can view any) |
 | DELETE | /api/conversations/[id] | Delete conversation |
 | PATCH | /api/conversations/[id]/title | Rename conversation |
+| POST | /api/conversations/[id]/messages | Save a single realtime turn (user or assistant) to a conversation |
 | GET | /api/mcp | List available MCP tools (bearer auth, permission-filtered) |
 | POST | /api/mcp | Execute tool or list tools (bearer auth, permission-checked) |
 | GET | /api/models | Get available models for current user (respects canChangeModel) |

--- a/src/__tests__/api/conversation-messages.test.ts
+++ b/src/__tests__/api/conversation-messages.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for POST /api/conversations/[id]/messages
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import path from "path";
+import { mockState } from "../helpers/mock-state";
+import { seedUser, seedSession, seedConversation } from "../helpers/db";
+
+// ---------------------------------------------------------------------------
+// DB mock
+// ---------------------------------------------------------------------------
+let sqlite: Database.Database;
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+
+vi.mock("@/lib/db", () => ({ getDb: () => testDb, schema }));
+
+// ---------------------------------------------------------------------------
+// next/headers mock
+// ---------------------------------------------------------------------------
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    get: (name: string) =>
+      name === "thinkarr_session" && mockState.sessionCookie
+        ? { value: mockState.sessionCookie }
+        : undefined,
+    set: vi.fn(),
+    delete: vi.fn(),
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Route handler (imported after mocks)
+// ---------------------------------------------------------------------------
+import { POST } from "@/app/api/conversations/[id]/messages/route";
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+function makeRequest(body: unknown, conversationId: string): Request {
+  return new Request(`http://localhost/api/conversations/${conversationId}/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  sqlite.pragma("foreign_keys = ON");
+  testDb = drizzle(sqlite, { schema });
+  migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
+  mockState.sessionCookie = undefined;
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+describe("POST /api/conversations/[id]/messages — auth", () => {
+  it("returns 401 when not authenticated", async () => {
+    const res = await POST(makeRequest({ role: "user", content: "hi" }, "c1"), makeParams("c1"));
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+describe("POST /api/conversations/[id]/messages — validation", () => {
+  it("returns 400 for invalid role", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid);
+
+    const res = await POST(makeRequest({ role: "system", content: "hi" }, convId), makeParams(convId));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/role/i);
+  });
+
+  it("returns 400 when content is missing", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid);
+
+    const res = await POST(makeRequest({ role: "user" }, convId), makeParams(convId));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when content is blank", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid);
+
+    const res = await POST(makeRequest({ role: "user", content: "   " }, convId), makeParams(convId));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Access control
+// ---------------------------------------------------------------------------
+describe("POST /api/conversations/[id]/messages — access control", () => {
+  it("returns 404 for a non-existent conversation", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+
+    const res = await POST(makeRequest({ role: "user", content: "hi" }, "nonexistent"), makeParams("nonexistent"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when saving to another user's conversation", async () => {
+    const uid1 = seedUser(testDb, { plexId: "u1" });
+    const uid2 = seedUser(testDb, { plexId: "u2" });
+    mockState.sessionCookie = seedSession(testDb, uid1);
+    const convId = seedConversation(testDb, uid2);
+
+    const res = await POST(makeRequest({ role: "user", content: "hi" }, convId), makeParams(convId));
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful saves
+// ---------------------------------------------------------------------------
+describe("POST /api/conversations/[id]/messages — success", () => {
+  it("saves a user message and returns 200 with the message id", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid);
+
+    const res = await POST(makeRequest({ role: "user", content: "Hello from realtime" }, convId), makeParams(convId));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(typeof body.data.id).toBe("string");
+
+    // Verify it's actually in the DB
+    const saved = testDb.select().from(schema.messages).where(eq(schema.messages.id, body.data.id)).get();
+    expect(saved).toBeDefined();
+    expect(saved!.role).toBe("user");
+    expect(saved!.content).toBe("Hello from realtime");
+    expect(saved!.conversationId).toBe(convId);
+  });
+
+  it("saves an assistant message", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid);
+
+    const res = await POST(
+      makeRequest({ role: "assistant", content: "Here are the results..." }, convId),
+      makeParams(convId),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    const saved = testDb.select().from(schema.messages).where(eq(schema.messages.id, body.data.id)).get();
+    expect(saved!.role).toBe("assistant");
+    expect(saved!.content).toBe("Here are the results...");
+  });
+
+  it("trims whitespace from content before saving", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid);
+
+    const res = await POST(
+      makeRequest({ role: "user", content: "  padded content  " }, convId),
+      makeParams(convId),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const saved = testDb.select().from(schema.messages).where(eq(schema.messages.id, body.data.id)).get();
+    expect(saved!.content).toBe("padded content");
+  });
+});

--- a/src/__tests__/api/realtime-session.test.ts
+++ b/src/__tests__/api/realtime-session.test.ts
@@ -136,6 +136,44 @@ describe("POST /api/realtime/session", () => {
     expect(body.data.realtimeModel).toBe("gpt-4o-realtime-preview-2024-12-17");
   });
 
+  it("passes ttsVoice from endpoint config to the realtime session", async () => {
+    mockGetEndpointConfig.mockReturnValue({
+      id: "ep1",
+      name: "OpenAI",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-test",
+      model: "gpt-4.1",
+      systemPrompt: "",
+      enabled: true,
+      supportsVoice: true,
+      supportsRealtime: true,
+      realtimeModel: "gpt-4o-realtime-preview-2024-12-17",
+      realtimeSystemPrompt: "",
+      ttsVoice: "nova",
+    });
+    const req = new Request("http://localhost/api/realtime/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ modelId: "ep1:gpt-4.1" }),
+    });
+    await POST(req);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.voice).toBe("nova");
+  });
+
+  it("falls back to alloy when ttsVoice is not set on the endpoint", async () => {
+    const req = new Request("http://localhost/api/realtime/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ modelId: "ep1:gpt-4.1" }),
+    });
+    await POST(req);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.voice).toBe("alloy");
+  });
+
   it("returns 400 when endpoint is ChatGPT-compatible but not OpenAI (e.g. Gemini)", async () => {
     mockGetEndpointConfig.mockReturnValue({
       id: "ep-gemini",

--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { v4 as uuidv4 } from "uuid";
+import { getSession } from "@/lib/auth/session";
+import { getDb, schema } from "@/lib/db";
+import { eq, and } from "drizzle-orm";
+import { checkUserApiRateLimit } from "@/lib/security/api-rate-limit";
+import { logger } from "@/lib/logger";
+import type { ApiResponse } from "@/types/api";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Not authenticated" },
+      { status: 401 },
+    );
+  }
+
+  if (!checkUserApiRateLimit(session.user.id)) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Too many requests. Please slow down." },
+      { status: 429 },
+    );
+  }
+
+  const { id } = await params;
+
+  let body: { role?: string; content?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const { role, content } = body;
+
+  if (role !== "user" && role !== "assistant") {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "role must be user or assistant" },
+      { status: 400 },
+    );
+  }
+
+  if (!content || typeof content !== "string" || !content.trim()) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "content is required" },
+      { status: 400 },
+    );
+  }
+
+  const db = getDb();
+
+  const conversation = db
+    .select()
+    .from(schema.conversations)
+    .where(and(eq(schema.conversations.id, id), eq(schema.conversations.userId, session.user.id)))
+    .get();
+
+  if (!conversation) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Conversation not found" },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const messageId = uuidv4();
+    db.insert(schema.messages)
+      .values({
+        id: messageId,
+        conversationId: id,
+        role: role as "user" | "assistant",
+        content: content.trim(),
+        createdAt: new Date(),
+      })
+      .run();
+
+    logger.info("Realtime message saved", {
+      conversationId: id,
+      userId: session.user.id,
+      role,
+      messageId,
+    });
+    return NextResponse.json<ApiResponse>({ success: true, data: { id: messageId } });
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e.message : "Database error";
+    logger.error("Failed to save realtime message", { conversationId: id, userId: session.user.id, error });
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Failed to save message" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -79,7 +79,7 @@ export async function POST(request: Request) {
       },
       body: JSON.stringify({
         model: ep.realtimeModel,
-        voice: "alloy",
+        voice: ep.ttsVoice || "alloy",
         instructions,
         tools: realtimeTools,
         tool_choice: "auto",

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -159,6 +159,28 @@ export default function ChatPage() {
     [activeConversationId, createConversation, sendMessage, selectedModel],
   );
 
+  const handleRealtimeTurn = useCallback(
+    async (role: "user" | "assistant", text: string) => {
+      let convId = activeConversationId;
+
+      if (!convId) {
+        const conv = await createConversation();
+        if (!conv) return;
+        convId = conv.id;
+        setActiveConversationId(convId);
+      }
+
+      await fetch(`/api/conversations/${convId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role, content: text }),
+      });
+
+      loadMessages(convId);
+    },
+    [activeConversationId, createConversation, loadMessages],
+  );
+
   if (userLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
@@ -281,6 +303,7 @@ export default function ChatPage() {
           selectedModel={selectedModel}
           ttsVoice={endpointCaps.ttsVoice}
           lastResponse={messages.findLast((m) => m.role === "assistant")?.content ?? ""}
+          onRealtimeTurn={handleRealtimeTurn}
         />
       </main>
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -21,6 +21,8 @@ import {
   Search,
   FileText,
   Download,
+  Play,
+  Square,
 } from "lucide-react";
 import { DEFAULT_SYSTEM_PROMPT, DEFAULT_REALTIME_SYSTEM_PROMPT } from "@/lib/llm/default-prompt";
 import { copyToClipboard } from "@/lib/utils";
@@ -103,6 +105,8 @@ export default function SettingsPage() {
 
   // LLM state (admin only)
   const [endpoints, setEndpoints] = useState<LlmEndpoint[]>([]);
+  const [previewingVoiceEpId, setPreviewingVoiceEpId] = useState<string | null>(null);
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null);
 
   // Plex & Arrs state (admin only)
   const [plexConfig, setPlexConfig] = useState<PlexConfig>({ url: "", token: "" });
@@ -449,6 +453,52 @@ export default function SettingsPage() {
       prev.map((ep) => (ep.id === id ? { ...ep, [field]: value } : ep)),
     );
     setSaved(false);
+  }
+
+  async function previewVoice(ep: LlmEndpoint) {
+    // Stop any in-progress preview
+    if (previewAudioRef.current) {
+      previewAudioRef.current.pause();
+      previewAudioRef.current = null;
+    }
+    if (previewingVoiceEpId === ep.id) {
+      setPreviewingVoiceEpId(null);
+      return;
+    }
+
+    setPreviewingVoiceEpId(ep.id);
+    try {
+      const res = await fetch("/api/voice/tts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: "Hi, I'm Thinkarr, your friendly AI assistant.",
+          modelId: ep.id,
+          voice: ep.ttsVoice || "alloy",
+        }),
+      });
+      if (!res.ok) {
+        setPreviewingVoiceEpId(null);
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      previewAudioRef.current = audio;
+      audio.onended = () => {
+        URL.revokeObjectURL(url);
+        setPreviewingVoiceEpId(null);
+        previewAudioRef.current = null;
+      };
+      audio.onerror = () => {
+        URL.revokeObjectURL(url);
+        setPreviewingVoiceEpId(null);
+        previewAudioRef.current = null;
+      };
+      await audio.play();
+    } catch {
+      setPreviewingVoiceEpId(null);
+    }
   }
 
   function removeEndpoint(id: string) {
@@ -849,15 +899,27 @@ export default function SettingsPage() {
                   {ep.supportsTts && (
                     <div className="space-y-1.5">
                       <Label>TTS Voice</Label>
-                      <select
-                        value={ep.ttsVoice || "alloy"}
-                        onChange={(e) => updateEndpoint(ep.id, "ttsVoice", e.target.value)}
-                        className="rounded border bg-background px-2 py-1.5 text-sm w-full"
-                      >
-                        {["alloy", "echo", "fable", "onyx", "nova", "shimmer"].map((v) => (
-                          <option key={v} value={v}>{v.charAt(0).toUpperCase() + v.slice(1)}</option>
-                        ))}
-                      </select>
+                      <div className="flex gap-2">
+                        <select
+                          value={ep.ttsVoice || "alloy"}
+                          onChange={(e) => updateEndpoint(ep.id, "ttsVoice", e.target.value)}
+                          className="rounded border bg-background px-2 py-1.5 text-sm flex-1"
+                        >
+                          {["alloy", "echo", "fable", "onyx", "nova", "shimmer"].map((v) => (
+                            <option key={v} value={v}>{v.charAt(0).toUpperCase() + v.slice(1)}</option>
+                          ))}
+                        </select>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => previewVoice(ep)}
+                          title="Preview this voice"
+                          className="shrink-0"
+                        >
+                          {previewingVoiceEpId === ep.id ? <Square size={14} /> : <Play size={14} />}
+                        </Button>
+                      </div>
                       <p className="text-xs text-muted-foreground">Voice used when reading responses aloud in voice mode.</p>
                     </div>
                   )}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -19,6 +19,7 @@ interface ChatInputProps {
   selectedModel: string;
   ttsVoice?: string;
   lastResponse?: string;
+  onRealtimeTurn?: (role: "user" | "assistant", text: string) => void;
 }
 
 export function ChatInput({
@@ -33,6 +34,7 @@ export function ChatInput({
   selectedModel,
   ttsVoice = "alloy",
   lastResponse = "",
+  onRealtimeTurn,
 }: ChatInputProps) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -121,7 +123,7 @@ export function ChatInput({
             lastResponse={lastResponse}
           />
         ) : chatMode === "realtime" ? (
-          <RealtimeChat modelId={selectedModel} />
+          <RealtimeChat modelId={selectedModel} onTurn={onRealtimeTurn} />
         ) : (
           <div className="flex items-end gap-2">
             <textarea

--- a/src/components/chat/realtime-chat.tsx
+++ b/src/components/chat/realtime-chat.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { Phone, PhoneOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -7,10 +8,21 @@ import { useRealtimeChat } from "@/hooks/use-realtime-chat";
 
 interface RealtimeChatProps {
   modelId: string;
+  onTurn?: (role: "user" | "assistant", text: string) => void;
 }
 
-export function RealtimeChat({ modelId }: RealtimeChatProps) {
-  const { connected, connecting, transcript, connect, disconnect, error } = useRealtimeChat(modelId);
+export function RealtimeChat({ modelId, onTurn }: RealtimeChatProps) {
+  const { connected, connecting, transcript, connect, disconnect, error } = useRealtimeChat(
+    modelId,
+    { onTurnComplete: onTurn },
+  );
+
+  // Disconnect when the component unmounts (mode change, conversation switch, new chat)
+  useEffect(() => {
+    return () => {
+      disconnect();
+    };
+  }, [disconnect]);
 
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-input bg-card p-4">

--- a/src/hooks/use-realtime-chat.ts
+++ b/src/hooks/use-realtime-chat.ts
@@ -14,7 +14,11 @@ interface SessionData {
   rtcBaseUrl: string;
 }
 
-export function useRealtimeChat(modelId: string) {
+interface UseRealtimeChatOptions {
+  onTurnComplete?: (role: "user" | "assistant", text: string) => void;
+}
+
+export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions = {}) {
   const [connected, setConnected] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [transcript, setTranscript] = useState<RealtimeTurn[]>([]);
@@ -24,6 +28,8 @@ export function useRealtimeChat(modelId: string) {
   const dcRef = useRef<RTCDataChannel | null>(null);
   const audioElRef = useRef<HTMLAudioElement | null>(null);
   const sessionRef = useRef<SessionData | null>(null);
+  const onTurnCompleteRef = useRef(options.onTurnComplete);
+  onTurnCompleteRef.current = options.onTurnComplete;
 
   const sendEvent = useCallback((event: Record<string, unknown>) => {
     if (dcRef.current?.readyState === "open") {
@@ -42,7 +48,7 @@ export function useRealtimeChat(modelId: string) {
 
       const type = event.type as string;
 
-      // Accumulate assistant audio transcript
+      // Accumulate assistant audio transcript (deltas for live display)
       if (type === "response.audio_transcript.delta") {
         const delta = event.delta as string;
         setTranscript((prev) => {
@@ -54,11 +60,28 @@ export function useRealtimeChat(modelId: string) {
         });
       }
 
+      // Assistant turn complete — save to conversation
+      if (type === "response.audio_transcript.done") {
+        const text = (event.transcript as string) ?? "";
+        if (text) {
+          onTurnCompleteRef.current?.("assistant", text);
+        }
+      }
+
       // User transcript (speech-to-text from input audio)
       if (type === "conversation.item.input_audio_transcription.completed") {
         const text = event.transcript as string;
         if (text) {
-          setTranscript((prev) => [...prev, { role: "user", text }]);
+          // Insert user turn before the last assistant entry if transcription
+          // arrived after the assistant started responding (common in realtime flow)
+          setTranscript((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.role === "assistant") {
+              return [...prev.slice(0, -1), { role: "user", text }, last];
+            }
+            return [...prev, { role: "user", text }];
+          });
+          onTurnCompleteRef.current?.("user", text);
         }
       }
 


### PR DESCRIPTION
## Summary

- **Persistence**: Realtime turns were never saved to the DB. New `POST /api/conversations/[id]/messages` endpoint saves individual user/assistant messages. `useRealtimeChat` fires `onTurnComplete` when each turn is complete (`response.audio_transcript.done` for assistant, `conversation.item.input_audio_transcription.completed` for user). `chat/page.tsx` creates the conversation on demand and reloads messages after each turn — turns now appear in `MessageList` and are included in `report-issue` transcripts.
- **Transcript ordering**: User speech-to-text transcription commonly arrives after the assistant's audio transcript deltas have already started. The old code appended the user entry at the end, so it appeared _after_ the assistant's response. Now when user transcription arrives and the last transcript entry is an assistant turn, the user entry is inserted before it.
- **Session leak**: Switching mode, clicking "New Chat", or selecting a different conversation all unmount `RealtimeChat` without disconnecting the WebRTC peer connection. Added `useEffect` cleanup that calls `disconnect()` on unmount, covering all exit paths.

## Test plan

- [ ] Connect in realtime mode and speak — verify user and assistant turns appear in `MessageList` after each exchange
- [ ] Start realtime, speak, then click "New Chat" — confirm no lingering audio/microphone activity
- [ ] Start realtime, speak, then switch to text mode — same as above
- [ ] Switch conversations while connected — verify disconnection and no messages saved to the wrong conversation
- [ ] `npm test` passes (403 tests, 32 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)