### PR TITLE
chore: dev → beta (1.1.4)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1862,6 +1862,16 @@ Long-running conversations previously grew unboundedly, increasing token usage a
 | `src/lib/llm/orchestrator.ts` | Add `MAX_CONVERSATION_TURNS`, `capConversationHistory()`, call it in `loadHistory()` |
 | `src/__tests__/lib/orchestrator.test.ts` | Add 6 unit tests for `capConversationHistory` |
 
+### Phase N+13 — Version bump to 1.1.4 (stable release)
+
+Bumped `package.json` version from `1.1.4-beta.5` to `1.1.4` for stable release.
+
+| File | Change |
+|------|--------|
+| `package.json` | Version `1.1.4-beta.5` → `1.1.4` |
+
+---
+
 ### Phase N+11 — Realtime: inject conversation history on connect
 
 When switching from text or voice mode into a realtime session mid-conversation, the OpenAI Realtime session previously started with no knowledge of prior turns. Fixed by injecting history in `dc.onopen`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.4-beta.5",
+  "version": "1.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- #243 — Bump version `1.1.4-beta.5` → `1.1.4` (strip beta suffix for stable release)

## Pre-merge checklist

- [x] `package.json` version bumped — `1.1.4-beta.5` → `1.1.4`
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

- [ ] `:beta` image boots and serves requests after merge
- [ ] Version string in chat sidebar shows `1.1.4`

https://claude.ai/code/session_01QiC6ZWPpKMMEzSEBiErxEK