### PR TITLE
chore: bump version to 1.1.4-beta.6 [superseded — not needed]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.4",
+  "version": "1.1.4-beta.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bumps `package.json` from `1.1.4` → `1.1.4-beta.6` to satisfy the version-parity rule before opening the dev → beta PR
- This iteration carries the security/CI fixes from #246 and #247 to beta
- The beta → main PR will strip the suffix back to `1.1.4` as per release rules

https://claude.ai/code/session_01QiC6ZWPpKMMEzSEBiErxEK