### PR TITLE
chore: bump version to 1.1.5-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.4",
+  "version": "1.1.5-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps `package.json` from `1.1.4` → `1.1.5-beta.1` to open the new beta cycle.

Required before the `dev → beta` PR can be raised.

https://claude.ai/code/session_01PFpjQXHBtNVe3CJNT5NGHF