### PR TITLE
Fix realtime VAD sensitivity, chat naming, and form accessibility (#242, #252, #236)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1925,3 +1925,53 @@ History is injected after `session.update` so transcription is enabled before th
 |------|--------|
 | `src/hooks/use-realtime-chat.ts` | Inject last 20 text turns as `conversation.item.create` events in `dc.onopen` |
 
+
+
+---
+
+### Phase N+16 — Fix realtime VAD sensitivity, chat naming, and form accessibility (#242, #252, #236)
+
+#### #242 — Realtime VAD too sensitive (coughs / background noise interrupt responses)
+
+The OpenAI Realtime API session was created without a `turn_detection` config, so it used the OpenAI default (threshold 0.5, silence 500 ms). This caused background noise and coughs to trigger VAD and interrupt the assistant's spoken response.
+
+Fixed by passing an explicit `turn_detection` block in the session creation payload:
+
+- `threshold: 0.7` — higher value means louder/clearer speech required to activate VAD
+- `silence_duration_ms: 800` — longer silence (800 ms vs 500 ms default) required before a turn ends, avoiding spurious cut-offs
+
+#### #252 — Realtime conversations never update the chat name
+
+Text-mode chats trigger `generateTitle()` inside `/api/chat/route.ts` after the first user message. Realtime turns bypass that route entirely — messages are saved directly via `POST /api/conversations/[id]/messages`. So the conversation title stayed as "New Chat" forever.
+
+Fixed by:
+
+1. **API route** (`src/app/api/conversations/[id]/messages/route.ts`): after saving a `user` message to a `"New Chat"` conversation, calls `generateTitle(conversationId, content)` and includes the resulting title as `data.newTitle` in the response.
+2. **Client** (`src/app/chat/page.tsx`): `handleRealtimeTurn` now reads `data.newTitle` from the API response and calls `updateConversationTitle` to update the sidebar immediately, matching the behaviour of text-mode chats.
+
+#### #236 — Form fields missing id/name attributes
+
+Many inputs, selects, textareas, and checkboxes across the settings page and chat components were missing `id` and `name` attributes. This breaks accessibility (label `htmlFor` linking), password manager autofill, browser autocomplete, and form submission semantics.
+
+Added `id` and `name` to all interactive fields:
+- LLM endpoint fields (name, enabled, default, baseUrl, apiKey, model, system prompt, TTS voice, realtime model, realtime system prompt) — using `ep-${ep.id}-<field>` IDs
+- Arr service fields (URL, apiKey) — using `arr-${svc.key}-<field>` IDs
+- Plex fields (url, token)
+- User management fields (role, model, canChangeModel, rateLimitMessages, rateLimitPeriod) — using `user-${user.id}-<field>` IDs
+- MCP endpoint and bearer token display inputs
+- GitHub issue reporting fields (already had `id`, added `name`)
+- Chat message textarea (`id="chat-message-input"`, `name="message"`)
+- Report issue textarea (`id="report-issue-description"`, `name="description"`)
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/app/api/realtime/session/route.ts` | Add `turn_detection` with `threshold: 0.7`, `silence_duration_ms: 800` |
+| `src/app/api/conversations/[id]/messages/route.ts` | Import `generateTitle`; call on first user message; return `newTitle` in response |
+| `src/app/chat/page.tsx` | `handleRealtimeTurn`: read `newTitle` from response, call `updateConversationTitle` |
+| `src/app/settings/page.tsx` | Add `id`/`name` to all form fields |
+| `src/components/chat/chat-input.tsx` | Add `id`/`name` to message textarea |
+| `src/components/chat/report-issue-modal.tsx` | Add `id`/`name` to description textarea |
+| `src/__tests__/api/conversation-messages.test.ts` | Add 3 tests for title generation behaviour |
+| `src/__tests__/api/realtime-session.test.ts` | Add 1 test asserting `turn_detection` is sent with raised threshold |

--- a/src/__tests__/api/conversation-messages.test.ts
+++ b/src/__tests__/api/conversation-messages.test.ts
@@ -71,6 +71,7 @@ beforeEach(() => {
   testDb = drizzle(sqlite, { schema });
   migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
   mockState.sessionCookie = undefined;
+  mockGenerateTitle.mockClear();
   mockGenerateTitle.mockResolvedValue(null);
 });
 

--- a/src/__tests__/api/conversation-messages.test.ts
+++ b/src/__tests__/api/conversation-messages.test.ts
@@ -35,6 +35,14 @@ vi.mock("next/headers", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// generateTitle mock
+// ---------------------------------------------------------------------------
+const mockGenerateTitle = vi.fn();
+vi.mock("@/lib/llm/orchestrator", () => ({
+  generateTitle: (...args: unknown[]) => mockGenerateTitle(...args),
+}));
+
+// ---------------------------------------------------------------------------
 // Route handler (imported after mocks)
 // ---------------------------------------------------------------------------
 import { POST } from "@/app/api/conversations/[id]/messages/route";
@@ -63,6 +71,7 @@ beforeEach(() => {
   testDb = drizzle(sqlite, { schema });
   migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
   mockState.sessionCookie = undefined;
+  mockGenerateTitle.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -191,5 +200,58 @@ describe("POST /api/conversations/[id]/messages — success", () => {
     const body = await res.json();
     const saved = testDb.select().from(schema.messages).where(eq(schema.messages.id, body.data.id)).get();
     expect(saved!.content).toBe("padded content");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Title generation (#252)
+// ---------------------------------------------------------------------------
+describe("POST /api/conversations/[id]/messages — title generation", () => {
+  it("calls generateTitle on the first user message and returns newTitle", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid, "New Chat");
+
+    mockGenerateTitle.mockResolvedValue("Ghostbusters (1984)");
+
+    const res = await POST(
+      makeRequest({ role: "user", content: "Is Ghostbusters on Plex?" }, convId),
+      makeParams(convId),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.newTitle).toBe("Ghostbusters (1984)");
+    expect(mockGenerateTitle).toHaveBeenCalledWith(convId, "Is Ghostbusters on Plex?");
+  });
+
+  it("does not call generateTitle for assistant messages", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid, "New Chat");
+
+    const res = await POST(
+      makeRequest({ role: "assistant", content: "Yes, it is available." }, convId),
+      makeParams(convId),
+    );
+    expect(res.status).toBe(200);
+    expect(mockGenerateTitle).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.data.newTitle).toBeNull();
+  });
+
+  it("returns newTitle as null when generateTitle returns null", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid, "New Chat");
+
+    mockGenerateTitle.mockResolvedValue(null);
+
+    const res = await POST(
+      makeRequest({ role: "user", content: "What is on TV tonight?" }, convId),
+      makeParams(convId),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.newTitle).toBeNull();
   });
 });

--- a/src/__tests__/api/realtime-session.test.ts
+++ b/src/__tests__/api/realtime-session.test.ts
@@ -174,6 +174,20 @@ describe("POST /api/realtime/session", () => {
     expect(sentBody.voice).toBe("alloy");
   });
 
+  it("sends turn_detection with raised threshold and silence_duration_ms to reduce VAD sensitivity (#242)", async () => {
+    const req = new Request("http://localhost/api/realtime/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ modelId: "ep1:gpt-4.1" }),
+    });
+    await POST(req);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.turn_detection.type).toBe("server_vad");
+    expect(sentBody.turn_detection.threshold).toBeGreaterThan(0.5);
+    expect(sentBody.turn_detection.silence_duration_ms).toBeGreaterThanOrEqual(800);
+  });
+
   it("returns 400 when endpoint is ChatGPT-compatible but not OpenAI (e.g. Gemini)", async () => {
     mockGetEndpointConfig.mockReturnValue({
       id: "ep-gemini",

--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -4,6 +4,7 @@ import { getSession } from "@/lib/auth/session";
 import { getDb, schema } from "@/lib/db";
 import { eq, and } from "drizzle-orm";
 import { checkUserApiRateLimit } from "@/lib/security/api-rate-limit";
+import { generateTitle } from "@/lib/llm/orchestrator";
 import { logger } from "@/lib/logger";
 import type { ApiResponse } from "@/types/api";
 
@@ -87,7 +88,14 @@ export async function POST(
       role,
       messageId,
     });
-    return NextResponse.json<ApiResponse>({ success: true, data: { id: messageId } });
+
+    // Generate a title on the first user message (conversation still called "New Chat")
+    let newTitle: string | null = null;
+    if (role === "user" && conversation.title === "New Chat") {
+      newTitle = await generateTitle(id, content.trim());
+    }
+
+    return NextResponse.json<ApiResponse>({ success: true, data: { id: messageId, newTitle } });
   } catch (e: unknown) {
     const error = e instanceof Error ? e.message : "Database error";
     logger.error("Failed to save realtime message", { conversationId: id, userId: session.user.id, error });

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -85,6 +85,14 @@ export async function POST(request: Request) {
         instructions,
         tools: realtimeTools,
         tool_choice: "auto",
+        // Raise VAD threshold and extend silence window so coughs / background
+        // noise don't interrupt the assistant's spoken response.
+        turn_detection: {
+          type: "server_vad",
+          threshold: 0.7,          // default 0.5 — higher = harder to trigger
+          prefix_padding_ms: 300,
+          silence_duration_ms: 800, // default 500 — longer pause required to end turn
+        },
       }),
     });
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -170,15 +170,22 @@ export default function ChatPage() {
         setActiveConversationId(convId);
       }
 
-      await fetch(`/api/conversations/${convId}/messages`, {
+      const res = await fetch(`/api/conversations/${convId}/messages`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ role, content: text }),
       });
 
+      if (res.ok) {
+        const json = await res.json();
+        if (json.data?.newTitle) {
+          updateConversationTitle(convId, json.data.newTitle);
+        }
+      }
+
       loadMessages(convId);
     },
-    [activeConversationId, createConversation, loadMessages],
+    [activeConversationId, createConversation, loadMessages, updateConversationTitle],
   );
 
   // Called by the realtime hook after each tool result is persisted to the DB.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -778,23 +778,28 @@ export default function SettingsPage() {
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div className="flex flex-wrap items-center gap-2">
                       <Input
+                        id={`ep-${ep.id}-name`}
+                        name={`ep-${ep.id}-name`}
                         value={ep.name}
                         onChange={(e) => updateEndpoint(ep.id, "name", e.target.value)}
                         className="h-8 w-full text-sm font-semibold sm:w-48"
                       />
                       <div className="flex items-center gap-3">
-                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground" htmlFor={`ep-${ep.id}-enabled`}>
                           <input
                             type="checkbox"
+                            id={`ep-${ep.id}-enabled`}
+                            name={`ep-${ep.id}-enabled`}
                             checked={ep.enabled}
                             onChange={(e) => updateEndpoint(ep.id, "enabled", e.target.checked)}
                             className="rounded"
                           />
                           Enabled
                         </label>
-                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground" htmlFor={`ep-${ep.id}-default`}>
                           <input
                             type="radio"
+                            id={`ep-${ep.id}-default`}
                             name="defaultEndpoint"
                             checked={ep.isDefault}
                             onChange={() => setDefaultEndpoint(ep.id)}
@@ -816,24 +821,30 @@ export default function SettingsPage() {
                 </CardHeader>
                 <CardContent className="space-y-3">
                   <div className="space-y-1.5">
-                    <Label>Base URL</Label>
+                    <Label htmlFor={`ep-${ep.id}-baseUrl`}>Base URL</Label>
                     <Input
+                      id={`ep-${ep.id}-baseUrl`}
+                      name={`ep-${ep.id}-baseUrl`}
                       value={ep.baseUrl}
                       onChange={(e) => updateEndpoint(ep.id, "baseUrl", e.target.value)}
                       placeholder="https://api.openai.com/v1"
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label>API Key</Label>
+                    <Label htmlFor={`ep-${ep.id}-apiKey`}>API Key</Label>
                     <Input
+                      id={`ep-${ep.id}-apiKey`}
+                      name={`ep-${ep.id}-apiKey`}
                       type="password"
                       value={ep.apiKey}
                       onChange={(e) => updateEndpoint(ep.id, "apiKey", e.target.value)}
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label>Model</Label>
+                    <Label htmlFor={`ep-${ep.id}-model`}>Model</Label>
                     <Input
+                      id={`ep-${ep.id}-model`}
+                      name={`ep-${ep.id}-model`}
                       value={ep.model}
                       onChange={(e) => updateEndpoint(ep.id, "model", e.target.value)}
                       placeholder="gpt-4.1"
@@ -843,18 +854,20 @@ export default function SettingsPage() {
                     <Label>System Prompt</Label>
                     {/* Radio: Use Default / Use Custom */}
                     <div className="flex gap-4 text-sm">
-                      <label className="flex items-center gap-1.5 cursor-pointer">
+                      <label className="flex items-center gap-1.5 cursor-pointer" htmlFor={`ep-${ep.id}-promptMode-default`}>
                         <input
                           type="radio"
+                          id={`ep-${ep.id}-promptMode-default`}
                           name={`promptMode-${ep.id}`}
                           checked={(ep.promptMode ?? "default") === "default"}
                           onChange={() => updateEndpoint(ep.id, "promptMode", "default")}
                         />
                         Use Default Prompt
                       </label>
-                      <label className="flex items-center gap-1.5 cursor-pointer">
+                      <label className="flex items-center gap-1.5 cursor-pointer" htmlFor={`ep-${ep.id}-promptMode-custom`}>
                         <input
                           type="radio"
+                          id={`ep-${ep.id}-promptMode-custom`}
                           name={`promptMode-${ep.id}`}
                           checked={ep.promptMode === "custom"}
                           onChange={() => updateEndpoint(ep.id, "promptMode", "custom")}
@@ -863,6 +876,8 @@ export default function SettingsPage() {
                       </label>
                     </div>
                     <Textarea
+                      id={`ep-${ep.id}-systemPrompt`}
+                      name={`ep-${ep.id}-systemPrompt`}
                       value={(ep.promptMode ?? "default") === "default" ? DEFAULT_SYSTEM_PROMPT : ep.systemPrompt}
                       onChange={(e) => {
                         // Auto-switch to custom when the user edits the text
@@ -901,6 +916,8 @@ export default function SettingsPage() {
                       <Label>TTS Voice</Label>
                       <div className="flex gap-2">
                         <select
+                          id={`ep-${ep.id}-ttsVoice`}
+                          name={`ep-${ep.id}-ttsVoice`}
                           value={ep.ttsVoice || "alloy"}
                           onChange={(e) => updateEndpoint(ep.id, "ttsVoice", e.target.value)}
                           className="rounded border bg-background px-2 py-1.5 text-sm flex-1"
@@ -926,8 +943,10 @@ export default function SettingsPage() {
 
                   {/* Realtime model override */}
                   <div className="space-y-1.5">
-                    <Label>Realtime Model <span className="text-muted-foreground font-normal">(optional — leave blank to disable)</span></Label>
+                    <Label htmlFor={`ep-${ep.id}-realtimeModel`}>Realtime Model <span className="text-muted-foreground font-normal">(optional — leave blank to disable)</span></Label>
                     <Input
+                      id={`ep-${ep.id}-realtimeModel`}
+                      name={`ep-${ep.id}-realtimeModel`}
                       value={ep.realtimeModel}
                       onChange={(e) => {
                         const val = e.target.value;
@@ -943,18 +962,20 @@ export default function SettingsPage() {
                     <div className="space-y-1.5">
                       <Label>Realtime System Prompt</Label>
                       <div className="flex gap-4 text-sm">
-                        <label className="flex items-center gap-1.5 cursor-pointer">
+                        <label className="flex items-center gap-1.5 cursor-pointer" htmlFor={`ep-${ep.id}-realtimePromptMode-default`}>
                           <input
                             type="radio"
+                            id={`ep-${ep.id}-realtimePromptMode-default`}
                             name={`realtimePromptMode-${ep.id}`}
                             checked={(ep.realtimePromptMode ?? "default") === "default"}
                             onChange={() => updateEndpoint(ep.id, "realtimePromptMode", "default")}
                           />
                           Use Default Realtime Prompt
                         </label>
-                        <label className="flex items-center gap-1.5 cursor-pointer">
+                        <label className="flex items-center gap-1.5 cursor-pointer" htmlFor={`ep-${ep.id}-realtimePromptMode-custom`}>
                           <input
                             type="radio"
+                            id={`ep-${ep.id}-realtimePromptMode-custom`}
                             name={`realtimePromptMode-${ep.id}`}
                             checked={ep.realtimePromptMode === "custom"}
                             onChange={() => updateEndpoint(ep.id, "realtimePromptMode", "custom")}
@@ -963,6 +984,8 @@ export default function SettingsPage() {
                         </label>
                       </div>
                       <Textarea
+                        id={`ep-${ep.id}-realtimeSystemPrompt`}
+                        name={`ep-${ep.id}-realtimeSystemPrompt`}
                         value={(ep.realtimePromptMode ?? "default") === "default" ? DEFAULT_REALTIME_SYSTEM_PROMPT : ep.realtimeSystemPrompt}
                         onChange={(e) => {
                           if ((ep.realtimePromptMode ?? "default") === "default") {
@@ -1051,8 +1074,10 @@ export default function SettingsPage() {
                 )}
 
                 <div className="space-y-1.5">
-                  <Label>URL</Label>
+                  <Label htmlFor="plex-url">URL</Label>
                   <Input
+                    id="plex-url"
+                    name="plex-url"
                     value={plexConfig.url}
                     onChange={(e) => {
                       setPlexConfig((prev) => ({ ...prev, url: e.target.value }));
@@ -1063,8 +1088,10 @@ export default function SettingsPage() {
                   <p className="text-xs text-muted-foreground">e.g. http://localhost:32400</p>
                 </div>
                 <div className="space-y-1.5">
-                  <Label>Plex Token</Label>
+                  <Label htmlFor="plex-token">Plex Token</Label>
                   <Input
+                    id="plex-token"
+                    name="plex-token"
                     type="password"
                     value={plexConfig.token}
                     onChange={(e) => {
@@ -1101,8 +1128,10 @@ export default function SettingsPage() {
                   </CardHeader>
                   <CardContent className="space-y-3">
                     <div className="space-y-1.5">
-                      <Label>URL</Label>
+                      <Label htmlFor={`arr-${svc.key}-url`}>URL</Label>
                       <Input
+                        id={`arr-${svc.key}-url`}
+                        name={`arr-${svc.key}-url`}
                         value={config.url}
                         onChange={(e) => {
                           setArrConfigs((prev) => ({
@@ -1116,8 +1145,10 @@ export default function SettingsPage() {
                       <p className="text-xs text-muted-foreground">e.g. {svc.hint}</p>
                     </div>
                     <div className="space-y-1.5">
-                      <Label>API Key</Label>
+                      <Label htmlFor={`arr-${svc.key}-apiKey`}>API Key</Label>
                       <Input
+                        id={`arr-${svc.key}-apiKey`}
+                        name={`arr-${svc.key}-apiKey`}
                         type="password"
                         value={config.apiKey}
                         onChange={(e) => {
@@ -1159,9 +1190,10 @@ export default function SettingsPage() {
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-1.5">
-                  <Label>MCP Endpoint</Label>
+                  <Label htmlFor="mcp-endpoint">MCP Endpoint</Label>
                   <div className="flex items-center gap-2">
                     <Input
+                      id="mcp-endpoint"
                       value={typeof window !== "undefined" ? `${window.location.origin}/api/mcp` : "/api/mcp"}
                       readOnly
                       className="font-mono text-sm"
@@ -1177,9 +1209,10 @@ export default function SettingsPage() {
                 </div>
 
                 <div className="space-y-1.5">
-                  <Label>{currentUser?.isAdmin ? "Admin Bearer Token" : "Your Bearer Token"}</Label>
+                  <Label htmlFor="mcp-bearer-token">{currentUser?.isAdmin ? "Admin Bearer Token" : "Your Bearer Token"}</Label>
                   <div className="flex items-center gap-2">
                     <Input
+                      id="mcp-bearer-token"
                       value={mcpToken}
                       readOnly
                       className="font-mono text-sm"
@@ -1297,7 +1330,7 @@ export default function SettingsPage() {
 
                           <div className="mt-2 flex flex-wrap gap-3">
                             {/* Role selector */}
-                            <label className="flex items-center gap-1.5 text-sm">
+                            <label className="flex items-center gap-1.5 text-sm" htmlFor={`user-${user.id}-role`}>
                               <span className="text-muted-foreground">Role:</span>
                               {user.id === masterAdminId ? (
                                 <span className="rounded border bg-background px-2 py-0.5 text-sm text-muted-foreground">
@@ -1305,6 +1338,8 @@ export default function SettingsPage() {
                                 </span>
                               ) : (
                                 <select
+                                  id={`user-${user.id}-role`}
+                                  name={`user-${user.id}-role`}
                                   value={user.isAdmin ? "admin" : "user"}
                                   onChange={(e) =>
                                     updateUser(user.id, {
@@ -1320,9 +1355,11 @@ export default function SettingsPage() {
                             </label>
 
                             {/* Default model */}
-                            <label className="flex items-center gap-1.5 text-sm">
+                            <label className="flex items-center gap-1.5 text-sm" htmlFor={`user-${user.id}-model`}>
                               <span className="text-muted-foreground">Model:</span>
                               <select
+                                id={`user-${user.id}-model`}
+                                name={`user-${user.id}-model`}
                                 value={user.defaultModel || ""}
                                 onChange={(e) =>
                                   updateUser(user.id, {
@@ -1341,9 +1378,11 @@ export default function SettingsPage() {
                             </label>
 
                             {/* Can change model */}
-                            <label className="flex items-center gap-1.5 text-sm">
+                            <label className="flex items-center gap-1.5 text-sm" htmlFor={`user-${user.id}-canChangeModel`}>
                               <input
                                 type="checkbox"
+                                id={`user-${user.id}-canChangeModel`}
+                                name={`user-${user.id}-canChangeModel`}
                                 checked={user.canChangeModel}
                                 onChange={(e) =>
                                   updateUser(user.id, {
@@ -1358,10 +1397,12 @@ export default function SettingsPage() {
                             </label>
 
                             {/* Rate limit */}
-                            <label className="flex items-center gap-1.5 text-sm">
+                            <label className="flex items-center gap-1.5 text-sm" htmlFor={`user-${user.id}-rateLimitMessages`}>
                               <span className="text-muted-foreground">Limit:</span>
                               <input
                                 type="number"
+                                id={`user-${user.id}-rateLimitMessages`}
+                                name={`user-${user.id}-rateLimitMessages`}
                                 min={1}
                                 value={user.rateLimitMessages}
                                 onChange={(e) =>
@@ -1373,6 +1414,8 @@ export default function SettingsPage() {
                               />
                               <span className="text-muted-foreground">messages per</span>
                               <select
+                                id={`user-${user.id}-rateLimitPeriod`}
+                                name={`user-${user.id}-rateLimitPeriod`}
                                 value={user.rateLimitPeriod}
                                 onChange={(e) =>
                                   updateUser(user.id, {
@@ -1458,6 +1501,7 @@ export default function SettingsPage() {
               <CardContent>
                 <div className="flex items-center gap-2">
                   <Input
+                    id="internal-api-key"
                     value={internalApiKey}
                     readOnly
                     className="font-mono text-sm"
@@ -1501,6 +1545,7 @@ export default function SettingsPage() {
                   <Label htmlFor="github-token">Personal Access Token</Label>
                   <Input
                     id="github-token"
+                    name="github-token"
                     type="password"
                     placeholder="ghp_••••••••"
                     value={githubConfig.token}
@@ -1516,6 +1561,7 @@ export default function SettingsPage() {
                     <Label htmlFor="github-owner">Repository Owner</Label>
                     <Input
                       id="github-owner"
+                      name="github-owner"
                       placeholder="chrisrothwell"
                       value={githubConfig.owner}
                       onChange={(e) => setGithubConfig((prev) => ({ ...prev, owner: e.target.value }))}
@@ -1525,6 +1571,7 @@ export default function SettingsPage() {
                     <Label htmlFor="github-repo">Repository Name</Label>
                     <Input
                       id="github-repo"
+                      name="github-repo"
                       placeholder="thinkarr"
                       value={githubConfig.repo}
                       onChange={(e) => setGithubConfig((prev) => ({ ...prev, repo: e.target.value }))}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -137,6 +137,8 @@ export function ChatInput({
           <div className="flex items-end gap-2">
             <textarea
               ref={textareaRef}
+              id="chat-message-input"
+              name="message"
               className="flex-1 resize-none rounded-xl border border-input bg-card px-4 py-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
               placeholder="Type a message..."
               rows={1}

--- a/src/components/chat/report-issue-modal.tsx
+++ b/src/components/chat/report-issue-modal.tsx
@@ -118,6 +118,8 @@ export function ReportIssueModal({ conversationId, onClose }: ReportIssueModalPr
 
               <textarea
                 ref={textareaRef}
+                id="report-issue-description"
+                name="description"
                 className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2.5 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
                 placeholder="Describe the issue you observed..."
                 rows={5}


### PR DESCRIPTION
## Summary

- **#242** — Realtime mode was too sensitive to background noise (coughs, ambient sound interrupting responses). Fixed by passing `turn_detection` with `threshold: 0.7` and `silence_duration_ms: 800` to the OpenAI session creation request, up from the API defaults of 0.5 and 500 ms.
- **#252** — Conversations started via realtime never got their chat name updated (stayed as "New Chat"). Fixed by calling `generateTitle()` in the messages save endpoint on the first user turn, returning the title in the response, and updating the sidebar in `handleRealtimeTurn` — matching the auto-naming behaviour of text chats.
- **#236** — Many form fields across the settings page and chat components were missing `id` and `name` attributes. Added them to all inputs, selects, textareas, and checkboxes using stable, descriptive IDs (e.g. `ep-${ep.id}-baseUrl`, `arr-${svc.key}-url`, `user-${user.id}-role`). Fixes accessibility (label `htmlFor`), password manager autofill, and browser autocomplete.

## Test plan

- [ ] Realtime session fetch body includes `turn_detection.threshold = 0.7` and `silence_duration_ms = 800` (new unit test)
- [ ] Posting the first user message to a "New Chat" conversation via `/api/conversations/[id]/messages` calls `generateTitle` and returns `newTitle` (3 new unit tests)
- [ ] All existing `conversation-messages` and `realtime-session` unit tests still pass
- [ ] Settings page: verify inputs have correct IDs and labels are linked (browser devtools / accessibility audit)
- [ ] Chat input and report-issue textarea have `id` and `name` set

https://claude.ai/code/session_01PFpjQXHBtNVe3CJNT5NGHF