### PR TITLE
fix: PWA manifest auth block, SW cross-origin intercept, remove ipify fetch

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -202,6 +202,18 @@ Build an LLM-powered chat frontend for media management (*arr stack). Users log 
 - [x] **`src/__tests__/lib/plex.test.ts`** — Added tests for `searchByTag` with `tagType` (country, director, default genre) and `getTagsForTitle` (full extraction, empty fields)
 - [x] **`src/__tests__/lib/overseerr.test.ts`** — New: `listRequests` title resolution (movie, TV), seasons list, graceful fallback on fetch failure
 
+### Phase 22: PWA Installability Fixes
+
+#### Bug Fixes
+- [x] **Manifest syntax error blocking PWA install** — Chrome's background PWA installability checker fetches `/manifest.json` without session cookies (unauthenticated context). The auth middleware was intercepting it and redirecting to the login page, so Chrome received HTML instead of JSON and reported "Manifest: Line 1, column 1, Syntax error". `beforeinstallprompt` never fired as a result. Fixed: `/manifest.json`, `/sw.js`, and icon files are now allowed through the middleware without a session cookie. — `src/proxy.ts`
+
+- [x] **Service worker intercepting cross-origin requests** — The SW's fetch handler called `event.respondWith(fetch(event.request))` for all GET/HEAD requests, including cross-origin ones (e.g. `https://api.ipify.org`). When the browser's CSP blocked the re-issued fetch, the SW produced an unhandled rejection and a console error. Fixed: same-origin check added — the SW now only intercepts requests whose origin matches its own. — `public/sw.js`
+
+- [x] **Sidebar fetching public IP via `api.ipify.org`** — `sidebar.tsx` fetched the user's public IP on every page load to display in the footer. This hit the cross-origin SW bug above and is a privacy concern (exposing the user's NAT IP in the UI). Removed entirely; unused `useState`/`useEffect` imports cleaned up. — `src/components/chat/sidebar.tsx`
+
+#### Version
+- Bumped to `1.1.4-beta.4`
+
 ### Phase 19: Orphaned Tool Call Repair (issue #151)
 
 #### Bug Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.4-beta.3",
+  "version": "1.1.4-beta.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,12 +5,17 @@ self.addEventListener("activate", (event) => {
   event.waitUntil(self.clients.claim());
 });
 self.addEventListener("fetch", (event) => {
-  // Only intercept GET/HEAD navigation requests — let non-GET requests (POST, etc.)
-  // and API calls bypass the SW entirely so the browser handles them natively.
-  // Re-issuing non-GET requests via fetch(event.request) can cause the SW to replay
-  // API calls (e.g. POST /api/voice/tts) as GET on subsequent visits, producing 405s.
+  // Only intercept same-origin GET/HEAD requests.
+  // Cross-origin requests (e.g. external APIs fetched by the page) must bypass
+  // the SW — intercepting them causes CSP violations and unexpected failures.
+  // Non-GET requests and /api/ calls also bypass so the browser handles them natively.
   const { method, url } = event.request;
   if (method !== "GET" && method !== "HEAD") return;
+  try {
+    if (new URL(url).origin !== self.location.origin) return;
+  } catch {
+    return;
+  }
   if (url.includes("/api/")) return;
   event.respondWith(fetch(event.request));
 });

--- a/src/components/chat/sidebar.tsx
+++ b/src/components/chat/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -34,14 +34,6 @@ export function Sidebar({
   selectedModel,
 }: SidebarProps) {
   const router = useRouter();
-  const [publicIp, setPublicIp] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch("https://api.ipify.org?format=json")
-      .then((r) => r.json())
-      .then((d) => setPublicIp(d.ip))
-      .catch(() => {});
-  }, []);
 
   async function handleLogout() {
     await fetch("/api/auth/session", { method: "DELETE" });
@@ -139,7 +131,6 @@ export function Sidebar({
               BETA
             </Badge>
           )}
-          {publicIp && <span>on {publicIp}</span>}
         </div>
       )}
 

--- a/src/components/chat/sidebar.tsx
+++ b/src/components/chat/sidebar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,6 +24,16 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // PWA assets must be publicly accessible so browsers can validate installability
+  // without a session cookie (Chrome's background PWA checker runs unauthenticated)
+  if (
+    pathname === "/manifest.json" ||
+    pathname === "/sw.js" ||
+    /^\/icon[\w.-]*\.(png|svg)$/.test(pathname)
+  ) {
+    return NextResponse.next();
+  }
+
   // Check for session cookie on protected routes
   const hasSession = request.cookies.has(SESSION_COOKIE);
   if (!hasSession) {


### PR DESCRIPTION
## Summary

Three bugs that collectively prevented PWA installation from ever working:

- **`src/proxy.ts`**: Chrome's background PWA installability checker fetches `/manifest.json`, `/sw.js`, and icon files without session cookies. The auth middleware was intercepting these and redirecting to `/login`, so Chrome received HTML instead of JSON — hence the "Manifest: Line 1, column 1, Syntax error" console error. Because Chrome couldn't validate the manifest, `beforeinstallprompt` never fired. Added an explicit allow for these PWA assets.

- **`public/sw.js`**: The SW's fetch handler passed all GET/HEAD requests through `event.respondWith(fetch(event.request))`, including cross-origin ones. When the page fetched `api.ipify.org`, the SW intercepted it, re-issued the request, and the CSP blocked it — producing the "violates Content Security Policy" errors. Added a same-origin guard so the SW only intercepts requests from its own origin.

- **`src/components/chat/sidebar.tsx`**: The sidebar fetched `https://api.ipify.org` on every load to display the user's public IP in the footer. This was the trigger for the cross-origin SW issue above, and also a privacy concern (exposing internal NAT addressing). Removed entirely.

## Test plan

- [ ] Open Chrome DevTools → Application → Manifest — no syntax errors, installability section shows no issues
- [ ] Application → Service Workers — sw.js shows as "activated and is running"
- [ ] After a page reload, `beforeinstallprompt` fires and the install banner appears (or the Settings → General PWA button becomes active)
- [ ] No `api.ipify.org` errors in console
- [ ] No public IP shown in sidebar footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)