### PR TITLE
ci: CodeQL required gate on dev, beta, and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,19 +131,46 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  # CodeQL SAST — runs on all PR targets (dev, beta, main).
+  # GitHub's auto-setup only gates main; this job ensures beta is covered too
+  # since :beta is a deployable Docker image with the same attack surface as :latest.
+  codeql:
+    name: CodeQL Security Scan
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"
+
   # Always runs — this is the single check required by branch protection rulesets.
-  # Passes if test/e2e succeeded or were skipped (docs-only PR).
-  # Fails if test or e2e failed.
+  # Passes if test/e2e/codeql succeeded or were skipped (docs-only PR).
+  # Fails if test, e2e, or codeql failed.
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
-    needs: [changes, test, e2e]
+    needs: [changes, test, e2e, codeql]
     if: always()
 
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" || "${{ needs.e2e.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.result }}" == "failure" || "${{ needs.e2e.result }}" == "failure" || "${{ needs.codeql.result }}" == "failure" ]]; then
             echo "One or more required jobs failed."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,14 @@ jobs:
           retention-days: 7
 
   # CodeQL SAST — runs on all PR targets (dev, beta, main).
-  # GitHub's auto-setup only gates main; this job ensures beta is covered too
+  # GitHub's default setup only gates main; this job ensures beta is covered too
   # since :beta is a deployable Docker image with the same attack surface as :latest.
+  #
+  # upload: false — avoids the "advanced configuration cannot be processed when
+  # default setup is enabled" conflict. The default setup continues to upload to
+  # the Security tab for main. This job acts as a local gate: fail-on: error exits
+  # non-zero if any high/error-level findings are present in the SARIF, blocking
+  # the PR without uploading. The SARIF is saved as a downloadable artifact.
   codeql:
     name: CodeQL Security Scan
     runs-on: ubuntu-latest
@@ -141,7 +147,6 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     permissions:
       contents: read
-      security-events: write
       actions: read
 
     steps:
@@ -157,6 +162,17 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:javascript-typescript"
+          upload: false
+          output: ${{ runner.temp }}/codeql-results
+          fail-on: error
+
+      - name: Upload SARIF as artifact
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: codeql-sarif-pr-${{ github.event.pull_request.number }}
+          path: ${{ runner.temp }}/codeql-results
+          retention-days: 7
 
   # Always runs — this is the single check required by branch protection rulesets.
   # Passes if test/e2e/codeql succeeded or were skipped (docs-only PR).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,13 +124,21 @@ For every PR, update `PLAN.md` to reflect what was built or changed:
 
 Do this as a separate commit on the same branch before pushing, so the PR includes the documentation alongside the code.
 
+## Rule: CodeQL is a required gate on dev, beta, and main
+
+CodeQL runs as the `codeql` job in `.github/workflows/ci.yml` and is included in the `CI Complete` gate. This means CodeQL must pass on every PR to `dev`, `beta`, and `main`.
+
+**Rationale:** `:beta` is a deployable Docker image with the same network attack surface as `:latest`. Security vulnerabilities must be caught before the image ships, not only on the `beta → main` PR.
+
+GitHub's auto-setup continues to run on `main` in parallel — this is intentional and not a conflict. Do not remove the `codeql` job from `ci.yml`.
+
 ## Rule: CodeQL false positives
 
 When GitHub Code Scanning raises a `js/ssrf` (or other) alert that is a confirmed false positive — i.e. the code has explicit URL validation that CodeQL cannot trace through — **dismiss the alert via the GitHub API**. Do not:
 
 - Add `// lgtm[...]` comments — ignored by GitHub Code Scanning (only worked on the legacy lgtm.com product)
 - Create `.github/codeql/codeql-config.yml` alone — GitHub's auto-setup ignores this file unless a custom workflow explicitly references it via `config-file:`
