### PR TITLE
Fix premature streaming text + realtime voice overhaul (#239)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1798,3 +1798,22 @@ Two issues reported in beta via the user feedback tool (#239):
 | `src/lib/llm/default-prompt.ts` | New `display_titles` latency guidance: no intermediate rounds, parallel batching for multi-title queries |
 | `src/__tests__/lib/orchestrator.test.ts` | 2 new tests: suppresses text when tool calls present; yields text when no tool calls |
 
+### Phase N+8 — Realtime voice: unify transcript into main chat window (#239 follow-up)
+
+Two further improvements requested following the #239 diagnosis:
+
+1. **Title cards and tool results in the voice chat window**: In realtime/voice mode, `display_titles` was filtered out of the tool list and tool call results were never persisted to the DB, so the main `MessageList` never rendered them. Every tool call and its result is now saved to the conversation DB (assistant row with `toolCalls` JSON + tool row with `toolCallId`). After each tool completes, the hook fires `onMessagesUpdated` so the message list reloads and renders title cards, tool call status widgets, etc. exactly as it does for text chat. Audio remains clean — the realtime system prompt already instructs the model to summarise results in speech without reading raw JSON.
+
+2. **Removed the ephemeral transcript widget**: `RealtimeChat` previously rendered a bounded scroll area with live character-by-character turn text that duplicated the main `MessageList`. This is removed. All interactions (user speech, assistant responses, tool results, title cards) appear exclusively in the main chat window. The `RealtimeChat` component now only renders the connection status and connect/end-call button. `transcript` state was removed from `useRealtimeChat` entirely.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/app/api/realtime/tool/route.ts` | Accept `conversationId` + `callId`; persist assistant tool-call message + tool result to DB when provided |
+| `src/app/api/realtime/session/route.ts` | Remove `display_titles` filter — all tools now available in realtime sessions |
+| `src/hooks/use-realtime-chat.ts` | Add `conversationId` + `onMessagesUpdated` options; pass them to tool route; remove `transcript` state |
+| `src/components/chat/realtime-chat.tsx` | Remove ephemeral transcript widget; accept `conversationId` + `onMessagesUpdated` props |
+| `src/components/chat/chat-input.tsx` | Thread `conversationId` + `onRealtimeMessagesUpdated` down to `RealtimeChat` |
+| `src/app/chat/page.tsx` | Pass `activeConversationId` + `handleRealtimeMessagesUpdated` (calls `loadMessages`) into `ChatInput` |
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1846,3 +1846,20 @@ Two mobile resilience improvements:
 |------|--------|
 | `src/hooks/use-realtime-chat.ts` | Wire `pc.onconnectionstatechange` + `dc.onclose` for unexpected-disconnect detection; add wake lock acquire/release/re-acquire lifecycle |
 
+### Phase N+11 — Realtime: inject conversation history on connect
+
+When switching from text or voice mode into a realtime session mid-conversation, the OpenAI Realtime session previously started with no knowledge of prior turns. Fixed by injecting history in `dc.onopen`:
+
+- Fetches the conversation from `GET /api/conversations/${conversationId}` after the data channel opens
+- Filters to user and assistant messages with non-empty text content (tool messages and pure tool-call assistant entries cannot be represented as Realtime API conversation items)
+- Replays the last 20 turns (≈10 exchanges) as `conversation.item.create` events using the correct content type (`input_text` for user, `text` for assistant)
+- Best-effort: if the fetch fails the session continues without history rather than erroring
+
+History is injected after `session.update` so transcription is enabled before the model sees the prior context.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/hooks/use-realtime-chat.ts` | Inject last 20 text turns as `conversation.item.create` events in `dc.onopen` |
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1817,3 +1817,18 @@ Two further improvements requested following the #239 diagnosis:
 | `src/components/chat/chat-input.tsx` | Thread `conversationId` + `onRealtimeMessagesUpdated` down to `RealtimeChat` |
 | `src/app/chat/page.tsx` | Pass `activeConversationId` + `handleRealtimeMessagesUpdated` (calls `loadMessages`) into `ChatInput` |
 
+### Phase N+9 — Realtime and voice: ensure connections tear down on all navigation paths
+
+Two cleanup gaps identified:
+
+1. **Realtime model change while connected**: switching to another realtime-capable model left the WebRTC session open on the old model (the component stayed mounted and the `modelId` prop changed silently). Fixed in `chat/page.tsx` by always resetting `chatMode` to `"text"` on any model change while in realtime — the session is model-specific and must be re-established fresh.
+
+2. **Voice mode unmount without cleanup**: `VoiceConversation` only stopped the mic and TTS via the "Exit voice" button handler. Navigating away (mode change, conversation switch, new chat) would unmount the component while the mic stream or TTS audio kept running. Fixed by adding a `useEffect` unmount cleanup that calls `cancelRecording()` and `stopTts()`, using stable refs so the cleanup always reads the latest values without needing them as effect dependencies.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/app/chat/page.tsx` | Always reset realtime to text on model change (session is model-specific) |
+| `src/components/chat/voice-conversation.tsx` | Add unmount `useEffect` cleanup for mic + TTS via stable refs |
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1777,3 +1777,24 @@ This lets Claude immediately identify which deployment and version a user report
 |------|--------|
 | `src/app/api/report-issue/route.ts` | Added `version` and `baseUrl` to issue body and both log entries |
 | `src/__tests__/api/report-issue.test.ts` | Extended existing test to assert version/baseUrl present in log metadata and issue body |
+
+### Phase N+7 — Fix premature streaming text and speed up title card display (#239)
+
+Two issues reported in beta via the user feedback tool (#239):
+
+1. **Premature text before tool results**: The orchestrator was yielding `text_delta` events to the client as soon as each streamed chunk arrived. When the LLM emitted text *and* tool calls in the same response (e.g. "I'm not seeing any results…" alongside a `plex_search_library` call), the speculative answer appeared in the chat before the tool ran — then the real answer appeared after. The transcript in #239 shows this clearly for the "When is the next apprentice?" query.
+
+   **Fix**: Text deltas are now buffered during streaming and only yielded to the client *after* the full response is consumed. If tool calls were also present in that response, the buffered text is silently discarded (it was a premature guess). If no tool calls were present, the accumulated text is yielded as a single `text_delta` event before `done`. The text is still saved to the DB and forwarded to the LLM context regardless, so history and the next round behave correctly.
+
+2. **Slow title card display**: Between receiving search results and calling `display_titles`, the LLM sometimes emitted an intermediate conversational message (e.g. "Here are the results!") which added a full LLM round of latency before cards appeared.
+
+   **Fix**: Added explicit instructions to `DEFAULT_SYSTEM_PROMPT` telling the LLM to call `display_titles` immediately in the next response after receiving search results — no intermediate text — and to batch all searches for multiple independent titles in a single round so they execute in parallel.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/llm/orchestrator.ts` | Buffer text deltas; suppress premature text when tool calls are present in the same LLM response |
+| `src/lib/llm/default-prompt.ts` | New `display_titles` latency guidance: no intermediate rounds, parallel batching for multi-title queries |
+| `src/__tests__/lib/orchestrator.test.ts` | 2 new tests: suppresses text when tool calls present; yields text when no tool calls |
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1832,3 +1832,17 @@ Two cleanup gaps identified:
 | `src/app/chat/page.tsx` | Always reset realtime to text on model change (session is model-specific) |
 | `src/components/chat/voice-conversation.tsx` | Add unmount `useEffect` cleanup for mic + TTS via stable refs |
 
+### Phase N+10 — Realtime: detect unexpected disconnects + Screen Wake Lock
+
+Two mobile resilience improvements:
+
+1. **Unexpected disconnect detection**: Previously `connected` state stayed `true` after the underlying WebRTC connection dropped (screen off, app backgrounded, network loss, server timeout). The UI showed the green dot and "Listening" even though `sendEvent` silently no-oped. Fixed by wiring `pc.onconnectionstatechange` (`"failed"` / `"closed"`) and `dc.onclose` in `useRealtimeChat`. Both fire `handleUnexpectedDisconnect` which tears down the connection and surfaces a "Connection lost. Tap Connect to start a new session." message. An `intentionalDisconnectRef` flag prevents showing this error on a user-initiated end-call.
+
+2. **Screen Wake Lock**: The browser Screen Wake Lock API (`navigator.wakeLock.request("screen")`) is called after a successful WebRTC handshake to prevent the device screen from turning off during an active session (supported on Android Chrome and iOS Safari 16.4+). The lock is released on disconnect (user-initiated or unexpected), and re-acquired on `visibilitychange` to `"visible"` if the session is still connected (since the browser auto-releases the lock when the page is hidden). Falls back silently if the API is unavailable.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/hooks/use-realtime-chat.ts` | Wire `pc.onconnectionstatechange` + `dc.onclose` for unexpected-disconnect detection; add wake lock acquire/release/re-acquire lifecycle |
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1846,6 +1846,22 @@ Two mobile resilience improvements:
 |------|--------|
 | `src/hooks/use-realtime-chat.ts` | Wire `pc.onconnectionstatechange` + `dc.onclose` for unexpected-disconnect detection; add wake lock acquire/release/re-acquire lifecycle |
 
+### Phase N+12 — Cap conversation history at 20 messages to limit token growth
+
+Long-running conversations previously grew unboundedly, increasing token usage and latency with every turn. Added a sliding-window cap of 20 individual messages (≈10 exchanges) applied at the end of history loading.
+
+- `MAX_CONVERSATION_TURNS = 20` constant added to `orchestrator.ts`
+- `capConversationHistory(messages, conversationId)` function: walks backwards counting user/assistant turns, finds the cutoff index, slices to the most recent 20, then strips any leading tool messages that would be orphaned
+- Called at the end of `loadHistory()` after `trimToolHistory()`
+- 6 new unit tests covering: unchanged when under limit, unchanged at exact limit, drops oldest when over, keeps most-recent messages, retains tool messages inside the window, drops tool messages outside the window
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/llm/orchestrator.ts` | Add `MAX_CONVERSATION_TURNS`, `capConversationHistory()`, call it in `loadHistory()` |
+| `src/__tests__/lib/orchestrator.test.ts` | Add 6 unit tests for `capConversationHistory` |
+
 ### Phase N+11 — Realtime: inject conversation history on connect
 
 When switching from text or voice mode into a realtime session mid-conversation, the OpenAI Realtime session previously started with no knowledge of prior turns. Fixed by injecting history in `dc.onopen`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.3-beta.1",
+  "version": "1.1.4-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.3-beta.1",
+      "version": "1.1.4-beta.4",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.4-beta.4",
+  "version": "1.1.4-beta.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -411,6 +411,7 @@ import type OpenAI from "openai";
 type AssistantMsg = OpenAI.ChatCompletionAssistantMessageParam;
 type ToolMsg = OpenAI.ChatCompletionToolMessageParam;
 type UserMsg = OpenAI.ChatCompletionUserMessageParam;
+type ChatMessage = OpenAI.ChatCompletionMessageParam;
 
 /** Build a minimal assistant message that has tool_calls. */
 function assistantWithCalls(id: string, toolName: string, content?: string): AssistantMsg {
@@ -539,6 +540,112 @@ describe("trimToolHistory — pure unit", () => {
 
     const toolMsgs = result.filter((m) => m.role === "tool");
     expect(toolMsgs).toHaveLength(MAX_TOOL_ROUNDS_IN_HISTORY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capConversationHistory — pure unit tests
+// ---------------------------------------------------------------------------
+
+// MAX_CONVERSATION_TURNS = 20 individual messages (user or assistant).
+// That is 10 back-and-forth exchanges.
+describe("capConversationHistory — pure unit", () => {
+  let cap: typeof import("@/lib/llm/orchestrator").capConversationHistory;
+  let MAX_TURNS: number;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ capConversationHistory: cap, MAX_CONVERSATION_TURNS: MAX_TURNS } =
+      await import("@/lib/llm/orchestrator"));
+  });
+
+  it("returns messages unchanged when individual message count < MAX_CONVERSATION_TURNS", () => {
+    // 9 exchanges = 18 individual messages < 20
+    const msgs: (UserMsg | AssistantMsg)[] = [];
+    for (let i = 0; i < 9; i++) {
+      msgs.push(userMsg(`q${i}`));
+      msgs.push({ role: "assistant", content: `a${i}` });
+    }
+    expect(cap(msgs, "c")).toHaveLength(18);
+  });
+
+  it("returns messages unchanged when individual message count equals MAX_CONVERSATION_TURNS", () => {
+    // 10 exchanges = 20 individual messages — exactly at the limit, nothing dropped
+    const msgs: (UserMsg | AssistantMsg)[] = [];
+    for (let i = 0; i < 10; i++) {
+      msgs.push(userMsg(`q${i}`));
+      msgs.push({ role: "assistant", content: `a${i}` });
+    }
+    expect(cap(msgs, "c")).toHaveLength(MAX_TURNS);
+  });
+
+  it("drops oldest messages when individual count exceeds MAX_CONVERSATION_TURNS", () => {
+    // 12 exchanges = 24 individual messages > 20
+    const msgs: (UserMsg | AssistantMsg)[] = [];
+    for (let i = 0; i < 12; i++) {
+      msgs.push(userMsg(`q${i}`));
+      msgs.push({ role: "assistant", content: `a${i}` });
+    }
+    const result = cap(msgs, "c");
+    const turns = result.filter((m) => m.role === "user" || m.role === "assistant");
+    expect(turns).toHaveLength(MAX_TURNS); // 20
+  });
+
+  it("keeps the most recent messages, not the oldest", () => {
+    // 12 exchanges = 24 messages. Capping to 20 drops the first 4 (q0, a0, q1, a1).
+    const msgs: (UserMsg | AssistantMsg)[] = [];
+    for (let i = 0; i < 12; i++) {
+      msgs.push(userMsg(`q${i}`));
+      msgs.push({ role: "assistant", content: `a${i}` });
+    }
+    const result = cap(msgs, "c");
+    const userMsgs = result.filter((m) => m.role === "user") as UserMsg[];
+    expect((userMsgs[0].content as string)).toBe("q2"); // q0 and q1 dropped
+  });
+
+  it("retains tool messages whose call_id is referenced in the kept window", () => {
+    // Build 9 plain exchanges (18 messages) then add a tool-call exchange,
+    // giving 21 individual messages — 1 over the limit.
+    // The tool-call exchange is the most recent so it must be kept.
+    const msgs: ChatMessage[] = [];
+    for (let i = 0; i < 9; i++) {
+      msgs.push(userMsg(`q${i}`));
+      msgs.push({ role: "assistant", content: `a${i}` });
+    }
+    const callId = "call_keep_me";
+    msgs.push(userMsg("latest"));
+    msgs.push({
+      role: "assistant",
+      tool_calls: [{ id: callId, type: "function", function: { name: "plex_search_library", arguments: "{}" } }],
+    } as AssistantMsg);
+    msgs.push(toolResult(callId)); // tool messages don't count toward the cap
+
+    const result = cap(msgs, "c");
+    const toolMsgs = result.filter((m) => m.role === "tool");
+    expect(toolMsgs).toHaveLength(1);
+    expect((toolMsgs[0] as ToolMsg).tool_call_id).toBe(callId);
+  });
+
+  it("drops tool messages whose call_id is no longer in the kept window", () => {
+    // Old exchange with tool call (3 messages: user + assistant_with_call + tool_result)
+    // followed by 10 plain exchanges (20 messages) — old exchange is pushed out.
+    const msgs: ChatMessage[] = [];
+    const oldCallId = "call_drop_me";
+    msgs.push(userMsg("old query"));
+    msgs.push({
+      role: "assistant",
+      tool_calls: [{ id: oldCallId, type: "function", function: { name: "plex_search_library", arguments: "{}" } }],
+    } as AssistantMsg);
+    msgs.push(toolResult(oldCallId));
+
+    for (let i = 0; i < 10; i++) {
+      msgs.push(userMsg(`q${i}`));
+      msgs.push({ role: "assistant", content: `a${i}` });
+    }
+    // Total: 2 old user/assistant + 20 new user/assistant = 22 turns — cap drops old 2
+    const result = cap(msgs, "c");
+    const toolMsgs = result.filter((m) => m.role === "tool");
+    expect(toolMsgs).toHaveLength(0);
   });
 });
 

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -542,6 +542,134 @@ describe("trimToolHistory — pure unit", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Text suppression when the LLM emits text alongside tool calls (issue #239)
+// ---------------------------------------------------------------------------
+
+describe("orchestrator — premature text suppression (issue #239)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sqlite = new Database(":memory:");
+    testDb = drizzle(sqlite, { schema });
+    migrate(testDb, { migrationsFolder: path.resolve(process.cwd(), "drizzle") });
+  });
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("suppresses text_delta events when the LLM emits text and tool calls in the same response", async () => {
+    // Simulate an LLM that streams "I'm not sure..." text *and* a tool call
+    // in the same response — the premature text must not reach the client.
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async () => {
+              return (async function* () {
+                // Round 1: text + tool call in the same response
+                yield {
+                  choices: [{
+                    delta: {
+                      content: "I'm not seeing any results right now.",
+                      tool_calls: [{
+                        index: 0,
+                        id: "call_abc123",
+                        function: { name: "plex_search_library", arguments: "" },
+                      }],
+                    },
+                  }],
+                  usage: null,
+                };
+                yield {
+                  choices: [{
+                    delta: {
+                      tool_calls: [{
+                        index: 0,
+                        id: "",
+                        function: { name: "", arguments: '{"query":"apprentice"}' },
+                      }],
+                    },
+                  }],
+                  usage: null,
+                };
+                yield {
+                  choices: [{ delta: {} }],
+                  usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+                };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gpt-4o",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+
+    vi.doMock("@/lib/tools/registry", () => ({
+      hasTools: () => true,
+      getOpenAITools: () => [{ type: "function", function: { name: "plex_search_library", description: "", parameters: {} } }],
+      executeTool: vi.fn().mockResolvedValue(JSON.stringify({ results: [] })),
+      getToolLlmContent: (_name: string, result: string) => result,
+    }));
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+
+    const events: { type: string }[] = [];
+    // Drain only one round (tool_call_start will fire but the test ends after
+    // the MAX_TOOL_ROUNDS error since the mock always returns tool calls)
+    for await (const event of orchestrate({ conversationId, userMessage: "When is the next apprentice?" })) {
+      events.push(event as { type: string });
+      // Stop after the first tool_result so we don't need the mock to produce a final text response
+      if (event.type === "tool_result") break;
+    }
+
+    // The premature text from round 1 must NOT have been yielded
+    const textEvents = events.filter((e) => e.type === "text_delta");
+    expect(textEvents).toHaveLength(0);
+
+    // Tool call events must still be present
+    const toolStartEvents = events.filter((e) => e.type === "tool_call_start");
+    expect(toolStartEvents).toHaveLength(1);
+  });
+
+  it("yields text_delta when the LLM responds with text only (no tool calls)", async () => {
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async () => {
+              return (async function* () {
+                yield { choices: [{ delta: { content: "The Apprentice airs on Thursday." } }], usage: null };
+                yield { choices: [{ delta: {} }], usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gpt-4o",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+
+    const events: { type: string; content?: string }[] = [];
+    for await (const event of orchestrate({ conversationId, userMessage: "When is The Apprentice?" })) {
+      events.push(event as { type: string; content?: string });
+    }
+
+    const textEvents = events.filter((e) => e.type === "text_delta");
+    expect(textEvents).toHaveLength(1);
+    expect(textEvents[0].content).toBe("The Apprentice airs on Thursday.");
+
+    const doneEvent = events.find((e) => e.type === "done");
+    expect(doneEvent).toBeDefined();
+  });
+});
+
 describe("orchestrator — 429 rate-limit retry", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -310,6 +310,7 @@ describe("orchestrator — orphaned tool call repair (issue #151)", () => {
     const { eq } = await import("drizzle-orm");
 
     // First request — triggers the repair and should persist the synthetic result
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for await (const _ of orchestrate({ conversationId, userMessage: "Hello" })) { /* drain */ }
 
     // Exactly one synthetic tool result row should exist in the DB
@@ -325,6 +326,7 @@ describe("orchestrator — orphaned tool call repair (issue #151)", () => {
     expect(content.error).toMatch(/did not complete/);
 
     // Second request — no new synthetic row should be added (repair does not repeat)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for await (const _ of orchestrate({ conversationId, userMessage: "Go on" })) { /* drain */ }
 
     const rowsAfterSecond = testDb

--- a/src/__tests__/lib/token-reduction.test.ts
+++ b/src/__tests__/lib/token-reduction.test.ts
@@ -476,7 +476,6 @@ describe("display_titles tool call arg compression", () => {
             // Strip only decorative fields (summary, cast) — NOT thumbPath.
             // thumbPath is needed so the LLM can reuse the poster URL in
             // follow-up display_titles calls without re-searching.
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             ({ summary: _s, cast: _c, ...rest }) => rest,
           ),
         };

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -52,11 +52,13 @@ export async function POST(request: Request) {
     );
   }
 
-  // Build tools for the realtime session (exclude display_titles — no visual cards in voice mode)
+  // Build tools for the realtime session — all tools including display_titles.
+  // Tool results are persisted to the conversation DB so they appear as title
+  // cards in the main chat window. The audio output stays clean because the
+  // realtime system prompt instructs the model to summarise results in speech.
   initializeTools();
   const allTools = getOpenAITools();
   const realtimeTools = allTools
-    .filter((t) => "function" in t && t.function.name !== "display_titles")
     .map((t) => {
       const fn = (t as { type: "function"; function: { name: string; description?: string; parameters?: unknown } }).function;
       return {

--- a/src/app/api/realtime/tool/route.ts
+++ b/src/app/api/realtime/tool/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from "next/server";
+import { v4 as uuidv4 } from "uuid";
 import { getSession } from "@/lib/auth/session";
+import { getDb, schema } from "@/lib/db";
 import { initializeTools } from "@/lib/tools/init";
 import { executeTool } from "@/lib/tools/registry";
 import { checkUserApiRateLimit } from "@/lib/security/api-rate-limit";
 import { logger } from "@/lib/logger";
+import { eq, and } from "drizzle-orm";
 import type { ApiResponse } from "@/types/api";
 
 export async function POST(request: Request) {
@@ -22,7 +25,12 @@ export async function POST(request: Request) {
     );
   }
 
-  let body: { toolName?: string; toolArgs?: Record<string, unknown> };
+  let body: {
+    toolName?: string;
+    toolArgs?: Record<string, unknown>;
+    conversationId?: string;
+    callId?: string;
+  };
   try {
     body = await request.json();
   } catch {
@@ -32,7 +40,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const { toolName, toolArgs } = body;
+  const { toolName, toolArgs, conversationId, callId } = body;
   if (!toolName) {
     return NextResponse.json<ApiResponse>(
       { success: false, error: "toolName is required" },
@@ -40,11 +48,78 @@ export async function POST(request: Request) {
     );
   }
 
+  // Verify the conversation belongs to this user before writing to it
+  const db = getDb();
+  if (conversationId) {
+    const conversation = db
+      .select()
+      .from(schema.conversations)
+      .where(
+        and(
+          eq(schema.conversations.id, conversationId),
+          eq(schema.conversations.userId, session.user.id),
+        ),
+      )
+      .get();
+
+    if (!conversation) {
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "Conversation not found" },
+        { status: 404 },
+      );
+    }
+  }
+
   initializeTools();
 
+  const startTime = Date.now();
   try {
-    const result = await executeTool(toolName, JSON.stringify(toolArgs ?? {}));
-    logger.info("REALTIME_TOOL_CALL", { userId: session.user.id, toolName });
+    const argsJson = JSON.stringify(toolArgs ?? {});
+    const result = await executeTool(toolName, argsJson);
+    const durationMs = Date.now() - startTime;
+
+    logger.info("REALTIME_TOOL_CALL", { userId: session.user.id, toolName, conversationId });
+
+    // Persist the tool call and its result so they appear in the main chat
+    // window (MessageList reads from DB; display_titles cards render from these rows).
+    if (conversationId && callId) {
+      const assistantMsgId = uuidv4();
+      db.insert(schema.messages)
+        .values({
+          id: assistantMsgId,
+          conversationId,
+          role: "assistant",
+          content: null,
+          toolCalls: JSON.stringify([
+            {
+              id: callId,
+              type: "function",
+              function: { name: toolName, arguments: argsJson },
+            },
+          ]),
+          createdAt: new Date(),
+        })
+        .run();
+
+      db.insert(schema.messages)
+        .values({
+          id: uuidv4(),
+          conversationId,
+          role: "tool",
+          content: result,
+          toolCallId: callId,
+          toolName,
+          durationMs,
+          createdAt: new Date(),
+        })
+        .run();
+
+      db.update(schema.conversations)
+        .set({ updatedAt: new Date() })
+        .where(eq(schema.conversations.id, conversationId))
+        .run();
+    }
+
     return NextResponse.json<ApiResponse>({
       success: true,
       data: { result },

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -181,6 +181,15 @@ export default function ChatPage() {
     [activeConversationId, createConversation, loadMessages],
   );
 
+  // Called by the realtime hook after each tool result is persisted to the DB.
+  // Reloads the message list so title cards and other tool outputs appear
+  // in the main chat window immediately after the tool completes.
+  const handleRealtimeMessagesUpdated = useCallback(() => {
+    if (activeConversationId) {
+      loadMessages(activeConversationId);
+    }
+  }, [activeConversationId, loadMessages]);
+
   if (userLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
@@ -303,7 +312,9 @@ export default function ChatPage() {
           selectedModel={selectedModel}
           ttsVoice={endpointCaps.ttsVoice}
           lastResponse={messages.findLast((m) => m.role === "assistant")?.content ?? ""}
+          conversationId={activeConversationId}
           onRealtimeTurn={handleRealtimeTurn}
+          onRealtimeMessagesUpdated={handleRealtimeMessagesUpdated}
         />
       </main>
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -238,7 +238,10 @@ export default function ChatPage() {
                     setEndpointCaps(caps);
                     setChatMode((prev) => {
                       if (prev === "voice" && !caps.supportsVoice) return "text";
-                      if (prev === "realtime" && !caps.supportsRealtime) return "text";
+                      // Realtime sessions are model-specific (baked into the WebRTC
+                      // handshake). Always drop back to text on model change so the
+                      // old session is torn down and the user reconnects fresh.
+                      if (prev === "realtime") return "text";
                       return prev;
                     });
                   }}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -19,7 +19,9 @@ interface ChatInputProps {
   selectedModel: string;
   ttsVoice?: string;
   lastResponse?: string;
+  conversationId?: string | null;
   onRealtimeTurn?: (role: "user" | "assistant", text: string) => void;
+  onRealtimeMessagesUpdated?: () => void;
 }
 
 export function ChatInput({
@@ -34,7 +36,9 @@ export function ChatInput({
   selectedModel,
   ttsVoice = "alloy",
   lastResponse = "",
+  conversationId,
   onRealtimeTurn,
+  onRealtimeMessagesUpdated,
 }: ChatInputProps) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -123,7 +127,12 @@ export function ChatInput({
             lastResponse={lastResponse}
           />
         ) : chatMode === "realtime" ? (
-          <RealtimeChat modelId={selectedModel} onTurn={onRealtimeTurn} />
+          <RealtimeChat
+            modelId={selectedModel}
+            conversationId={conversationId}
+            onTurn={onRealtimeTurn}
+            onMessagesUpdated={onRealtimeMessagesUpdated}
+          />
         ) : (
           <div className="flex items-end gap-2">
             <textarea

--- a/src/components/chat/realtime-chat.tsx
+++ b/src/components/chat/realtime-chat.tsx
@@ -8,14 +8,22 @@ import { useRealtimeChat } from "@/hooks/use-realtime-chat";
 
 interface RealtimeChatProps {
   modelId: string;
+  conversationId?: string | null;
   onTurn?: (role: "user" | "assistant", text: string) => void;
+  onMessagesUpdated?: () => void;
 }
 
-export function RealtimeChat({ modelId, onTurn }: RealtimeChatProps) {
-  const { connected, connecting, transcript, connect, disconnect, error } = useRealtimeChat(
-    modelId,
-    { onTurnComplete: onTurn },
-  );
+export function RealtimeChat({
+  modelId,
+  conversationId,
+  onTurn,
+  onMessagesUpdated,
+}: RealtimeChatProps) {
+  const { connected, connecting, connect, disconnect, error } = useRealtimeChat(modelId, {
+    onTurnComplete: onTurn,
+    conversationId,
+    onMessagesUpdated,
+  });
 
   // Disconnect when the component unmounts (mode change, conversation switch, new chat)
   useEffect(() => {
@@ -26,7 +34,6 @@ export function RealtimeChat({ modelId, onTurn }: RealtimeChatProps) {
 
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-input bg-card p-4">
-      {/* Status + controls */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 text-sm">
           <span
@@ -35,7 +42,11 @@ export function RealtimeChat({ modelId, onTurn }: RealtimeChatProps) {
             }`}
           />
           <span className="text-muted-foreground">
-            {connected ? "Connected" : connecting ? "Connecting..." : "Disconnected"}
+            {connected
+              ? "Listening — speak now"
+              : connecting
+              ? "Connecting..."
+              : "Disconnected"}
           </span>
         </div>
 
@@ -53,29 +64,6 @@ export function RealtimeChat({ modelId, onTurn }: RealtimeChatProps) {
       </div>
 
       {error && <p className="text-sm text-destructive">{error}</p>}
-
-      {/* Live transcript */}
-      {transcript.length > 0 && (
-        <div className="max-h-48 overflow-y-auto space-y-1.5 text-sm">
-          {transcript.map((turn, i) => (
-            <div key={i} className={`flex gap-2 ${turn.role === "user" ? "justify-end" : "justify-start"}`}>
-              <span
-                className={`rounded-lg px-3 py-1.5 max-w-[80%] ${
-                  turn.role === "user"
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-muted text-foreground"
-                }`}
-              >
-                {turn.text}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {connected && transcript.length === 0 && (
-        <p className="text-xs text-muted-foreground text-center">Speak now — transcript will appear here</p>
-      )}
     </div>
   );
 }

--- a/src/components/chat/voice-conversation.tsx
+++ b/src/components/chat/voice-conversation.tsx
@@ -44,10 +44,13 @@ export function VoiceConversation({
   // Keep stable refs so the unmount cleanup can read the latest values
   // without needing them as effect dependencies.
   const recordingRef = useRef(recording);
+  // eslint-disable-next-line react-hooks/refs
   recordingRef.current = recording;
   const cancelRecordingRef = useRef(cancelRecording);
+  // eslint-disable-next-line react-hooks/refs
   cancelRecordingRef.current = cancelRecording;
   const stopTtsRef = useRef(stopTts);
+  // eslint-disable-next-line react-hooks/refs
   stopTtsRef.current = stopTts;
 
   // Release mic and stop TTS when the component unmounts (mode change,

--- a/src/components/chat/voice-conversation.tsx
+++ b/src/components/chat/voice-conversation.tsx
@@ -41,6 +41,25 @@ export function VoiceConversation({
   const bars = useAudioLevel(recording ? stream : null);
   const { speaking, speakText, stop: stopTts } = useTts(modelId);
 
+  // Keep stable refs so the unmount cleanup can read the latest values
+  // without needing them as effect dependencies.
+  const recordingRef = useRef(recording);
+  recordingRef.current = recording;
+  const cancelRecordingRef = useRef(cancelRecording);
+  cancelRecordingRef.current = cancelRecording;
+  const stopTtsRef = useRef(stopTts);
+  stopTtsRef.current = stopTts;
+
+  // Release mic and stop TTS when the component unmounts (mode change,
+  // conversation switch, new chat, etc.) so resources are not held after
+  // the user navigates away from voice mode.
+  useEffect(() => {
+    return () => {
+      if (recordingRef.current) cancelRecordingRef.current();
+      stopTtsRef.current();
+    };
+  }, []);
+
   // Derive the full 4-value phase for the UI without storing "speaking" in state.
   // This avoids calling setPhase synchronously inside effects (react-hooks/set-state-in-effect).
   const effectivePhase = speaking ? "speaking" : phase;

--- a/src/hooks/use-realtime-chat.ts
+++ b/src/hooks/use-realtime-chat.ts
@@ -255,9 +255,10 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
       dcRef.current = dc;
 
       // How many individual user/assistant messages to inject as history.
-      // 20 ≈ 10 back-and-forth exchanges — enough for continuity without
-      // overwhelming the realtime model's context window.
-      const REALTIME_HISTORY_TURNS = 20;
+      // 10 = 5 back-and-forth exchanges, mirroring MAX_TOOL_ROUNDS_IN_HISTORY
+      // in the text orchestrator — enough for immediate context without
+      // front-loading the realtime session with a large token payload.
+      const REALTIME_HISTORY_TURNS = 10;
 
       dc.onopen = () => {
         // Enable input audio transcription so user speech is surfaced as text

--- a/src/hooks/use-realtime-chat.ts
+++ b/src/hooks/use-realtime-chat.ts
@@ -3,11 +3,6 @@
 import { useState, useRef, useCallback } from "react";
 import { clientLog } from "@/lib/client-logger";
 
-export interface RealtimeTurn {
-  role: "user" | "assistant";
-  text: string;
-}
-
 interface SessionData {
   clientSecret: string;
   realtimeModel: string;
@@ -15,13 +10,23 @@ interface SessionData {
 }
 
 interface UseRealtimeChatOptions {
+  /** Called when a user or assistant turn completes (transcript text). */
   onTurnComplete?: (role: "user" | "assistant", text: string) => void;
+  /**
+   * Active conversation ID. When provided, tool calls and their results are
+   * persisted to the conversation so they appear in the main chat window.
+   */
+  conversationId?: string | null;
+  /**
+   * Called after each tool result is saved to the DB so the caller can
+   * reload the message list and render the updated tool cards.
+   */
+  onMessagesUpdated?: () => void;
 }
 
 export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions = {}) {
   const [connected, setConnected] = useState(false);
   const [connecting, setConnecting] = useState(false);
-  const [transcript, setTranscript] = useState<RealtimeTurn[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   const pcRef = useRef<RTCPeerConnection | null>(null);
@@ -30,6 +35,10 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
   const sessionRef = useRef<SessionData | null>(null);
   const onTurnCompleteRef = useRef(options.onTurnComplete);
   onTurnCompleteRef.current = options.onTurnComplete;
+  const conversationIdRef = useRef(options.conversationId);
+  conversationIdRef.current = options.conversationId;
+  const onMessagesUpdatedRef = useRef(options.onMessagesUpdated);
+  onMessagesUpdatedRef.current = options.onMessagesUpdated;
 
   const sendEvent = useCallback((event: Record<string, unknown>) => {
     if (dcRef.current?.readyState === "open") {
@@ -48,19 +57,7 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
 
       const type = event.type as string;
 
-      // Accumulate assistant audio transcript (deltas for live display)
-      if (type === "response.audio_transcript.delta") {
-        const delta = event.delta as string;
-        setTranscript((prev) => {
-          const last = prev[prev.length - 1];
-          if (last?.role === "assistant") {
-            return [...prev.slice(0, -1), { ...last, text: last.text + delta }];
-          }
-          return [...prev, { role: "assistant", text: delta }];
-        });
-      }
-
-      // Assistant turn complete — save to conversation
+      // Assistant turn complete — save to conversation and refresh message list
       if (type === "response.audio_transcript.done") {
         const text = (event.transcript as string) ?? "";
         if (text) {
@@ -72,15 +69,6 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
       if (type === "conversation.item.input_audio_transcription.completed") {
         const text = event.transcript as string;
         if (text) {
-          // Insert user turn before the last assistant entry if transcription
-          // arrived after the assistant started responding (common in realtime flow)
-          setTranscript((prev) => {
-            const last = prev[prev.length - 1];
-            if (last?.role === "assistant") {
-              return [...prev.slice(0, -1), { role: "user", text }, last];
-            }
-            return [...prev, { role: "user", text }];
-          });
           onTurnCompleteRef.current?.("user", text);
         }
       }
@@ -90,12 +78,20 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
         const callId = event.call_id as string;
         const name = event.name as string;
         const argsStr = event.arguments as string;
+        const conversationId = conversationIdRef.current;
 
         try {
           const res = await fetch("/api/realtime/tool", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ toolName: name, toolArgs: JSON.parse(argsStr || "{}") }),
+            body: JSON.stringify({
+              toolName: name,
+              toolArgs: JSON.parse(argsStr || "{}"),
+              // Pass conversation context so the route can persist the tool
+              // call and result to the DB — makes them visible in the main
+              // chat window (MessageList reads from DB).
+              ...(conversationId ? { conversationId, callId } : {}),
+            }),
           });
           const data = await res.json();
           const output = data.success ? data.data.result : JSON.stringify({ error: data.error });
@@ -111,6 +107,11 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
           });
           // Ask the model to respond
           sendEvent({ type: "response.create" });
+
+          // Notify caller so it can reload the message list and show the new cards
+          if (conversationId) {
+            onMessagesUpdatedRef.current?.();
+          }
         } catch (e) {
           clientLog.error("Realtime tool execution failed", {
             toolName: name,
@@ -138,7 +139,6 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
     if (connected || connecting) return;
     setConnecting(true);
     setError(null);
-    setTranscript([]);
 
     // Microphone access requires a secure context (HTTPS or localhost)
     if (!window.isSecureContext) {
@@ -278,5 +278,5 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
     setConnecting(false);
   }, []);
 
-  return { connected, connecting, transcript, connect, disconnect, error };
+  return { connected, connecting, connect, disconnect, error };
 }

--- a/src/hooks/use-realtime-chat.ts
+++ b/src/hooks/use-realtime-chat.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { clientLog } from "@/lib/client-logger";
 
 interface SessionData {
@@ -33,12 +33,75 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
   const dcRef = useRef<RTCDataChannel | null>(null);
   const audioElRef = useRef<HTMLAudioElement | null>(null);
   const sessionRef = useRef<SessionData | null>(null);
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  // Stable refs so event-handler closures always read the latest values
+  // without needing them as effect / callback dependencies.
+  const connectedRef = useRef(false);
+  connectedRef.current = connected;
   const onTurnCompleteRef = useRef(options.onTurnComplete);
   onTurnCompleteRef.current = options.onTurnComplete;
   const conversationIdRef = useRef(options.conversationId);
   conversationIdRef.current = options.conversationId;
   const onMessagesUpdatedRef = useRef(options.onMessagesUpdated);
   onMessagesUpdatedRef.current = options.onMessagesUpdated;
+
+  // Set when the user explicitly calls disconnect() so that dc.onclose /
+  // pc.onconnectionstatechange know not to show an error message.
+  const intentionalDisconnectRef = useRef(false);
+
+  // ---------------------------------------------------------------------------
+  // Wake Lock helpers
+  // ---------------------------------------------------------------------------
+
+  const acquireWakeLock = useCallback(async () => {
+    if (!("wakeLock" in navigator)) return;
+    try {
+      wakeLockRef.current = await navigator.wakeLock.request("screen");
+    } catch {
+      // Wake lock denied or not available — not critical, session continues
+    }
+  }, []);
+
+  const releaseWakeLock = useCallback(() => {
+    if (wakeLockRef.current) {
+      wakeLockRef.current.release().catch(() => {});
+      wakeLockRef.current = null;
+    }
+  }, []);
+
+  // Re-acquire the wake lock when the page becomes visible again — the browser
+  // auto-releases it when the page is hidden (screen off, app backgrounded).
+  // If the session survived the background period, keep the screen on.
+  useEffect(() => {
+    const handleVisibilityChange = async () => {
+      if (document.visibilityState === "visible" && connectedRef.current) {
+        await acquireWakeLock();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [acquireWakeLock]);
+
+  // ---------------------------------------------------------------------------
+  // Unexpected-disconnect handler (shared between pc and dc events)
+  // ---------------------------------------------------------------------------
+
+  const handleUnexpectedDisconnect = useCallback(() => {
+    if (intentionalDisconnectRef.current) return;
+    releaseWakeLock();
+    pcRef.current?.close();
+    pcRef.current = null;
+    dcRef.current = null;
+    sessionRef.current = null;
+    setConnected(false);
+    setConnecting(false);
+    setError("Connection lost. Tap Connect to start a new session.");
+  }, [releaseWakeLock]);
+
+  // ---------------------------------------------------------------------------
+  // Data channel message handler
+  // ---------------------------------------------------------------------------
 
   const sendEvent = useCallback((event: Record<string, unknown>) => {
     if (dcRef.current?.readyState === "open") {
@@ -87,16 +150,12 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
             body: JSON.stringify({
               toolName: name,
               toolArgs: JSON.parse(argsStr || "{}"),
-              // Pass conversation context so the route can persist the tool
-              // call and result to the DB — makes them visible in the main
-              // chat window (MessageList reads from DB).
               ...(conversationId ? { conversationId, callId } : {}),
             }),
           });
           const data = await res.json();
           const output = data.success ? data.data.result : JSON.stringify({ error: data.error });
 
-          // Send tool result back to the realtime session
           sendEvent({
             type: "conversation.item.create",
             item: {
@@ -105,10 +164,8 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
               output,
             },
           });
-          // Ask the model to respond
           sendEvent({ type: "response.create" });
 
-          // Notify caller so it can reload the message list and show the new cards
           if (conversationId) {
             onMessagesUpdatedRef.current?.();
           }
@@ -119,7 +176,6 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
             errorName: e instanceof Error ? e.name : "UnknownError",
             errorMessage: e instanceof Error ? e.message : "Unknown error",
           });
-          // Send error as tool result
           sendEvent({
             type: "conversation.item.create",
             item: {
@@ -135,12 +191,16 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
     [sendEvent],
   );
 
+  // ---------------------------------------------------------------------------
+  // Connect / disconnect
+  // ---------------------------------------------------------------------------
+
   const connect = useCallback(async () => {
     if (connected || connecting) return;
     setConnecting(true);
     setError(null);
+    intentionalDisconnectRef.current = false;
 
-    // Microphone access requires a secure context (HTTPS or localhost)
     if (!window.isSecureContext) {
       setError("Microphone access requires a secure connection (HTTPS). Please reload over HTTPS.");
       setConnecting(false);
@@ -155,7 +215,6 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
 
     let phase: "session" | "microphone" | "rtc-setup" | "sdp-exchange" = "session";
     try {
-      // 1. Get ephemeral session token from our server
       const sessionRes = await fetch("/api/realtime/session", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -168,12 +227,10 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
       const session = sessionData.data as SessionData;
       sessionRef.current = session;
 
-      // 2. Create RTCPeerConnection
       phase = "rtc-setup";
       const pc = new RTCPeerConnection();
       pcRef.current = pc;
 
-      // 3. Set up remote audio playback
       const audioEl = new Audio();
       audioEl.autoplay = true;
       audioElRef.current = audioEl;
@@ -181,18 +238,23 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
         audioEl.srcObject = e.streams[0];
       };
 
-      // 4. Add local microphone track
+      // Detect unexpected connection drops (screen off, network loss, server timeout).
+      // "disconnected" can self-recover so we only act on definitive states.
+      pc.onconnectionstatechange = () => {
+        if (pc.connectionState === "failed" || pc.connectionState === "closed") {
+          handleUnexpectedDisconnect();
+        }
+      };
+
       phase = "microphone";
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       stream.getTracks().forEach((track) => pc.addTrack(track, stream));
 
-      // 5. Create data channel for events
       phase = "rtc-setup";
       const dc = pc.createDataChannel("oai-events");
       dcRef.current = dc;
 
       dc.onopen = () => {
-        // Enable input audio transcription so user speech is surfaced as text
         sendEvent({
           type: "session.update",
           session: {
@@ -203,11 +265,13 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
 
       dc.onmessage = (e) => handleDataChannelMessage(e.data as string);
 
-      // 6. Create SDP offer
+      // Data channel close is the most reliable signal that the session has ended
+      // (fires on network loss, server timeout, and screen-off on mobile).
+      dc.onclose = () => handleUnexpectedDisconnect();
+
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
 
-      // 7. Exchange SDP with OpenAI Realtime API
       phase = "sdp-exchange";
       const sdpRes = await fetch(
         `${session.rtcBaseUrl}/realtime?model=${encodeURIComponent(session.realtimeModel)}`,
@@ -229,6 +293,8 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
       await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
 
       setConnected(true);
+      // Keep the screen on for the duration of the session
+      await acquireWakeLock();
     } catch (e) {
       const errName = e instanceof Error ? e.name : "UnknownError";
       const errMsg = e instanceof Error ? e.message : "Unknown error";
@@ -263,9 +329,11 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
     } finally {
       setConnecting(false);
     }
-  }, [modelId, connected, connecting, handleDataChannelMessage, sendEvent]);
+  }, [modelId, connected, connecting, handleDataChannelMessage, sendEvent, acquireWakeLock, handleUnexpectedDisconnect]);
 
   const disconnect = useCallback(() => {
+    intentionalDisconnectRef.current = true;
+    releaseWakeLock();
     dcRef.current?.close();
     pcRef.current?.close();
     if (audioElRef.current) {
@@ -276,7 +344,7 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
     sessionRef.current = null;
     setConnected(false);
     setConnecting(false);
-  }, []);
+  }, [releaseWakeLock]);
 
   return { connected, connecting, connect, disconnect, error };
 }

--- a/src/hooks/use-realtime-chat.ts
+++ b/src/hooks/use-realtime-chat.ts
@@ -254,13 +254,68 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
       const dc = pc.createDataChannel("oai-events");
       dcRef.current = dc;
 
+      // How many individual user/assistant messages to inject as history.
+      // 20 ≈ 10 back-and-forth exchanges — enough for continuity without
+      // overwhelming the realtime model's context window.
+      const REALTIME_HISTORY_TURNS = 20;
+
       dc.onopen = () => {
+        // Enable input audio transcription so user speech is surfaced as text
         sendEvent({
           type: "session.update",
           session: {
             input_audio_transcription: { model: "whisper-1" },
           },
         });
+
+        // Inject recent conversation history so the model has context when
+        // switching from text or voice mode into realtime.
+        const convId = conversationIdRef.current;
+        if (convId) {
+          void (async () => {
+            try {
+              const res = await fetch(`/api/conversations/${convId}`);
+              const data = (await res.json()) as {
+                success: boolean;
+                data?: { messages?: { role: string; content: string | null }[] };
+              };
+              if (!data.success) return;
+
+              const allMessages = data.data?.messages ?? [];
+
+              // Keep only user and assistant turns that have text content.
+              // Tool messages and pure tool-call assistant entries (content: null)
+              // are not representable as Realtime API conversation items.
+              const textTurns = allMessages.filter(
+                (m) =>
+                  (m.role === "user" || m.role === "assistant") &&
+                  typeof m.content === "string" &&
+                  m.content.trim() !== "",
+              );
+
+              const recent = textTurns.slice(-REALTIME_HISTORY_TURNS);
+
+              for (const msg of recent) {
+                sendEvent({
+                  type: "conversation.item.create",
+                  item: {
+                    type: "message",
+                    role: msg.role,
+                    content: [
+                      {
+                        // Realtime API uses "input_text" for user turns, "text" for assistant
+                        type: msg.role === "user" ? "input_text" : "text",
+                        text: msg.content,
+                      },
+                    ],
+                  },
+                });
+              }
+            } catch {
+              // History injection is best-effort — session continues without it
+            }
+          })();
+        }
       };
 
       dc.onmessage = (e) => handleDataChannelMessage(e.data as string);

--- a/src/lib/llm/default-prompt.ts
+++ b/src/lib/llm/default-prompt.ts
@@ -31,6 +31,9 @@ Guidelines:
 
 Displaying title cards:
 - After searching Plex or Overseerr (including overseerr_list_requests), ALWAYS call display_titles to show visual cards — even when a title is not in Plex (use Overseerr results alone).
+- When you have search results ready, call display_titles immediately in the next response — do NOT add a conversational message between receiving search results and calling display_titles. Every extra round adds visible delay before the user sees the cards.
+- For movies (not TV shows): after a plex_search_library or plex_check_availability result, call display_titles in the very next response without any intermediate text or tool calls.
+- When a user query involves multiple independent titles (e.g. "do I have X and Y?"), call all relevant search tools in a single response so they run in parallel, then call display_titles once in the following response.
 - Set mediaStatus correctly: "available" if the title is in the Plex library, "partial" if a TV show exists in Plex but not all seasons or is already tracked in Overseerr with new episodes incoming (do NOT show a request button for partial — it is already being managed), "pending" if requested in Overseerr but not yet available, "not_requested" if not in Plex and not in Overseerr.
 - Pass plexKey from the Plex result's "key" field (e.g. "/library/metadata/123") — this is required for the Watch Now button.
 - Thumbnails: for Plex results pass thumbPath from the Plex "thumb" field; for Overseerr results pass thumbPath from the Overseerr result's "thumbPath" field (a full https://image.tmdb.org URL). Never use "posterUrl" — the field is called "thumbPath".

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -376,10 +376,14 @@ export async function* orchestrate(
 
         const delta = choice.delta;
 
-        // Text content
+        // Text content — accumulate but do NOT yield yet.
+        // We defer yielding until after the full stream is consumed so we can
+        // tell whether the LLM also emitted tool calls in this same response.
+        // If it did, the text is a premature / speculative answer produced
+        // before the tools ran and should be suppressed entirely (the next LLM
+        // turn after seeing the tool results will produce the real answer).
         if (delta?.content) {
           fullContent += delta.content;
-          yield { type: "text_delta", content: delta.content };
         }
 
         // Tool call deltas
@@ -418,8 +422,12 @@ export async function* orchestrate(
       return;
     }
 
-    // If no tool calls, save the final assistant message and we're done
+    // If no tool calls, this is the final assistant response — yield the
+    // accumulated text now that we know no tool calls came in this round.
     if (toolCalls.length === 0) {
+      if (fullContent) {
+        yield { type: "text_delta", content: fullContent };
+      }
       const messageId = saveMessage(conversationId, "assistant", fullContent);
       logger.info("LLM response complete", {
         conversationId,

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -123,7 +123,6 @@ function loadHistory(conversationId: string): ChatMessage[] {
                 // watch buttons remain functional.
                 const compacted = {
                   titles: args.titles.map(
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     ({ summary: _s, cast: _c, ...rest }) => rest,
                   ),
                 };

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -199,10 +199,70 @@ function loadHistory(conversationId: string): ChatMessage[] {
     }
   }
 
-  return trimToolHistory(repaired, conversationId);
+  return capConversationHistory(trimToolHistory(repaired, conversationId), conversationId);
 }
 
 export const MAX_TOOL_ROUNDS_IN_HISTORY = 5;
+
+/**
+ * Maximum number of user + assistant turns kept in conversation history.
+ * Older turns are dropped to keep per-request token cost predictable.
+ * Tool messages are kept only if their tool_call_id is still referenced
+ * by a kept assistant message.
+ */
+export const MAX_CONVERSATION_TURNS = 20;
+
+/**
+ * Slide the history window so at most MAX_CONVERSATION_TURNS user/assistant
+ * messages are sent to the LLM per request.
+ */
+export function capConversationHistory(
+  messages: ChatMessage[],
+  conversationId: string,
+): ChatMessage[] {
+  // Count user + assistant messages from the end to find the cutoff index
+  let turnCount = 0;
+  let cutoffIdx = 0;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const role = (messages[i] as { role: string }).role;
+    if (role === "user" || role === "assistant") {
+      turnCount++;
+      if (turnCount === MAX_CONVERSATION_TURNS) {
+        cutoffIdx = i;
+        break;
+      }
+    }
+  }
+
+  if (turnCount < MAX_CONVERSATION_TURNS) return messages;
+
+  logger.info("Capping conversation history", {
+    conversationId,
+    totalTurns: turnCount,
+    keptTurns: MAX_CONVERSATION_TURNS,
+    droppedMessages: cutoffIdx,
+  });
+
+  const kept = messages.slice(cutoffIdx);
+
+  // Collect tool_call IDs referenced by assistant messages in the kept window
+  const keptToolCallIds = new Set<string>();
+  for (const msg of kept) {
+    if (msg.role === "assistant" && "tool_calls" in msg) {
+      const aMsg = msg as OpenAI.ChatCompletionAssistantMessageParam;
+      for (const tc of aMsg.tool_calls ?? []) keptToolCallIds.add(tc.id);
+    }
+  }
+
+  // Drop tool messages whose call is no longer in the kept window
+  return kept.filter((msg) => {
+    if (msg.role !== "tool") return true;
+    return keptToolCallIds.has(
+      (msg as OpenAI.ChatCompletionToolMessageParam).tool_call_id,
+    );
+  });
+}
 
 /**
  * Cap the number of tool-calling rounds kept in conversation history.

--- a/src/lib/tools/radarr-tools.ts
+++ b/src/lib/tools/radarr-tools.ts
@@ -15,7 +15,6 @@ export function registerRadarrTools() {
      *  LLM has already acted on the search. Keep all identity and status fields. */
     llmSummary: (result: unknown) => {
       return (result as RadarrMovie[]).map(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ overview: _ov, ...rest }) => rest,
       );
     },

--- a/src/lib/tools/sonarr-tools.ts
+++ b/src/lib/tools/sonarr-tools.ts
@@ -15,7 +15,6 @@ export function registerSonarrTools() {
      *  LLM has already acted on the search. Keep all identity and status fields. */
     llmSummary: (result: unknown) => {
       return (result as SonarrSeries[]).map(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ overview: _ov, ...rest }) => rest,
       );
     },


### PR DESCRIPTION
## Summary

- **Fix premature LLM text before tool results**: Text deltas are now buffered and only emitted after the full response is consumed — if tool calls were present in the same response, the speculative text is discarded silently.
- **Faster title card display**: System prompt guidance added to call `display_titles` immediately after search results with no intermediate round, and to batch multi-title searches in parallel.
- **Tool results and title cards in realtime voice window**: `display_titles` and all tools now work in realtime sessions. Each tool call + result is persisted to the conversation DB so `MessageList` renders cards exactly as in text mode. Audio stays clean — the realtime system prompt instructs the model to summarise in speech.
- **Removed ephemeral transcript widget**: The bounded scroll area that duplicated the main message list is gone. All interactions (speech, responses, tool results, title cards) appear exclusively in the main chat window.
- **Realtime/voice cleanup on all navigation paths**: Model change while in realtime always resets to text (WebRTC session is model-specific). Voice mode unmount now stops the mic and TTS via a `useEffect` cleanup.
- **Unexpected disconnect detection**: `pc.onconnectionstatechange` (`failed`/`closed`) and `dc.onclose` detect drops from screen off, app backgrounded, network loss, or server timeout. UI shows "Connection lost. Tap Connect to start a new session." instead of a false "Listening" state.
- **Screen Wake Lock**: `navigator.wakeLock.request("screen")` prevents the device screen turning off mid-session (Android Chrome + iOS Safari 16.4+). Released on disconnect; re-acquired on `visibilitychange` if still connected.
- **Conversation history injected on realtime connect**: When switching from text/voice into realtime mid-conversation, the last 10 text turns (user+assistant) are replayed as `conversation.item.create` events so the model has full context. Best-effort — session continues without history if the fetch fails.
- **Conversation history cap (20 messages)**: Long-running text conversations are now capped at the 20 most recent messages (~10 exchanges) to prevent unbounded token growth. Orphaned leading tool messages are stripped automatically.
- **Version bump**: `1.1.4-beta.4` → `1.1.4-beta.5`

## Test plan

- [ ] Text chat: ask about a TV show — confirm no premature "I'm not seeing…" text appears before the search tool completes
- [ ] Text chat: ask about multiple titles — confirm `display_titles` cards appear without an extra conversational round
- [ ] Realtime voice: connect, ask about a show — confirm title cards appear in the main chat window (not a separate widget)
- [ ] Realtime voice: confirm audio speaks a natural summary, not raw JSON
- [ ] Realtime voice: confirm the ephemeral transcript widget is gone; all turns appear in the main message list
- [ ] Realtime voice: switch model while connected — confirm session ends and mode resets to text
- [ ] Realtime voice: turn screen off for 30s, turn back on — confirm UI shows "Connection lost" rather than false "Listening" state
- [ ] Realtime voice: confirm screen does not auto-dim/lock while session is active on Android/iOS
- [ ] Voice mode: switch conversation while listening — confirm mic stops
- [ ] Mode switch mid-conversation: have a text chat, switch to realtime — confirm the model references prior turns
- [ ] Long conversation (>20 messages): confirm oldest messages are dropped and the session continues normally without error

https://claude.ai/code/session_01PMm55ybcwE7ewAXkR9pLjK