### PR TITLE
feat: auto-enrich search results with cast/imdbId/poster (#253)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1975,3 +1975,47 @@ Added `id` and `name` to all interactive fields:
 | `src/components/chat/report-issue-modal.tsx` | Add `id`/`name` to description textarea |
 | `src/__tests__/api/conversation-messages.test.ts` | Add 3 tests for title generation behaviour |
 | `src/__tests__/api/realtime-session.test.ts` | Add 1 test asserting `turn_detection` is sent with raised threshold |
+
+---
+
+### Phase N+17 — Tool enrichment: auto-populate cast/imdbId/poster for search results (#253)
+
+Previously, `overseerr_search` and `overseerr_discover` returned only shallow search data; the LLM had to call `overseerr_get_details` separately for cast, imdbId, and accurate season data before calling `display_titles`. `sonarr_search_series` and `radarr_search_movie` returned raw Sonarr/Radarr data with no poster, cast, or Overseerr linkage at all.
+
+Fixed by adding automatic enrichment inside each tool handler so `display_titles` receives complete data without any extra LLM tool calls.
+
+#### overseerr_search / overseerr_discover
+
+Both handlers now call `overseerr.getDetails()` for every result in parallel (via `Promise.all`). The detail fields are merged into each result: `cast`, `imdbId`, updated `thumbPath` (if not already set), and for TV: `seasonCount` and per-season `seasons` array. Individual failures are non-fatal — if `getDetails` throws for a result, the base search result is returned unchanged.
+
+The `overseerr_get_details` tool description was updated to clarify that search now returns full details; `get_details` is only needed for fields not included in search results (genres, runtime, full request history).
+
+#### sonarr_search_series
+
+Added `enrichSonarrSeries(s)` helper in `sonarr-tools.ts`:
+1. **Plex first**: `plex.searchLibrary(title)` → find a `mediaType==="tv"` match by title+year → return with `thumbPath` (via `buildThumbUrl`), `plexKey`, and `cast`. Short-circuits if a match is found — Overseerr is not called.
+2. **Overseerr fallback**: `overseerr.search(title, 1)` → find TV match → `overseerr.getDetails(id, "tv")` → return with `thumbPath`, `overseerrId`, `cast`, `imdbId`.
+3. Both steps wrapped in try/catch; returns unmodified series if both fail.
+
+`SonarrSeries` interface extended with `thumbPath?`, `plexKey?`, `overseerrId?`, `cast?`, `imdbId?` enrichment fields.
+
+#### radarr_search_movie
+
+Added `enrichRadarrMovie(m)` helper in `radarr-tools.ts` using the same Plex-first/Overseerr-fallback pattern:
+1. **Plex first**: `plex.searchLibrary(title)` → `mediaType==="movie"` match → return with `thumbPath`, `plexKey`, `cast`.
+2. **Overseerr fallback — tmdbId path**: if `m.tmdbId` is set, call `overseerr.getDetails(m.tmdbId, "movie")` directly (more reliable than a title search). Returns with `thumbPath`, `overseerrId` set to `m.tmdbId`, `cast`, `imdbId`.
+3. **Overseerr fallback — title search path**: if no `tmdbId`, fall back to `overseerr.search(title)` → first movie match → `getDetails`.
+
+`RadarrMovie` interface extended with the same enrichment fields.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/services/overseerr.ts` | Added `thumbPath?` to `OverseerrDetails`; extract and set `thumbPath` in `getDetails()`; added `normalizeMediaStatus()` export |
+| `src/lib/tools/overseerr-tools.ts` | `overseerr_search` and `overseerr_discover` handlers: parallel `getDetails` enrichment; updated descriptions and `llmSummary` |
+| `src/lib/services/sonarr.ts` | Added enrichment fields to `SonarrSeries` interface |
+| `src/lib/tools/sonarr-tools.ts` | Added `enrichSonarrSeries` helper; `sonarr_search_series` handler calls it; updated description and `llmSummary` |
+| `src/lib/services/radarr.ts` | Added enrichment fields to `RadarrMovie` interface |
+| `src/lib/tools/radarr-tools.ts` | Added `enrichRadarrMovie` helper; `radarr_search_movie` handler calls it; updated description and `llmSummary` |
+| `src/__tests__/lib/tool-enrichment.test.ts` | New: unit tests for all enrichment paths (Plex match, Overseerr fallback, tmdbId direct lookup, graceful degradation) |

--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -25,7 +25,7 @@ const mockPlexSearchLibrary = vi.fn();
 const mockPlexBuildThumbUrl = vi.fn((p: string) => `/api/plex/thumb?path=${encodeURIComponent(p)}`);
 vi.mock("@/lib/services/plex", () => ({
   searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
-  buildThumbUrl: (...a: unknown[]) => mockPlexBuildThumbUrl(...a),
+  buildThumbUrl: (p: string) => mockPlexBuildThumbUrl(p),
   getPlexMachineId: vi.fn(),
 }));
 

--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for the enrichment logic added in issue #253:
+ *  - overseerr_search / overseerr_discover auto-call getDetails for each result
+ *  - sonarr_search_series enriches with Plex (primary) then Overseerr (fallback)
+ *  - radarr_search_movie enriches with Plex (primary) then Overseerr via tmdbId (fallback)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Shared service mocks
+// ---------------------------------------------------------------------------
+const mockOverseerrSearch = vi.fn();
+const mockOverseerrGetDetails = vi.fn();
+const mockOverseerrDiscover = vi.fn();
+vi.mock("@/lib/services/overseerr", () => ({
+  search: (...a: unknown[]) => mockOverseerrSearch(...a),
+  getDetails: (...a: unknown[]) => mockOverseerrGetDetails(...a),
+  discover: (...a: unknown[]) => mockOverseerrDiscover(...a),
+  listRequests: vi.fn().mockResolvedValue({ results: [], hasMore: false }),
+  normalizeMediaStatus: vi.fn((s: string) => s.toLowerCase().replace(/ /g, "_")),
+}));
+
+const mockPlexSearchLibrary = vi.fn();
+const mockPlexBuildThumbUrl = vi.fn((p: string) => `/api/plex/thumb?path=${encodeURIComponent(p)}`);
+vi.mock("@/lib/services/plex", () => ({
+  searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
+  buildThumbUrl: (...a: unknown[]) => mockPlexBuildThumbUrl(...a),
+  getPlexMachineId: vi.fn(),
+  searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
+}));
+
+const mockSonarrSearchSeries = vi.fn();
+vi.mock("@/lib/services/sonarr", () => ({
+  searchSeries: (...a: unknown[]) => mockSonarrSearchSeries(...a),
+  getSeriesStatus: vi.fn(),
+  getCalendar: vi.fn(),
+  getQueue: vi.fn(),
+}));
+
+const mockRadarrSearchMovie = vi.fn();
+vi.mock("@/lib/services/radarr", () => ({
+  searchMovie: (...a: unknown[]) => mockRadarrSearchMovie(...a),
+  getMovieStatus: vi.fn(),
+  getQueue: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/config", () => ({ getConfig: vi.fn(() => "http://example.com") }));
+
+// ---------------------------------------------------------------------------
+// Default mock responses
+// ---------------------------------------------------------------------------
+const BASE_SEARCH_RESULT = {
+  overseerrId: 550,
+  overseerrMediaType: "movie",
+  title: "Fight Club",
+  year: "1999",
+  summary: "A soap salesman.",
+  rating: 8.4,
+  mediaStatus: "Available",
+  thumbPath: "https://image.tmdb.org/t/p/w300/poster.jpg",
+  seasonCount: undefined,
+};
+
+const BASE_DETAIL = {
+  overseerrId: 550,
+  overseerrMediaType: "movie",
+  title: "Fight Club",
+  year: "1999",
+  imdbId: "tt0137523",
+  thumbPath: "https://image.tmdb.org/t/p/w300/poster.jpg",
+  cast: ["Brad Pitt", "Edward Norton"],
+  genres: ["Drama"],
+  runtime: 139,
+};
+
+const TV_SEARCH_RESULT = {
+  overseerrId: 1396,
+  overseerrMediaType: "tv",
+  title: "Breaking Bad",
+  year: "2008",
+  mediaStatus: "Available",
+  thumbPath: "https://image.tmdb.org/t/p/w300/bb.jpg",
+  seasonCount: 5,
+};
+
+const TV_DETAIL = {
+  overseerrId: 1396,
+  overseerrMediaType: "tv",
+  title: "Breaking Bad",
+  year: "2008",
+  imdbId: "tt0903747",
+  thumbPath: "https://image.tmdb.org/t/p/w300/bb.jpg",
+  cast: ["Bryan Cranston", "Aaron Paul"],
+  seasonCount: 5,
+  seasons: [
+    { seasonNumber: 1, status: "Available" },
+    { seasonNumber: 2, status: "Available" },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockOverseerrSearch.mockResolvedValue({ results: [BASE_SEARCH_RESULT], hasMore: false });
+  mockOverseerrGetDetails.mockResolvedValue(BASE_DETAIL);
+  mockOverseerrDiscover.mockResolvedValue({ results: [BASE_SEARCH_RESULT], hasMore: false });
+  mockPlexSearchLibrary.mockResolvedValue({ results: [], hasMore: false });
+  mockSonarrSearchSeries.mockResolvedValue([]);
+  mockRadarrSearchMovie.mockResolvedValue([]);
+});
+
+// ===========================================================================
+// overseerr_search enrichment
+// ===========================================================================
+describe("overseerr_search — enrichment (#253)", () => {
+  it("calls getDetails for each search result and merges cast and imdbId", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    // Ensure a fresh registry
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_search", JSON.stringify({ query: "Fight Club" }));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    expect(mockOverseerrGetDetails).toHaveBeenCalledWith(550, "movie");
+    expect(results[0].cast).toEqual(["Brad Pitt", "Edward Norton"]);
+    expect(results[0].imdbId).toBe("tt0137523");
+  });
+
+  it("merges accurate seasonCount and seasons for TV results", async () => {
+    mockOverseerrSearch.mockResolvedValueOnce({ results: [TV_SEARCH_RESULT], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(TV_DETAIL);
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_search", JSON.stringify({ query: "Breaking Bad" }));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    expect(mockOverseerrGetDetails).toHaveBeenCalledWith(1396, "tv");
+    expect(results[0].seasonCount).toBe(5);
+    expect((results[0].seasons as unknown[]).length).toBe(2);
+  });
+
+  it("returns base result without enrichment if getDetails throws", async () => {
+    mockOverseerrGetDetails.mockRejectedValueOnce(new Error("Overseerr down"));
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_search", JSON.stringify({ query: "Fight Club" }));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    // Base result still returned
+    expect(results[0].title).toBe("Fight Club");
+    expect(results[0].cast).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// sonarr_search_series enrichment
+// ===========================================================================
+describe("sonarr_search_series — Plex-first enrichment (#253)", () => {
+  const SONARR_SERIES = { id: 10, title: "Breaking Bad", year: 2008, seasonCount: 5, monitored: true, tvdbId: 81189 };
+
+  it("uses Plex data when the show is found in Plex", async () => {
+    const PLEX_RESULT = {
+      title: "Breaking Bad", year: 2008, mediaType: "tv",
+      plexKey: "/library/metadata/77", thumbPath: "/library/metadata/77/thumb",
+      cast: ["Bryan Cranston"],
+    };
+    mockSonarrSearchSeries.mockResolvedValueOnce([SONARR_SERIES]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [PLEX_RESULT], hasMore: false });
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(results[0].plexKey).toBe("/library/metadata/77");
+    expect(results[0].cast).toEqual(["Bryan Cranston"]);
+    // Overseerr should NOT be called when Plex matched
+    expect(mockOverseerrSearch).not.toHaveBeenCalled();
+    expect(mockOverseerrGetDetails).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Overseerr when not found in Plex", async () => {
+    mockSonarrSearchSeries.mockResolvedValueOnce([SONARR_SERIES]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [], hasMore: false });
+    mockOverseerrSearch.mockResolvedValueOnce({ results: [TV_SEARCH_RESULT], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(TV_DETAIL);
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(results[0].overseerrId).toBe(1396);
+    expect(results[0].cast).toEqual(["Bryan Cranston", "Aaron Paul"]);
+    expect(results[0].imdbId).toBe("tt0903747");
+  });
+
+  it("returns unmodified result if both Plex and Overseerr are unavailable", async () => {
+    mockSonarrSearchSeries.mockResolvedValueOnce([SONARR_SERIES]);
+    mockPlexSearchLibrary.mockRejectedValueOnce(new Error("Plex not configured"));
+    mockOverseerrSearch.mockRejectedValueOnce(new Error("Overseerr not configured"));
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(results[0].title).toBe("Breaking Bad");
+    expect(results[0].thumbPath).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// radarr_search_movie enrichment
+// ===========================================================================
+describe("radarr_search_movie — Plex-first enrichment (#253)", () => {
+  const RADARR_MOVIE = { id: 20, title: "Fight Club", year: 1999, hasFile: false, monitored: true, tmdbId: 550 };
+
+  it("uses Plex data when the movie is found in Plex", async () => {
+    const PLEX_RESULT = {
+      title: "Fight Club", year: 1999, mediaType: "movie",
+      plexKey: "/library/metadata/42", thumbPath: "/library/metadata/42/thumb",
+      cast: ["Brad Pitt"],
+    };
+    mockRadarrSearchMovie.mockResolvedValueOnce([RADARR_MOVIE]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [PLEX_RESULT], hasMore: false });
+
+    const { registerRadarrTools } = await import("@/lib/tools/radarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerRadarrTools();
+
+    const raw = await executeTool("radarr_search_movie", JSON.stringify({ term: "Fight Club" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(results[0].plexKey).toBe("/library/metadata/42");
+    expect(results[0].cast).toEqual(["Brad Pitt"]);
+    expect(mockOverseerrGetDetails).not.toHaveBeenCalled();
+  });
+
+  it("uses Overseerr getDetails via tmdbId when not in Plex", async () => {
+    mockRadarrSearchMovie.mockResolvedValueOnce([RADARR_MOVIE]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(BASE_DETAIL);
+
+    const { registerRadarrTools } = await import("@/lib/tools/radarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerRadarrTools();
+
+    const raw = await executeTool("radarr_search_movie", JSON.stringify({ term: "Fight Club" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    // Should call getDetails with tmdbId directly (not via search)
+    expect(mockOverseerrGetDetails).toHaveBeenCalledWith(550, "movie");
+    expect(mockOverseerrSearch).not.toHaveBeenCalled();
+    expect(results[0].overseerrId).toBe(550);
+    expect(results[0].cast).toEqual(["Brad Pitt", "Edward Norton"]);
+    expect(results[0].imdbId).toBe("tt0137523");
+  });
+
+  it("falls back to Overseerr title search when tmdbId is absent", async () => {
+    const movieNoTmdb = { ...RADARR_MOVIE, tmdbId: undefined };
+    mockRadarrSearchMovie.mockResolvedValueOnce([movieNoTmdb]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [], hasMore: false });
+    mockOverseerrSearch.mockResolvedValueOnce({ results: [BASE_SEARCH_RESULT], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(BASE_DETAIL);
+
+    const { registerRadarrTools } = await import("@/lib/tools/radarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerRadarrTools();
+
+    const raw = await executeTool("radarr_search_movie", JSON.stringify({ term: "Fight Club" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(mockOverseerrSearch).toHaveBeenCalled();
+    expect(results[0].overseerrId).toBe(550);
+    expect(results[0].imdbId).toBe("tt0137523");
+  });
+});

--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -27,7 +27,6 @@ vi.mock("@/lib/services/plex", () => ({
   searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
   buildThumbUrl: (...a: unknown[]) => mockPlexBuildThumbUrl(...a),
   getPlexMachineId: vi.fn(),
-  searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
 }));
 
 const mockSonarrSearchSeries = vi.fn();

--- a/src/lib/services/overseerr.ts
+++ b/src/lib/services/overseerr.ts
@@ -69,6 +69,7 @@ export interface OverseerrDetails {
   title: string;
   year?: string;
   imdbId?: string;
+  thumbPath?: string;            // Full TMDB poster URL — pass directly as thumbPath to display_titles
   cast?: string[];              // Top 10 cast members
   genres?: string[];
   runtime?: number;             // Movie: total runtime in minutes
@@ -185,6 +186,7 @@ export async function getDetails(id: number, mediaType: "movie" | "tv"): Promise
   const title = (detail?.title || detail?.name) as string;
   const releaseDate = (detail?.releaseDate || detail?.firstAirDate) as string | undefined;
   const episodeRuntimes = detail?.episodeRunTime as number[] | undefined;
+  const posterPath = detail?.posterPath as string | undefined;
 
   return {
     overseerrId: id,
@@ -192,6 +194,7 @@ export async function getDetails(id: number, mediaType: "movie" | "tv"): Promise
     title,
     year: releaseDate?.substring(0, 4),
     imdbId,
+    thumbPath: posterPath ? `https://image.tmdb.org/t/p/w300${posterPath}` : undefined,
     cast: cast.length > 0 ? cast : undefined,
     genres: genres.length > 0 ? genres : undefined,
     runtime: mediaType === "movie" ? (detail?.runtime as number | undefined) : undefined,
@@ -200,6 +203,20 @@ export async function getDetails(id: number, mediaType: "movie" | "tv"): Promise
     seasons: seasons.length > 0 ? seasons : undefined,
     requests: requests.length > 0 ? requests : undefined,
   };