-- Create `.github/workflows/codeql.yml` to replace GitHub's built-in scanning — this repo uses GitHub's auto-setup intentionally
+- Create `.github/workflows/codeql.yml` to replace GitHub's built-in scanning — this repo uses GitHub's auto-setup intentionally; the `codeql` job in `ci.yml` supplements it, it does not replace it
 
 ### How to dismiss via `gh` CLI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ CodeQL runs as the `codeql` job in `.github/workflows/ci.yml` and is included in
 
 **Rationale:** `:beta` is a deployable Docker image with the same network attack surface as `:latest`. Security vulnerabilities must be caught before the image ships, not only on the `beta → main` PR.
 
-GitHub's auto-setup continues to run on `main` in parallel — this is intentional and not a conflict. Do not remove the `codeql` job from `ci.yml`.
+The `codeql` job uses `upload: false` on the `analyze` step to avoid the "advanced configuration cannot be processed when default setup is enabled" conflict. GitHub's default setup continues to upload results to the Security tab for `main`; the `ci.yml` job acts as a local gate on `dev` and `beta` PRs, failing CI on `error`-level findings and saving the SARIF as a downloadable artifact. Do not remove the `codeql` job from `ci.yml` and do not change `upload: false` to `true`.
 
 ## Rule: CodeQL false positives
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1879,6 +1879,23 @@ Two CodeQL alerts were raised on the `beta → main` PR (#245) because these fun
 | `src/app/api/voice/tts/route.ts` | Replace fenced-code-block regex with `split("``\`")` to eliminate ReDoS vector |
 | `src/lib/services/test-connection.ts` | `probeTtsSupport`: use `new URL(path, origin).toString()` as fetch target |
 
+### Phase N+15 — CodeQL required on beta (CI gate parity with main)
+
+`:beta` is a deployable Docker image with the same attack surface as `:latest`. GitHub's auto-setup CodeQL only gates `main`; a security vulnerability could ship to the beta deployment undetected.
+
+Added a `codeql` job to `ci.yml` that runs on PRs to `dev`, `beta`, and `main`. The job is included in `ci-complete`'s required-jobs list, so `CI Complete` (the single check required by branch protection on all three branches) now automatically requires CodeQL to pass.
+
+`upload: false` is set on the `analyze` step to avoid the "advanced configuration cannot be processed when default setup is enabled" conflict. The default setup continues uploading to the Security tab for `main`; this job acts as a local gate on `dev` and `beta`, failing CI on `error`-level findings and saving the SARIF as a downloadable artifact. GitHub's auto-setup continues to run on `main` in parallel — this is intentional.
+
+Updated `CLAUDE.md` to document the new gate, the `upload: false` constraint, and clarify that the `ci.yml` `codeql` job supplements auto-setup rather than replacing it.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yml` | Added `codeql` job (`upload: false`, `fail-on: error`, SARIF artifact); added to `ci-complete` needs |
+| `CLAUDE.md` | New "CodeQL is a required gate on dev, beta, and main" rule; documents `upload: false` constraint |
+
 ---
 
 ### Phase N+13 — Version bump to 1.1.4 (stable release)


### PR DESCRIPTION
## Summary

`:beta` is a deployable Docker image with the same attack surface as `:latest`. GitHub's auto-setup CodeQL only gates `main` — a vulnerability could reach the beta deployment undetected (as happened with the `probeTtsSupport` SSRF and `stripMarkdown` ReDoS alerts that only surfaced on the `beta → main` PR).

- Added `codeql` job to `ci.yml` — runs JavaScript/TypeScript analysis with `security-and-quality` queries on PRs to `dev`, `beta`, and `main`
- Wired into `ci-complete` (the single required branch protection check) so CodeQL is automatically required on all three branches without any branch protection rule changes
- GitHub's auto-setup continues to run on `main` in parallel — this is intentional, not a conflict
- Updated `CLAUDE.md` to document the new gate and update the false-positive dismissal rule

## What this does NOT change

- Branch protection rules — `CI Complete` is already required on `beta`; adding `codeql` to its `needs` list automatically extends the gate
- GitHub's auto-setup CodeQL on `main` — not touched, runs as before

https://claude.ai/code/session_01QiC6ZWPpKMMEzSEBiErxEK