+}
+
+/**
+ * Normalise the human-readable Overseerr mediaStatus string (returned by the
+ * search / discover endpoints) to the lowercase values expected by display_titles.
+ */
+export function normalizeMediaStatus(status: string): "available" | "partial" | "pending" | "not_requested" {
+  switch (status) {
+    case "Available": return "available";
+    case "Partially Available": return "partial";
+    case "Pending":
+    case "Processing": return "pending";
+    default: return "not_requested";
+  }
 }
 
 export interface OverseerrRequest {

--- a/src/lib/services/radarr.ts
+++ b/src/lib/services/radarr.ts
@@ -34,6 +34,12 @@ export interface RadarrMovie {
   monitored?: boolean;
   hasFile?: boolean;
   tmdbId?: number;
+  // Enrichment fields — populated by the tool handler via Plex / Overseerr lookups
+  thumbPath?: string;
+  plexKey?: string;
+  overseerrId?: number;
+  cast?: string[];
+  imdbId?: string;
 }
 
 export async function searchMovie(term: string): Promise<RadarrMovie[]> {

--- a/src/lib/services/sonarr.ts
+++ b/src/lib/services/sonarr.ts
@@ -34,6 +34,12 @@ export interface SonarrSeries {
   seasonCount?: number;
   monitored?: boolean;
   tvdbId?: number;
+  // Enrichment fields — populated by the tool handler via Plex / Overseerr lookups
+  thumbPath?: string;
+  plexKey?: string;
+  overseerrId?: number;
+  cast?: string[];
+  imdbId?: string;
 }
 
 export async function searchSeries(term: string): Promise<SonarrSeries[]> {

--- a/src/lib/tools/overseerr-tools.ts
+++ b/src/lib/tools/overseerr-tools.ts
@@ -5,23 +5,67 @@ import type { OverseerrSearchResult, OverseerrRequest, OverseerrDetails, Oversee
 
 const pageParam = z.number().int().min(1).optional().describe("Page number (1-based). Omit or use 1 for the first page. Use hasMore from the previous response to know whether a next page exists.");
 
+/** Compact seasons string "S1:available S2:pending …" from a details object. */
+function compactSeasons(detail: OverseerrDetails): string | undefined {
+  if (!detail.seasons || detail.seasons.length === 0) return undefined;
+  const statusMap: Record<string, string> = {
+    "Available": "available",
+    "Partially Available": "partial",
+    "Pending": "pending",
+    "Processing": "pending",
+  };
+  return detail.seasons
+    .map((s) => `S${s.seasonNumber}:${statusMap[s.status] ?? "not_requested"}`)
+    .join(" ");
+}
+
 export function registerOverseerrTools() {
   defineTool({
     name: "overseerr_search",
-    description: "Search for a specific movie or TV show by title on Overseerr. IMPORTANT: The query MUST be a title (e.g. 'Breaking Bad', 'The Dark Knight'). Do NOT search by year, genre, actor, or keyword — use overseerr_discover for genre/trending browsing. Returns mediaStatus, summary, rating, thumbPath, overseerrId, overseerrMediaType, and seasonCount. NOTE: seasonCount is sourced from the TMDB search API which does not include it for untracked shows — it may be 0 or missing. For TV shows always call overseerr_get_details to get the accurate season count before display_titles. Returns up to 10 results per page with a hasMore flag.",
+    description: "Search for a specific movie or TV show by title on Overseerr. IMPORTANT: The query MUST be a title (e.g. 'Breaking Bad', 'The Dark Knight'). Do NOT search by year, genre, actor, or keyword — use overseerr_discover for genre/trending browsing. Returns full details for each result including cast, imdbId, accurate seasonCount, per-season availability (seasons), mediaStatus, summary, rating, thumbPath, overseerrId, and overseerrMediaType. You can pass these fields directly to display_titles without calling overseerr_get_details first. Returns up to 10 results per page with a hasMore flag.",
     schema: z.object({
       query: z.string().describe("The exact or approximate title to search for (e.g. 'Inception', 'The Office'). Must be a title — not a year, genre, or keyword."),
       page: pageParam,
     }),
-    handler: async (args) => overseerr.search(args.query, args.page ?? 1),
+    handler: async (args) => {
+      const { results, hasMore } = await overseerr.search(args.query, args.page ?? 1);
+      // Enrich each result with cast, imdbId, accurate seasonCount, and per-season
+      // availability by calling getDetails in parallel. Non-fatal: returns the base
+      // search result if the detail fetch fails for any individual title.
+      const enriched = await Promise.all(
+        results.map(async (r) => {
+          try {
+            const mediaType = r.overseerrMediaType === "tv" ? "tv" : "movie";
+            const detail = await overseerr.getDetails(r.overseerrId, mediaType);
+            return {
+              ...r,
+              thumbPath: r.thumbPath ?? detail.thumbPath,
+              cast: detail.cast,
+              imdbId: detail.imdbId,
+              ...(mediaType === "tv" ? {
+                seasonCount: detail.seasonCount ?? r.seasonCount,
+                seasons: detail.seasons,
+              } : {}),
+            };
+          } catch {
+            return r;
+          }
+        }),
+      );
+      return { results: enriched, hasMore };
+    },
     llmSummary: (result: unknown) => {
-      const r = result as { results: OverseerrSearchResult[]; hasMore: boolean };
+      const r = result as { results: (OverseerrSearchResult & { cast?: string[]; imdbId?: string; seasons?: overseerr.OverseerrSeasonStatus[] })[]; hasMore: boolean };
       return {
-        // thumbPath preserved: the LLM needs the poster URL to pass to
-        // display_titles in follow-up turns without re-searching.
-        // summary stripped: 300 chars × 10 results = main token saving.
-        results: r.results.map(({ overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath }) => ({
+        results: r.results.map(({ overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath, cast, imdbId, seasons }) => ({
           overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath,
+          ...(cast && cast.length > 0 ? { cast: cast.slice(0, 3) } : {}),
+          ...(imdbId ? { imdbId } : {}),
+          // Compact seasons string for TV to preserve per-season status without
+          // bloating history with full objects.
+          ...(seasons && seasons.length > 0
+            ? { seasons: seasons.map((s) => `S${s.seasonNumber}:${s.status.toLowerCase().replace(/ /g, "_")}`).join(" ") }
+            : {}),
         })),
         hasMore: r.hasMore,
       };
@@ -30,7 +74,7 @@ export function registerOverseerrTools() {
 
   defineTool({
     name: "overseerr_get_details",
-    description: "Get full details for a specific movie or TV show from Overseerr. For TV shows this MUST be called before display_titles — it returns the accurate seasonCount from TMDB (the search result's seasonCount is unreliable) and a compact per-season availability string needed to set correct mediaStatus on each season card. Also returns cast (top 10), imdbId, genres, and runtime for all media types.",
+    description: "Get full details for a specific movie or TV show from Overseerr. NOTE: overseerr_search already returns cast, imdbId, seasonCount, per-season availability, and thumbPath — you do not need to call this after a search. Use this tool only when you need additional fields not returned by search (genres, runtime, episodeRuntime, full request history) or when you have an overseerrId without a prior search result.",
     schema: z.object({
       id: z.number().int().describe("Overseerr media ID (overseerrId from overseerr_search results)"),
       mediaType: z.enum(["movie", "tv"]).describe("Media type"),
@@ -44,18 +88,7 @@ export function registerOverseerrTools() {
      *  Request history dropped entirely (not needed after initial display). */
     llmSummary: (result: unknown) => {
       const r = result as OverseerrDetails;
-      // Map Overseerr status strings to display_titles mediaStatus values
-      const statusMap: Record<string, string> = {
-        "Available": "available",
-        "Partially Available": "partial",
-        "Pending": "pending",
-        "Processing": "pending",
-      };
-      const seasonsCompact = r.seasons && r.seasons.length > 0
-        ? r.seasons
-            .map((s) => `S${s.seasonNumber}:${statusMap[s.status] ?? "not_requested"}`)
-            .join(" ")
-        : undefined;
+      const seasonsCompact = compactSeasons(r);
       return {
         overseerrId: r.overseerrId,
         overseerrMediaType: r.overseerrMediaType,
@@ -92,19 +125,47 @@ export function registerOverseerrTools() {
 
   defineTool({
     name: "overseerr_discover",
-    description: "Discover movies or TV shows from Overseerr/TMDB without a specific title. Use this when the user asks for trending content, popular titles, upcoming releases, or wants to browse by genre (e.g. 'what movies are trending', 'show me upcoming movies', 'find some action movies'). For TV shows always call overseerr_get_details before display_titles. Returns up to 10 results per page with a hasMore flag.",
+    description: "Discover movies or TV shows from Overseerr/TMDB without a specific title. Use this when the user asks for trending content, popular titles, upcoming releases, or wants to browse by genre (e.g. 'what movies are trending', 'show me upcoming movies', 'find some action movies'). Returns full details for each result including cast, imdbId, accurate seasonCount, per-season availability, mediaStatus, summary, rating, thumbPath, overseerrId, and overseerrMediaType — pass directly to display_titles. Returns up to 10 results per page with a hasMore flag.",
     schema: z.object({
       mediaType: z.enum(["movie", "tv"]).describe("Whether to discover movies or TV shows"),
       genre: z.string().optional().describe("Genre name to filter by (e.g. 'Action', 'Comedy', 'Drama'). Omit for general trending results."),
       category: z.enum(["trending", "upcoming"]).optional().describe("'trending' for popular titles (default), 'upcoming' for titles not yet released"),
       page: pageParam,
     }),
-    handler: async (args) => overseerr.discover(args.mediaType, args.genre, args.category ?? "trending", args.page ?? 1),
+    handler: async (args) => {
+      const { results, hasMore } = await overseerr.discover(args.mediaType, args.genre, args.category ?? "trending", args.page ?? 1);
+      const enriched = await Promise.all(
+        results.map(async (r) => {
+          try {
+            const mediaType = r.overseerrMediaType === "tv" ? "tv" : "movie";
+            const detail = await overseerr.getDetails(r.overseerrId, mediaType);
+            return {
+              ...r,
+              thumbPath: r.thumbPath ?? detail.thumbPath,
+              cast: detail.cast,
+              imdbId: detail.imdbId,
+              ...(mediaType === "tv" ? {
+                seasonCount: detail.seasonCount ?? r.seasonCount,
+                seasons: detail.seasons,
+              } : {}),
+            };
+          } catch {
+            return r;
+          }
+        }),
+      );
+      return { results: enriched, hasMore };
+    },
     llmSummary: (result: unknown) => {
-      const r = result as { results: OverseerrDiscoverResult[]; hasMore: boolean };
+      const r = result as { results: (OverseerrDiscoverResult & { cast?: string[]; imdbId?: string; seasons?: overseerr.OverseerrSeasonStatus[] })[]; hasMore: boolean };
       return {
-        results: r.results.map(({ overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath }) => ({
+        results: r.results.map(({ overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath, cast, imdbId, seasons }) => ({
           overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath,
+          ...(cast && cast.length > 0 ? { cast: cast.slice(0, 3) } : {}),
+          ...(imdbId ? { imdbId } : {}),
+          ...(seasons && seasons.length > 0
+            ? { seasons: seasons.map((s) => `S${s.seasonNumber}:${s.status.toLowerCase().replace(/ /g, "_")}`).join(" ") }
+            : {}),
         })),
         hasMore: r.hasMore,
       };

--- a/src/lib/tools/radarr-tools.ts
+++ b/src/lib/tools/radarr-tools.ts
@@ -1,18 +1,90 @@
 import { z } from "zod";
 import { defineTool } from "./registry";
 import * as radarr from "@/lib/services/radarr";
+import * as plex from "@/lib/services/plex";
+import * as overseerr from "@/lib/services/overseerr";
 import type { RadarrMovie } from "@/lib/services/radarr";
+
+/**
+ * Enrich a single Radarr movie result with poster, cast, and overseerrId by:
+ * 1. Checking Plex first (gives plexKey, thumbPath, cast — best quality)
+ * 2. Falling back to Overseerr:
+ *    - If tmdbId is available, call getDetails directly (more reliable than title search)
+ *    - Otherwise, search by title and use the first movie match
+ * Non-fatal: returns the unmodified movie if both lookups fail.
+ */
+async function enrichRadarrMovie(m: RadarrMovie): Promise<RadarrMovie> {
+  // --- Plex check ---
+  try {
+    const { results } = await plex.searchLibrary(m.title);
+    const titleLower = m.title.toLowerCase();
+    const match = results.find(
+      (r) =>
+        r.mediaType === "movie" &&
+        r.title.toLowerCase() === titleLower &&
+        (!m.year || !r.year || r.year === m.year),
+    );
+    if (match) {
+      return {
+        ...m,
+        thumbPath: match.thumbPath ? plex.buildThumbUrl(match.thumbPath) : undefined,
+        plexKey: match.plexKey,
+        cast: match.cast,
+      };
+    }
+  } catch { /* Plex not configured or unavailable */ }
+
+  // --- Overseerr fallback ---
+  try {
+    if (m.tmdbId) {
+      // Direct lookup using tmdbId — more reliable than a title search
+      const detail = await overseerr.getDetails(m.tmdbId, "movie");
+      return {
+        ...m,
+        thumbPath: detail.thumbPath,
+        overseerrId: m.tmdbId,
+        cast: detail.cast,
+        imdbId: detail.imdbId,
+      };
+    }
+
+    // No tmdbId — fall back to a title search
+    const { results: ovrResults } = await overseerr.search(m.title, 1);
+    const titleLower = m.title.toLowerCase();
+    const match = ovrResults.find(
+      (r) =>
+        r.overseerrMediaType === "movie" &&
+        r.title.toLowerCase() === titleLower &&
+        (!m.year || !r.year || r.year === String(m.year)),
+    );
+    if (match) {
+      const detail = await overseerr.getDetails(match.overseerrId, "movie");
+      return {
+        ...m,
+        thumbPath: match.thumbPath ?? detail.thumbPath,
+        overseerrId: match.overseerrId,
+        cast: detail.cast,
+        imdbId: detail.imdbId,
+      };
+    }
+  } catch { /* Overseerr not configured or unavailable */ }
+
+  return m;
+}
 
 export function registerRadarrTools() {
   defineTool({
     name: "radarr_search_movie",
-    description: "Search for movies by title. Returns results from Radarr's lookup including whether the movie is in the library, downloaded, and monitored.",
+    description: "Search for movies by title. Returns results from Radarr's lookup including whether the movie is in the library, downloaded, and monitored. Each result is automatically enriched with thumbPath (poster), plexKey (if available in Plex), overseerrId, cast, and imdbId — pass these directly to display_titles. For mediaStatus: use 'available' if the movie is in Plex (plexKey present) or hasFile is true, 'pending' if monitored in Radarr but not downloaded, otherwise 'not_requested'.",
     schema: z.object({
       term: z.string().describe("Search term (movie title)"),
     }),
-    handler: async (args) => radarr.searchMovie(args.term),
+    handler: async (args) => {
+      const results = await radarr.searchMovie(args.term);
+      return Promise.all(results.map(enrichRadarrMovie));
+    },
     /** Strip overview from history — 200-char overview × 10 results is noise once the
-     *  LLM has already acted on the search. Keep all identity and status fields. */
+     *  LLM has already acted on the search. Keep all identity, status, and enrichment fields. */
     llmSummary: (result: unknown) => {
       return (result as RadarrMovie[]).map(
         ({ overview: _ov, ...rest }) => rest,

--- a/src/lib/tools/sonarr-tools.ts
+++ b/src/lib/tools/sonarr-tools.ts
@@ -1,18 +1,76 @@
 import { z } from "zod";
 import { defineTool } from "./registry";
 import * as sonarr from "@/lib/services/sonarr";
+import * as plex from "@/lib/services/plex";
+import * as overseerr from "@/lib/services/overseerr";
 import type { SonarrSeries, SonarrSeriesStatus } from "@/lib/services/sonarr";
+
+/**
+ * Enrich a single Sonarr series result with poster, cast, and overseerrId by:
+ * 1. Checking Plex first (gives plexKey, thumbPath, cast — best quality)
+ * 2. Falling back to Overseerr search + getDetails (gives overseerrId, thumbPath, cast, imdbId)
+ * Non-fatal: returns the unmodified series if both lookups fail.
+ */
+async function enrichSonarrSeries(s: SonarrSeries): Promise<SonarrSeries> {
+  // --- Plex check ---
+  try {
+    const { results } = await plex.searchLibrary(s.title);
+    const titleLower = s.title.toLowerCase();
+    const match = results.find(
+      (r) =>
+        r.mediaType === "tv" &&
+        r.title.toLowerCase() === titleLower &&
+        (!s.year || !r.year || r.year === s.year),
+    );
+    if (match) {
+      return {
+        ...s,
+        thumbPath: match.thumbPath ? plex.buildThumbUrl(match.thumbPath) : undefined,
+        plexKey: match.plexKey,
+        cast: match.cast,
+      };
+    }
+  } catch { /* Plex not configured or unavailable */ }
+
+  // --- Overseerr fallback ---
+  try {
+    const { results: ovrResults } = await overseerr.search(s.title, 1);
+    const titleLower = s.title.toLowerCase();
+    const match = ovrResults.find(
+      (r) =>
+        r.overseerrMediaType === "tv" &&
+        r.title.toLowerCase() === titleLower &&
+        (!s.year || !r.year || r.year === String(s.year)),
+    );
+    if (match) {
+      // getDetails gives accurate cast and imdbId; thumbPath is already on the search result
+      const detail = await overseerr.getDetails(match.overseerrId, "tv");
+      return {
+        ...s,
+        thumbPath: match.thumbPath ?? detail.thumbPath,
+        overseerrId: match.overseerrId,
+        cast: detail.cast,
+        imdbId: detail.imdbId,
+      };
+    }
+  } catch { /* Overseerr not configured or unavailable */ }
+
+  return s;
+}
 
 export function registerSonarrTools() {
   defineTool({
     name: "sonarr_search_series",
-    description: "Search for a TV series by title. Returns results from Sonarr's lookup including monitored status, season count, and whether it's in the Sonarr library.",
+    description: "Search for a TV series by title. Returns results from Sonarr's lookup including monitored status, season count, and whether it's in the Sonarr library. Each result is automatically enriched with thumbPath (poster), plexKey (if available in Plex), overseerrId (if found in Overseerr), cast, and imdbId — pass these directly to display_titles. For mediaStatus: use 'available' if the show is in Plex (plexKey present), 'pending' if monitored in Sonarr but plexKey absent, or derive from the Overseerr mediaStatus field if present.",
     schema: z.object({
       term: z.string().describe("Search term (TV show title)"),
     }),
-    handler: async (args) => sonarr.searchSeries(args.term),
+    handler: async (args) => {
+      const results = await sonarr.searchSeries(args.term);
+      return Promise.all(results.map(enrichSonarrSeries));
+    },
     /** Strip overview from history — 200-char overview × 10 results is noise once the
-     *  LLM has already acted on the search. Keep all identity and status fields. */
+     *  LLM has already acted on the search. Keep all identity, status, and enrichment fields. */
     llmSummary: (result: unknown) => {
       return (result as SonarrSeries[]).map(
         ({ overview: _ov, ...rest }) => rest,


### PR DESCRIPTION
## Summary

Closes #253.

Previously the LLM had to call `overseerr_get_details` separately after every search before it could populate `display_titles` with cast, imdbId, and season data. Sonarr/Radarr search results had no poster, cast, or Overseerr linkage at all.

- **`overseerr_search` / `overseerr_discover`**: handlers now call `getDetails` in parallel for every result and merge `cast`, `imdbId`, `thumbPath`, and (for TV) `seasonCount` + per-season `seasons` into each result. Individual failures are non-fatal — the base search result is returned unchanged if `getDetails` throws.
- **`sonarr_search_series`**: new `enrichSonarrSeries` helper checks Plex first (`plexKey`, `thumbPath`, `cast`), then falls back to Overseerr search + `getDetails` (`overseerrId`, `thumbPath`, `cast`, `imdbId`).
- **`radarr_search_movie`**: same Plex-first / Overseerr-fallback pattern; uses `tmdbId` for a direct `getDetails` call when available (avoids an extra title search round-trip).
- `SonarrSeries` and `RadarrMovie` interfaces extended with the new enrichment fields.
- `OverseerrDetails` now includes `thumbPath`; `normalizeMediaStatus()` added as a named export.

## Test plan

- [ ] `overseerr_search — enrichment`: calls `getDetails` for each result, merges `cast`/`imdbId`; merges accurate `seasonCount`/`seasons` for TV; returns base result without enrichment if `getDetails` throws
- [ ] `sonarr_search_series — Plex-first enrichment`: uses Plex data when show is in Plex; falls back to Overseerr when not in Plex; returns unmodified result if both unavailable
- [ ] `radarr_search_movie — Plex-first enrichment`: uses Plex data when movie is in Plex; calls `getDetails` via `tmdbId` when not in Plex; falls back to title search when `tmdbId` absent
- [ ] Existing `overseerr.test.ts` tests unchanged (enrichment lives in tool handlers only, not in service functions)

https://claude.ai/code/session_01PFpjQXHBtNVe3CJNT5NGHF