### PR TITLE
dev → beta: v1.1.5-beta.1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1975,3 +1975,47 @@ Added `id` and `name` to all interactive fields:
 | `src/components/chat/report-issue-modal.tsx` | Add `id`/`name` to description textarea |
 | `src/__tests__/api/conversation-messages.test.ts` | Add 3 tests for title generation behaviour |
 | `src/__tests__/api/realtime-session.test.ts` | Add 1 test asserting `turn_detection` is sent with raised threshold |
+
+---
+
+### Phase N+17 — Tool enrichment: auto-populate cast/imdbId/poster for search results (#253)
+
+Previously, `overseerr_search` and `overseerr_discover` returned only shallow search data; the LLM had to call `overseerr_get_details` separately for cast, imdbId, and accurate season data before calling `display_titles`. `sonarr_search_series` and `radarr_search_movie` returned raw Sonarr/Radarr data with no poster, cast, or Overseerr linkage at all.
+
+Fixed by adding automatic enrichment inside each tool handler so `display_titles` receives complete data without any extra LLM tool calls.
+
+#### overseerr_search / overseerr_discover
+
+Both handlers now call `overseerr.getDetails()` for every result in parallel (via `Promise.all`). The detail fields are merged into each result: `cast`, `imdbId`, updated `thumbPath` (if not already set), and for TV: `seasonCount` and per-season `seasons` array. Individual failures are non-fatal — if `getDetails` throws for a result, the base search result is returned unchanged.
+
+The `overseerr_get_details` tool description was updated to clarify that search now returns full details; `get_details` is only needed for fields not included in search results (genres, runtime, full request history).
+
+#### sonarr_search_series
+
+Added `enrichSonarrSeries(s)` helper in `sonarr-tools.ts`:
+1. **Plex first**: `plex.searchLibrary(title)` → find a `mediaType==="tv"` match by title+year → return with `thumbPath` (via `buildThumbUrl`), `plexKey`, and `cast`. Short-circuits if a match is found — Overseerr is not called.
+2. **Overseerr fallback**: `overseerr.search(title, 1)` → find TV match → `overseerr.getDetails(id, "tv")` → return with `thumbPath`, `overseerrId`, `cast`, `imdbId`.
+3. Both steps wrapped in try/catch; returns unmodified series if both fail.
+
+`SonarrSeries` interface extended with `thumbPath?`, `plexKey?`, `overseerrId?`, `cast?`, `imdbId?` enrichment fields.
+
+#### radarr_search_movie
+
+Added `enrichRadarrMovie(m)` helper in `radarr-tools.ts` using the same Plex-first/Overseerr-fallback pattern:
+1. **Plex first**: `plex.searchLibrary(title)` → `mediaType==="movie"` match → return with `thumbPath`, `plexKey`, `cast`.
+2. **Overseerr fallback — tmdbId path**: if `m.tmdbId` is set, call `overseerr.getDetails(m.tmdbId, "movie")` directly (more reliable than a title search). Returns with `thumbPath`, `overseerrId` set to `m.tmdbId`, `cast`, `imdbId`.
+3. **Overseerr fallback — title search path**: if no `tmdbId`, fall back to `overseerr.search(title)` → first movie match → `getDetails`.
+
+`RadarrMovie` interface extended with the same enrichment fields.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/services/overseerr.ts` | Added `thumbPath?` to `OverseerrDetails`; extract and set `thumbPath` in `getDetails()`; added `normalizeMediaStatus()` export |
+| `src/lib/tools/overseerr-tools.ts` | `overseerr_search` and `overseerr_discover` handlers: parallel `getDetails` enrichment; updated descriptions and `llmSummary` |
+| `src/lib/services/sonarr.ts` | Added enrichment fields to `SonarrSeries` interface |
+| `src/lib/tools/sonarr-tools.ts` | Added `enrichSonarrSeries` helper; `sonarr_search_series` handler calls it; updated description and `llmSummary` |
+| `src/lib/services/radarr.ts` | Added enrichment fields to `RadarrMovie` interface |
+| `src/lib/tools/radarr-tools.ts` | Added `enrichRadarrMovie` helper; `radarr_search_movie` handler calls it; updated description and `llmSummary` |
+| `src/__tests__/lib/tool-enrichment.test.ts` | New: unit tests for all enrichment paths (Plex match, Overseerr fallback, tmdbId direct lookup, graceful degradation) |

--- a/PLAN.md
+++ b/PLAN.md
@@ -1925,3 +1925,53 @@ History is injected after `session.update` so transcription is enabled before th
 |------|--------|
 | `src/hooks/use-realtime-chat.ts` | Inject last 20 text turns as `conversation.item.create` events in `dc.onopen` |
 
+
+
+---
+
+### Phase N+16 — Fix realtime VAD sensitivity, chat naming, and form accessibility (#242, #252, #236)
+
+#### #242 — Realtime VAD too sensitive (coughs / background noise interrupt responses)
+
+The OpenAI Realtime API session was created without a `turn_detection` config, so it used the OpenAI default (threshold 0.5, silence 500 ms). This caused background noise and coughs to trigger VAD and interrupt the assistant's spoken response.
+
+Fixed by passing an explicit `turn_detection` block in the session creation payload:
+
+- `threshold: 0.7` — higher value means louder/clearer speech required to activate VAD
+- `silence_duration_ms: 800` — longer silence (800 ms vs 500 ms default) required before a turn ends, avoiding spurious cut-offs
+
+#### #252 — Realtime conversations never update the chat name
+
+Text-mode chats trigger `generateTitle()` inside `/api/chat/route.ts` after the first user message. Realtime turns bypass that route entirely — messages are saved directly via `POST /api/conversations/[id]/messages`. So the conversation title stayed as "New Chat" forever.
+
+Fixed by:
+
+1. **API route** (`src/app/api/conversations/[id]/messages/route.ts`): after saving a `user` message to a `"New Chat"` conversation, calls `generateTitle(conversationId, content)` and includes the resulting title as `data.newTitle` in the response.
+2. **Client** (`src/app/chat/page.tsx`): `handleRealtimeTurn` now reads `data.newTitle` from the API response and calls `updateConversationTitle` to update the sidebar immediately, matching the behaviour of text-mode chats.
+
+#### #236 — Form fields missing id/name attributes
+
+Many inputs, selects, textareas, and checkboxes across the settings page and chat components were missing `id` and `name` attributes. This breaks accessibility (label `htmlFor` linking), password manager autofill, browser autocomplete, and form submission semantics.
+
+Added `id` and `name` to all interactive fields:
+- LLM endpoint fields (name, enabled, default, baseUrl, apiKey, model, system prompt, TTS voice, realtime model, realtime system prompt) — using `ep-${ep.id}-<field>` IDs
+- Arr service fields (URL, apiKey) — using `arr-${svc.key}-<field>` IDs
+- Plex fields (url, token)
+- User management fields (role, model, canChangeModel, rateLimitMessages, rateLimitPeriod) — using `user-${user.id}-<field>` IDs
+- MCP endpoint and bearer token display inputs
+- GitHub issue reporting fields (already had `id`, added `name`)
+- Chat message textarea (`id="chat-message-input"`, `name="message"`)
+- Report issue textarea (`id="report-issue-description"`, `name="description"`)
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/app/api/realtime/session/route.ts` | Add `turn_detection` with `threshold: 0.7`, `silence_duration_ms: 800` |
+| `src/app/api/conversations/[id]/messages/route.ts` | Import `generateTitle`; call on first user message; return `newTitle` in response |
+| `src/app/chat/page.tsx` | `handleRealtimeTurn`: read `newTitle` from response, call `updateConversationTitle` |
+| `src/app/settings/page.tsx` | Add `id`/`name` to all form fields |
+| `src/components/chat/chat-input.tsx` | Add `id`/`name` to message textarea |
+| `src/components/chat/report-issue-modal.tsx` | Add `id`/`name` to description textarea |
+| `src/__tests__/api/conversation-messages.test.ts` | Add 3 tests for title generation behaviour |
+| `src/__tests__/api/realtime-session.test.ts` | Add 1 test asserting `turn_detection` is sent with raised threshold |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.4",
+  "version": "1.1.5-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/api/conversation-messages.test.ts
+++ b/src/__tests__/api/conversation-messages.test.ts
@@ -71,6 +71,7 @@ beforeEach(() => {
   testDb = drizzle(sqlite, { schema });
   migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
   mockState.sessionCookie = undefined;
+  mockGenerateTitle.mockClear();
   mockGenerateTitle.mockResolvedValue(null);
 });
 

--- a/src/__tests__/api/conversation-messages.test.ts
+++ b/src/__tests__/api/conversation-messages.test.ts
@@ -35,6 +35,14 @@ vi.mock("next/headers", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// generateTitle mock
+// ---------------------------------------------------------------------------
+const mockGenerateTitle = vi.fn();
+vi.mock("@/lib/llm/orchestrator", () => ({
+  generateTitle: (...args: unknown[]) => mockGenerateTitle(...args),
+}));
+
+// ---------------------------------------------------------------------------
 // Route handler (imported after mocks)
 // ---------------------------------------------------------------------------
 import { POST } from "@/app/api/conversations/[id]/messages/route";
@@ -63,6 +71,7 @@ beforeEach(() => {
   testDb = drizzle(sqlite, { schema });
   migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
   mockState.sessionCookie = undefined;
+  mockGenerateTitle.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -191,5 +200,58 @@ describe("POST /api/conversations/[id]/messages — success", () => {
     const body = await res.json();
     const saved = testDb.select().from(schema.messages).where(eq(schema.messages.id, body.data.id)).get();
     expect(saved!.content).toBe("padded content");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Title generation (#252)
+// ---------------------------------------------------------------------------
+describe("POST /api/conversations/[id]/messages — title generation", () => {
+  it("calls generateTitle on the first user message and returns newTitle", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid, "New Chat");
+
+    mockGenerateTitle.mockResolvedValue("Ghostbusters (1984)");
+
+    const res = await POST(
+      makeRequest({ role: "user", content: "Is Ghostbusters on Plex?" }, convId),
+      makeParams(convId),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.newTitle).toBe("Ghostbusters (1984)");
+    expect(mockGenerateTitle).toHaveBeenCalledWith(convId, "Is Ghostbusters on Plex?");
+  });
+
+  it("does not call generateTitle for assistant messages", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid, "New Chat");
+
+    const res = await POST(
+      makeRequest({ role: "assistant", content: "Yes, it is available." }, convId),
+      makeParams(convId),
+    );
+    expect(res.status).toBe(200);
+    expect(mockGenerateTitle).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.data.newTitle).toBeNull();
+  });
+
+  it("returns newTitle as null when generateTitle returns null", async () => {
+    const uid = seedUser(testDb);
+    mockState.sessionCookie = seedSession(testDb, uid);
+    const convId = seedConversation(testDb, uid, "New Chat");
+
+    mockGenerateTitle.mockResolvedValue(null);
+
+    const res = await POST(
+      makeRequest({ role: "user", content: "What is on TV tonight?" }, convId),
+      makeParams(convId),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.newTitle).toBeNull();
   });
 });

--- a/src/__tests__/api/realtime-session.test.ts
+++ b/src/__tests__/api/realtime-session.test.ts
@@ -174,6 +174,20 @@ describe("POST /api/realtime/session", () => {
     expect(sentBody.voice).toBe("alloy");
   });
 
+  it("sends turn_detection with raised threshold and silence_duration_ms to reduce VAD sensitivity (#242)", async () => {
+    const req = new Request("http://localhost/api/realtime/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ modelId: "ep1:gpt-4.1" }),
+    });
+    await POST(req);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.turn_detection.type).toBe("server_vad");
+    expect(sentBody.turn_detection.threshold).toBeGreaterThan(0.5);
+    expect(sentBody.turn_detection.silence_duration_ms).toBeGreaterThanOrEqual(800);
+  });
+
   it("returns 400 when endpoint is ChatGPT-compatible but not OpenAI (e.g. Gemini)", async () => {
     mockGetEndpointConfig.mockReturnValue({
       id: "ep-gemini",

--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -25,7 +25,7 @@ const mockPlexSearchLibrary = vi.fn();
 const mockPlexBuildThumbUrl = vi.fn((p: string) => `/api/plex/thumb?path=${encodeURIComponent(p)}`);
 vi.mock("@/lib/services/plex", () => ({
   searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
-  buildThumbUrl: (...a: unknown[]) => mockPlexBuildThumbUrl(...a),
+  buildThumbUrl: (p: string) => mockPlexBuildThumbUrl(p),
   getPlexMachineId: vi.fn(),
 }));
 

--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for the enrichment logic added in issue #253:
+ *  - overseerr_search / overseerr_discover auto-call getDetails for each result
+ *  - sonarr_search_series enriches with Plex (primary) then Overseerr (fallback)
+ *  - radarr_search_movie enriches with Plex (primary) then Overseerr via tmdbId (fallback)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Shared service mocks
+// ---------------------------------------------------------------------------
+const mockOverseerrSearch = vi.fn();
+const mockOverseerrGetDetails = vi.fn();
+const mockOverseerrDiscover = vi.fn();
+vi.mock("@/lib/services/overseerr", () => ({
+  search: (...a: unknown[]) => mockOverseerrSearch(...a),
+  getDetails: (...a: unknown[]) => mockOverseerrGetDetails(...a),
+  discover: (...a: unknown[]) => mockOverseerrDiscover(...a),
+  listRequests: vi.fn().mockResolvedValue({ results: [], hasMore: false }),
+  normalizeMediaStatus: vi.fn((s: string) => s.toLowerCase().replace(/ /g, "_")),
+}));
+
+const mockPlexSearchLibrary = vi.fn();
+const mockPlexBuildThumbUrl = vi.fn((p: string) => `/api/plex/thumb?path=${encodeURIComponent(p)}`);
+vi.mock("@/lib/services/plex", () => ({
+  searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
+  buildThumbUrl: (...a: unknown[]) => mockPlexBuildThumbUrl(...a),
+  getPlexMachineId: vi.fn(),
+  searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
+}));
+
+const mockSonarrSearchSeries = vi.fn();
+vi.mock("@/lib/services/sonarr", () => ({
+  searchSeries: (...a: unknown[]) => mockSonarrSearchSeries(...a),
+  getSeriesStatus: vi.fn(),
+  getCalendar: vi.fn(),
+  getQueue: vi.fn(),
+}));
+
+const mockRadarrSearchMovie = vi.fn();
+vi.mock("@/lib/services/radarr", () => ({
+  searchMovie: (...a: unknown[]) => mockRadarrSearchMovie(...a),
+  getMovieStatus: vi.fn(),
+  getQueue: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/config", () => ({ getConfig: vi.fn(() => "http://example.com") }));
+
+// ---------------------------------------------------------------------------
+// Default mock responses
+// ---------------------------------------------------------------------------
+const BASE_SEARCH_RESULT = {
+  overseerrId: 550,
+  overseerrMediaType: "movie",
+  title: "Fight Club",
+  year: "1999",
+  summary: "A soap salesman.",
+  rating: 8.4,
+  mediaStatus: "Available",
+  thumbPath: "https://image.tmdb.org/t/p/w300/poster.jpg",
+  seasonCount: undefined,
+};
+
+const BASE_DETAIL = {
+  overseerrId: 550,
+  overseerrMediaType: "movie",
+  title: "Fight Club",
+  year: "1999",
+  imdbId: "tt0137523",
+  thumbPath: "https://image.tmdb.org/t/p/w300/poster.jpg",
+  cast: ["Brad Pitt", "Edward Norton"],
+  genres: ["Drama"],
+  runtime: 139,
+};
+
+const TV_SEARCH_RESULT = {
+  overseerrId: 1396,
+  overseerrMediaType: "tv",
+  title: "Breaking Bad",
+  year: "2008",
+  mediaStatus: "Available",
+  thumbPath: "https://image.tmdb.org/t/p/w300/bb.jpg",
+  seasonCount: 5,
+};
+
+const TV_DETAIL = {
+  overseerrId: 1396,
+  overseerrMediaType: "tv",
+  title: "Breaking Bad",
+  year: "2008",
+  imdbId: "tt0903747",
+  thumbPath: "https://image.tmdb.org/t/p/w300/bb.jpg",
+  cast: ["Bryan Cranston", "Aaron Paul"],
+  seasonCount: 5,
+  seasons: [
+    { seasonNumber: 1, status: "Available" },
+    { seasonNumber: 2, status: "Available" },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockOverseerrSearch.mockResolvedValue({ results: [BASE_SEARCH_RESULT], hasMore: false });
+  mockOverseerrGetDetails.mockResolvedValue(BASE_DETAIL);
+  mockOverseerrDiscover.mockResolvedValue({ results: [BASE_SEARCH_RESULT], hasMore: false });
+  mockPlexSearchLibrary.mockResolvedValue({ results: [], hasMore: false });
+  mockSonarrSearchSeries.mockResolvedValue([]);
+  mockRadarrSearchMovie.mockResolvedValue([]);
+});
+
+// ===========================================================================
+// overseerr_search enrichment
+// ===========================================================================
+describe("overseerr_search — enrichment (#253)", () => {
+  it("calls getDetails for each search result and merges cast and imdbId", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    // Ensure a fresh registry
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_search", JSON.stringify({ query: "Fight Club" }));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    expect(mockOverseerrGetDetails).toHaveBeenCalledWith(550, "movie");
+    expect(results[0].cast).toEqual(["Brad Pitt", "Edward Norton"]);
+    expect(results[0].imdbId).toBe("tt0137523");
+  });
+
+  it("merges accurate seasonCount and seasons for TV results", async () => {
+    mockOverseerrSearch.mockResolvedValueOnce({ results: [TV_SEARCH_RESULT], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(TV_DETAIL);
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_search", JSON.stringify({ query: "Breaking Bad" }));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    expect(mockOverseerrGetDetails).toHaveBeenCalledWith(1396, "tv");
+    expect(results[0].seasonCount).toBe(5);
+    expect((results[0].seasons as unknown[]).length).toBe(2);
+  });
+
+  it("returns base result without enrichment if getDetails throws", async () => {
+    mockOverseerrGetDetails.mockRejectedValueOnce(new Error("Overseerr down"));
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_search", JSON.stringify({ query: "Fight Club" }));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    // Base result still returned
+    expect(results[0].title).toBe("Fight Club");
+    expect(results[0].cast).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// sonarr_search_series enrichment
+// ===========================================================================
+describe("sonarr_search_series — Plex-first enrichment (#253)", () => {
+  const SONARR_SERIES = { id: 10, title: "Breaking Bad", year: 2008, seasonCount: 5, monitored: true, tvdbId: 81189 };
+
+  it("uses Plex data when the show is found in Plex", async () => {
+    const PLEX_RESULT = {
+      title: "Breaking Bad", year: 2008, mediaType: "tv",
+      plexKey: "/library/metadata/77", thumbPath: "/library/metadata/77/thumb",
+      cast: ["Bryan Cranston"],
+    };
+    mockSonarrSearchSeries.mockResolvedValueOnce([SONARR_SERIES]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [PLEX_RESULT], hasMore: false });
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(results[0].plexKey).toBe("/library/metadata/77");
+    expect(results[0].cast).toEqual(["Bryan Cranston"]);
+    // Overseerr should NOT be called when Plex matched
+    expect(mockOverseerrSearch).not.toHaveBeenCalled();
+    expect(mockOverseerrGetDetails).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Overseerr when not found in Plex", async () => {
+    mockSonarrSearchSeries.mockResolvedValueOnce([SONARR_SERIES]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [], hasMore: false });
+    mockOverseerrSearch.mockResolvedValueOnce({ results: [TV_SEARCH_RESULT], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(TV_DETAIL);
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(results[0].overseerrId).toBe(1396);
+    expect(results[0].cast).toEqual(["Bryan Cranston", "Aaron Paul"]);
+    expect(results[0].imdbId).toBe("tt0903747");
+  });
+
+  it("returns unmodified result if both Plex and Overseerr are unavailable", async () => {
+    mockSonarrSearchSeries.mockResolvedValueOnce([SONARR_SERIES]);
+    mockPlexSearchLibrary.mockRejectedValueOnce(new Error("Plex not configured"));
+    mockOverseerrSearch.mockRejectedValueOnce(new Error("Overseerr not configured"));
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(results[0].title).toBe("Breaking Bad");
+    expect(results[0].thumbPath).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// radarr_search_movie enrichment
+// ===========================================================================
+describe("radarr_search_movie — Plex-first enrichment (#253)", () => {
+  const RADARR_MOVIE = { id: 20, title: "Fight Club", year: 1999, hasFile: false, monitored: true, tmdbId: 550 };
+
+  it("uses Plex data when the movie is found in Plex", async () => {
+    const PLEX_RESULT = {
+      title: "Fight Club", year: 1999, mediaType: "movie",
+      plexKey: "/library/metadata/42", thumbPath: "/library/metadata/42/thumb",
+      cast: ["Brad Pitt"],
+    };
+    mockRadarrSearchMovie.mockResolvedValueOnce([RADARR_MOVIE]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [PLEX_RESULT], hasMore: false });
+
+    const { registerRadarrTools } = await import("@/lib/tools/radarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerRadarrTools();
+
+    const raw = await executeTool("radarr_search_movie", JSON.stringify({ term: "Fight Club" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(results[0].plexKey).toBe("/library/metadata/42");
+    expect(results[0].cast).toEqual(["Brad Pitt"]);
+    expect(mockOverseerrGetDetails).not.toHaveBeenCalled();
+  });
+
+  it("uses Overseerr getDetails via tmdbId when not in Plex", async () => {
+    mockRadarrSearchMovie.mockResolvedValueOnce([RADARR_MOVIE]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(BASE_DETAIL);
+
+    const { registerRadarrTools } = await import("@/lib/tools/radarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerRadarrTools();
+
+    const raw = await executeTool("radarr_search_movie", JSON.stringify({ term: "Fight Club" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    // Should call getDetails with tmdbId directly (not via search)
+    expect(mockOverseerrGetDetails).toHaveBeenCalledWith(550, "movie");
+    expect(mockOverseerrSearch).not.toHaveBeenCalled();
+    expect(results[0].overseerrId).toBe(550);
+    expect(results[0].cast).toEqual(["Brad Pitt", "Edward Norton"]);
+    expect(results[0].imdbId).toBe("tt0137523");
+  });
+
+  it("falls back to Overseerr title search when tmdbId is absent", async () => {
+    const movieNoTmdb = { ...RADARR_MOVIE, tmdbId: undefined };
+    mockRadarrSearchMovie.mockResolvedValueOnce([movieNoTmdb]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [], hasMore: false });
+    mockOverseerrSearch.mockResolvedValueOnce({ results: [BASE_SEARCH_RESULT], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(BASE_DETAIL);
+
+    const { registerRadarrTools } = await import("@/lib/tools/radarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerRadarrTools();
+
+    const raw = await executeTool("radarr_search_movie", JSON.stringify({ term: "Fight Club" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+
+    expect(mockOverseerrSearch).toHaveBeenCalled();
+    expect(results[0].overseerrId).toBe(550);
+    expect(results[0].imdbId).toBe("tt0137523");
+  });
+});

--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -27,7 +27,6 @@ vi.mock("@/lib/services/plex", () => ({
   searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
   buildThumbUrl: (...a: unknown[]) => mockPlexBuildThumbUrl(...a),
   getPlexMachineId: vi.fn(),
-  searchLibrary: (...a: unknown[]) => mockPlexSearchLibrary(...a),
 }));
 
 const mockSonarrSearchSeries = vi.fn();

--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -4,6 +4,7 @@ import { getSession } from "@/lib/auth/session";
 import { getDb, schema } from "@/lib/db";
 import { eq, and } from "drizzle-orm";
 import { checkUserApiRateLimit } from "@/lib/security/api-rate-limit";
+import { generateTitle } from "@/lib/llm/orchestrator";
 import { logger } from "@/lib/logger";
 import type { ApiResponse } from "@/types/api";
 
@@ -87,7 +88,14 @@ export async function POST(
       role,
       messageId,
     });
-    return NextResponse.json<ApiResponse>({ success: true, data: { id: messageId } });
+
+    // Generate a title on the first user message (conversation still called "New Chat")
+    let newTitle: string | null = null;
+    if (role === "user" && conversation.title === "New Chat") {
+      newTitle = await generateTitle(id, content.trim());
+    }
+
+    return NextResponse.json<ApiResponse>({ success: true, data: { id: messageId, newTitle } });
   } catch (e: unknown) {
     const error = e instanceof Error ? e.message : "Database error";
     logger.error("Failed to save realtime message", { conversationId: id, userId: session.user.id, error });

--- a/src/app/api/realtime/session/route.ts
+++ b/src/app/api/realtime/session/route.ts
@@ -85,6 +85,14 @@ export async function POST(request: Request) {
         instructions,
         tools: realtimeTools,
         tool_choice: "auto",
+        // Raise VAD threshold and extend silence window so coughs / background
+        // noise don't interrupt the assistant's spoken response.
+        turn_detection: {
+          type: "server_vad",
+          threshold: 0.7,          // default 0.5 — higher = harder to trigger
+          prefix_padding_ms: 300,
+          silence_duration_ms: 800, // default 500 — longer pause required to end turn
+        },
       }),
     });
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -170,15 +170,22 @@ export default function ChatPage() {
         setActiveConversationId(convId);
       }
 
-      await fetch(`/api/conversations/${convId}/messages`, {
+      const res = await fetch(`/api/conversations/${convId}/messages`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ role, content: text }),
       });
 
+      if (res.ok) {
+        const json = await res.json();
+        if (json.data?.newTitle) {
+          updateConversationTitle(convId, json.data.newTitle);
+        }
+      }
+
       loadMessages(convId);
     },
-    [activeConversationId, createConversation, loadMessages],
+    [activeConversationId, createConversation, loadMessages, updateConversationTitle],
   );
 
   // Called by the realtime hook after each tool result is persisted to the DB.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -778,23 +778,28 @@ export default function SettingsPage() {
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div className="flex flex-wrap items-center gap-2">
                       <Input
+                        id={`ep-${ep.id}-name`}
+                        name={`ep-${ep.id}-name`}
                         value={ep.name}
                         onChange={(e) => updateEndpoint(ep.id, "name", e.target.value)}
                         className="h-8 w-full text-sm font-semibold sm:w-48"
                       />
                       <div className="flex items-center gap-3">
-                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground" htmlFor={`ep-${ep.id}-enabled`}>
                           <input
                             type="checkbox"
+                            id={`ep-${ep.id}-enabled`}
+                            name={`ep-${ep.id}-enabled`}
                             checked={ep.enabled}
                             onChange={(e) => updateEndpoint(ep.id, "enabled", e.target.checked)}
                             className="rounded"
                           />
                           Enabled
                         </label>
-                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground" htmlFor={`ep-${ep.id}-default`}>
                           <input
                             type="radio"
+                            id={`ep-${ep.id}-default`}
                             name="defaultEndpoint"
                             checked={ep.isDefault}
                             onChange={() => setDefaultEndpoint(ep.id)}
@@ -816,24 +821,30 @@ export default function SettingsPage() {
                 </CardHeader>
                 <CardContent className="space-y-3">
                   <div className="space-y-1.5">
-                    <Label>Base URL</Label>
+                    <Label htmlFor={`ep-${ep.id}-baseUrl`}>Base URL</Label>
                     <Input
+                      id={`ep-${ep.id}-baseUrl`}
+                      name={`ep-${ep.id}-baseUrl`}
                       value={ep.baseUrl}
                       onChange={(e) => updateEndpoint(ep.id, "baseUrl", e.target.value)}
                       placeholder="https://api.openai.com/v1"
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label>API Key</Label>
+                    <Label htmlFor={`ep-${ep.id}-apiKey`}>API Key</Label>
                     <Input
+                      id={`ep-${ep.id}-apiKey`}
+                      name={`ep-${ep.id}-apiKey`}
                       type="password"
                       value={ep.apiKey}
                       onChange={(e) => updateEndpoint(ep.id, "apiKey", e.target.value)}
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label>Model</Label>
+                    <Label htmlFor={`ep-${ep.id}-model`}>Model</Label>
                     <Input
+                      id={`ep-${ep.id}-model`}
+                      name={`ep-${ep.id}-model`}
                       value={ep.model}
                       onChange={(e) => updateEndpoint(ep.id, "model", e.target.value)}
                       placeholder="gpt-4.1"
@@ -843,18 +854,20 @@ export default function SettingsPage() {
                     <Label>System Prompt</Label>
                     {/* Radio: Use Default / Use Custom */}
                     <div className="flex gap-4 text-sm">
-                      <label className="flex items-center gap-1.5 cursor-pointer">
+                      <label className="flex items-center gap-1.5 cursor-pointer" htmlFor={`ep-${ep.id}-promptMode-default`}>
                         <input
                           type="radio"
+                          id={`ep-${ep.id}-promptMode-default`}
                           name={`promptMode-${ep.id}`}
                           checked={(ep.promptMode ?? "default") === "default"}
                           onChange={() => updateEndpoint(ep.id, "promptMode", "default")}
                         />
                         Use Default Prompt
                       </label>
-                      <label className="flex items-center gap-1.5 cursor-pointer">
+                      <label className="flex items-center gap-1.5 cursor-pointer" htmlFor={`ep-${ep.id}-promptMode-custom`}>
                         <input
                           type="radio"
+                          id={`ep-${ep.id}-promptMode-custom`}
                           name={`promptMode-${ep.id}`}
                           checked={ep.promptMode === "custom"}
                           onChange={() => updateEndpoint(ep.id, "promptMode", "custom")}
@@ -863,6 +876,8 @@ export default function SettingsPage() {
                       </label>
                     </div>
                     <Textarea
+                      id={`ep-${ep.id}-systemPrompt`}
+                      name={`ep-${ep.id}-systemPrompt`}
                       value={(ep.promptMode ?? "default") === "default" ? DEFAULT_SYSTEM_PROMPT : ep.systemPrompt}
                       onChange={(e) => {
                         // Auto-switch to custom when the user edits the text
@@ -901,6 +916,8 @@ export default function SettingsPage() {
                       <Label>TTS Voice</Label>
                       <div className="flex gap-2">
                         <select
+                          id={`ep-${ep.id}-ttsVoice`}
+                          name={`ep-${ep.id}-ttsVoice`}
                           value={ep.ttsVoice || "alloy"}
                           onChange={(e) => updateEndpoint(ep.id, "ttsVoice", e.target.value)}
                           className="rounded border bg-background px-2 py-1.5 text-sm flex-1"
@@ -926,8 +943,10 @@ export default function SettingsPage() {
 
                   {/* Realtime model override */}
                   <div className="space-y-1.5">
-                    <Label>Realtime Model <span className="text-muted-foreground font-normal">(optional — leave blank to disable)</span></Label>
+                    <Label htmlFor={`ep-${ep.id}-realtimeModel`}>Realtime Model <span className="text-muted-foreground font-normal">(optional — leave blank to disable)</span></Label>
                     <Input
+                      id={`ep-${ep.id}-realtimeModel`}
+                      name={`ep-${ep.id}-realtimeModel`}
                       value={ep.realtimeModel}
                       onChange={(e) => {
                         const val = e.target.value;
@@ -943,18 +962,20 @@ export default function SettingsPage() {
                     <div className="space-y-1.5">
                       <Label>Realtime System Prompt</Label>
                       <div className="flex gap-4 text-sm">
-                        <label className="flex items-center gap-1.5 cursor-pointer">
+                        <label className="flex items-center gap-1.5 cursor-pointer" htmlFor={`ep-${ep.id}-realtimePromptMode-default`}>
                           <input
                             type="radio"
+                            id={`ep-${ep.id}-realtimePromptMode-default`}
                             name={`realtimePromptMode-${ep.id}`}
                             checked={(ep.realtimePromptMode ?? "default") === "default"}
                             onChange={() => updateEndpoint(ep.id, "realtimePromptMode", "default")}
                           />
                           Use Default Realtime Prompt
                         </label>
-                        <label className="flex items-center gap-1.5 cursor-pointer">
+                        <label className="flex items-center gap-1.5 cursor-pointer" htmlFor={`ep-${ep.id}-realtimePromptMode-custom`}>
                           <input
                             type="radio"
+                            id={`ep-${ep.id}-realtimePromptMode-custom`}
                             name={`realtimePromptMode-${ep.id}`}
                             checked={ep.realtimePromptMode === "custom"}
                             onChange={() => updateEndpoint(ep.id, "realtimePromptMode", "custom")}
@@ -963,6 +984,8 @@ export default function SettingsPage() {
                         </label>
                       </div>
                       <Textarea
+                        id={`ep-${ep.id}-realtimeSystemPrompt`}
+                        name={`ep-${ep.id}-realtimeSystemPrompt`}
                         value={(ep.realtimePromptMode ?? "default") === "default" ? DEFAULT_REALTIME_SYSTEM_PROMPT : ep.realtimeSystemPrompt}
                         onChange={(e) => {
                           if ((ep.realtimePromptMode ?? "default") === "default") {
@@ -1051,8 +1074,10 @@ export default function SettingsPage() {
                 )}
 
                 <div className="space-y-1.5">
-                  <Label>URL</Label>
+                  <Label htmlFor="plex-url">URL</Label>
                   <Input
+                    id="plex-url"
+                    name="plex-url"
                     value={plexConfig.url}
                     onChange={(e) => {
                       setPlexConfig((prev) => ({ ...prev, url: e.target.value }));
@@ -1063,8 +1088,10 @@ export default function SettingsPage() {
                   <p className="text-xs text-muted-foreground">e.g. http://localhost:32400</p>
                 </div>
                 <div className="space-y-1.5">
-                  <Label>Plex Token</Label>
+                  <Label htmlFor="plex-token">Plex Token</Label>
                   <Input
+                    id="plex-token"
+                    name="plex-token"
                     type="password"
                     value={plexConfig.token}
                     onChange={(e) => {
@@ -1101,8 +1128,10 @@ export default function SettingsPage() {
                   </CardHeader>
                   <CardContent className="space-y-3">
                     <div className="space-y-1.5">
-                      <Label>URL</Label>
+                      <Label htmlFor={`arr-${svc.key}-url`}>URL</Label>
                       <Input
+                        id={`arr-${svc.key}-url`}
+                        name={`arr-${svc.key}-url`}
                         value={config.url}
                         onChange={(e) => {
                           setArrConfigs((prev) => ({
@@ -1116,8 +1145,10 @@ export default function SettingsPage() {
                       <p className="text-xs text-muted-foreground">e.g. {svc.hint}</p>
                     </div>
                     <div className="space-y-1.5">
-                      <Label>API Key</Label>
+                      <Label htmlFor={`arr-${svc.key}-apiKey`}>API Key</Label>
                       <Input
+                        id={`arr-${svc.key}-apiKey`}
+                        name={`arr-${svc.key}-apiKey`}
                         type="password"
                         value={config.apiKey}
                         onChange={(e) => {
@@ -1159,9 +1190,10 @@ export default function SettingsPage() {
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-1.5">
-                  <Label>MCP Endpoint</Label>
+                  <Label htmlFor="mcp-endpoint">MCP Endpoint</Label>
                   <div className="flex items-center gap-2">
                     <Input
+                      id="mcp-endpoint"
                       value={typeof window !== "undefined" ? `${window.location.origin}/api/mcp` : "/api/mcp"}
                       readOnly
                       className="font-mono text-sm"
@@ -1177,9 +1209,10 @@ export default function SettingsPage() {
                 </div>
 
                 <div className="space-y-1.5">
-                  <Label>{currentUser?.isAdmin ? "Admin Bearer Token" : "Your Bearer Token"}</Label>
+                  <Label htmlFor="mcp-bearer-token">{currentUser?.isAdmin ? "Admin Bearer Token" : "Your Bearer Token"}</Label>
                   <div className="flex items-center gap-2">
                     <Input
+                      id="mcp-bearer-token"
                       value={mcpToken}
                       readOnly
                       className="font-mono text-sm"
@@ -1297,7 +1330,7 @@ export default function SettingsPage() {
 
                           <div className="mt-2 flex flex-wrap gap-3">
                             {/* Role selector */}
-                            <label className="flex items-center gap-1.5 text-sm">
+                            <label className="flex items-center gap-1.5 text-sm" htmlFor={`user-${user.id}-role`}>
                               <span className="text-muted-foreground">Role:</span>
                               {user.id === masterAdminId ? (
                                 <span className="rounded border bg-background px-2 py-0.5 text-sm text-muted-foreground">
@@ -1305,6 +1338,8 @@ export default function SettingsPage() {
                                 </span>
                               ) : (
                                 <select
+                                  id={`user-${user.id}-role`}
+                                  name={`user-${user.id}-role`}
                                   value={user.isAdmin ? "admin" : "user"}
                                   onChange={(e) =>
                                     updateUser(user.id, {
@@ -1320,9 +1355,11 @@ export default function SettingsPage() {
                             </label>
 
                             {/* Default model */}
-                            <label className="flex items-center gap-1.5 text-sm">
+                            <label className="flex items-center gap-1.5 text-sm" htmlFor={`user-${user.id}-model`}>
                               <span className="text-muted-foreground">Model:</span>
                               <select
+                                id={`user-${user.id}-model`}
+                                name={`user-${user.id}-model`}
                                 value={user.defaultModel || ""}
                                 onChange={(e) =>
                                   updateUser(user.id, {
@@ -1341,9 +1378,11 @@ export default function SettingsPage() {
                             </label>
 
                             {/* Can change model */}
-                            <label className="flex items-center gap-1.5 text-sm">
+                            <label className="flex items-center gap-1.5 text-sm" htmlFor={`user-${user.id}-canChangeModel`}>
                               <input
                                 type="checkbox"
+                                id={`user-${user.id}-canChangeModel`}
+                                name={`user-${user.id}-canChangeModel`}
                                 checked={user.canChangeModel}
                                 onChange={(e) =>
                                   updateUser(user.id, {
@@ -1358,10 +1397,12 @@ export default function SettingsPage() {
                             </label>
 
                             {/* Rate limit */}
-                            <label className="flex items-center gap-1.5 text-sm">
+                            <label className="flex items-center gap-1.5 text-sm" htmlFor={`user-${user.id}-rateLimitMessages`}>
                               <span className="text-muted-foreground">Limit:</span>
                               <input
                                 type="number"
+                                id={`user-${user.id}-rateLimitMessages`}
+                                name={`user-${user.id}-rateLimitMessages`}
                                 min={1}
                                 value={user.rateLimitMessages}
                                 onChange={(e) =>
@@ -1373,6 +1414,8 @@ export default function SettingsPage() {
                               />
                               <span className="text-muted-foreground">messages per</span>
                               <select
+                                id={`user-${user.id}-rateLimitPeriod`}
+                                name={`user-${user.id}-rateLimitPeriod`}
                                 value={user.rateLimitPeriod}
                                 onChange={(e) =>
                                   updateUser(user.id, {
@@ -1458,6 +1501,7 @@ export default function SettingsPage() {
               <CardContent>
                 <div className="flex items-center gap-2">
                   <Input
+                    id="internal-api-key"
                     value={internalApiKey}
                     readOnly
                     className="font-mono text-sm"
@@ -1501,6 +1545,7 @@ export default function SettingsPage() {
                   <Label htmlFor="github-token">Personal Access Token</Label>
                   <Input
                     id="github-token"
+                    name="github-token"
                     type="password"
                     placeholder="ghp_••••••••"
                     value={githubConfig.token}
@@ -1516,6 +1561,7 @@ export default function SettingsPage() {
                     <Label htmlFor="github-owner">Repository Owner</Label>
                     <Input
                       id="github-owner"
+                      name="github-owner"
                       placeholder="chrisrothwell"
                       value={githubConfig.owner}
                       onChange={(e) => setGithubConfig((prev) => ({ ...prev, owner: e.target.value }))}
@@ -1525,6 +1571,7 @@ export default function SettingsPage() {
                     <Label htmlFor="github-repo">Repository Name</Label>
                     <Input
                       id="github-repo"
+                      name="github-repo"
                       placeholder="thinkarr"
                       value={githubConfig.repo}
                       onChange={(e) => setGithubConfig((prev) => ({ ...prev, repo: e.target.value }))}

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -137,6 +137,8 @@ export function ChatInput({
           <div className="flex items-end gap-2">
             <textarea
               ref={textareaRef}
+              id="chat-message-input"
+              name="message"
               className="flex-1 resize-none rounded-xl border border-input bg-card px-4 py-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
               placeholder="Type a message..."
               rows={1}

--- a/src/components/chat/report-issue-modal.tsx
+++ b/src/components/chat/report-issue-modal.tsx
@@ -118,6 +118,8 @@ export function ReportIssueModal({ conversationId, onClose }: ReportIssueModalPr
 
               <textarea
                 ref={textareaRef}
+                id="report-issue-description"
+                name="description"
                 className="w-full resize-none rounded-lg border border-input bg-background px-3 py-2.5 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
                 placeholder="Describe the issue you observed..."
                 rows={5}

--- a/src/lib/services/overseerr.ts
+++ b/src/lib/services/overseerr.ts
@@ -69,6 +69,7 @@ export interface OverseerrDetails {
   title: string;
   year?: string;
   imdbId?: string;
+  thumbPath?: string;            // Full TMDB poster URL — pass directly as thumbPath to display_titles
   cast?: string[];              // Top 10 cast members
   genres?: string[];
   runtime?: number;             // Movie: total runtime in minutes
@@ -185,6 +186,7 @@ export async function getDetails(id: number, mediaType: "movie" | "tv"): Promise
   const title = (detail?.title || detail?.name) as string;
   const releaseDate = (detail?.releaseDate || detail?.firstAirDate) as string | undefined;
   const episodeRuntimes = detail?.episodeRunTime as number[] | undefined;
+  const posterPath = detail?.posterPath as string | undefined;
 
   return {
     overseerrId: id,
@@ -192,6 +194,7 @@ export async function getDetails(id: number, mediaType: "movie" | "tv"): Promise
     title,
     year: releaseDate?.substring(0, 4),
     imdbId,
+    thumbPath: posterPath ? `https://image.tmdb.org/t/p/w300${posterPath}` : undefined,
     cast: cast.length > 0 ? cast : undefined,
     genres: genres.length > 0 ? genres : undefined,
     runtime: mediaType === "movie" ? (detail?.runtime as number | undefined) : undefined,
@@ -200,6 +203,20 @@ export async function getDetails(id: number, mediaType: "movie" | "tv"): Promise
     seasons: seasons.length > 0 ? seasons : undefined,
     requests: requests.length > 0 ? requests : undefined,
   };
+}
+
+/**
+ * Normalise the human-readable Overseerr mediaStatus string (returned by the
+ * search / discover endpoints) to the lowercase values expected by display_titles.
+ */
+export function normalizeMediaStatus(status: string): "available" | "partial" | "pending" | "not_requested" {
+  switch (status) {
+    case "Available": return "available";
+    case "Partially Available": return "partial";
+    case "Pending":
+    case "Processing": return "pending";
+    default: return "not_requested";
+  }
 }
 
 export interface OverseerrRequest {

--- a/src/lib/services/radarr.ts
+++ b/src/lib/services/radarr.ts
@@ -34,6 +34,12 @@ export interface RadarrMovie {
   monitored?: boolean;
   hasFile?: boolean;
   tmdbId?: number;
+  // Enrichment fields — populated by the tool handler via Plex / Overseerr lookups
+  thumbPath?: string;
+  plexKey?: string;
+  overseerrId?: number;
+  cast?: string[];
+  imdbId?: string;
 }
 
 export async function searchMovie(term: string): Promise<RadarrMovie[]> {

--- a/src/lib/services/sonarr.ts
+++ b/src/lib/services/sonarr.ts
@@ -34,6 +34,12 @@ export interface SonarrSeries {
   seasonCount?: number;
   monitored?: boolean;
   tvdbId?: number;
+  // Enrichment fields — populated by the tool handler via Plex / Overseerr lookups
+  thumbPath?: string;
+  plexKey?: string;
+  overseerrId?: number;
+  cast?: string[];
+  imdbId?: string;
 }
 
 export async function searchSeries(term: string): Promise<SonarrSeries[]> {

--- a/src/lib/tools/overseerr-tools.ts
+++ b/src/lib/tools/overseerr-tools.ts
@@ -5,23 +5,67 @@ import type { OverseerrSearchResult, OverseerrRequest, OverseerrDetails, Oversee
 
 const pageParam = z.number().int().min(1).optional().describe("Page number (1-based). Omit or use 1 for the first page. Use hasMore from the previous response to know whether a next page exists.");
 
+/** Compact seasons string "S1:available S2:pending …" from a details object. */
+function compactSeasons(detail: OverseerrDetails): string | undefined {
+  if (!detail.seasons || detail.seasons.length === 0) return undefined;
+  const statusMap: Record<string, string> = {
+    "Available": "available",
+    "Partially Available": "partial",
+    "Pending": "pending",
+    "Processing": "pending",
+  };
+  return detail.seasons
+    .map((s) => `S${s.seasonNumber}:${statusMap[s.status] ?? "not_requested"}`)
+    .join(" ");
+}
+
 export function registerOverseerrTools() {
   defineTool({
     name: "overseerr_search",
-    description: "Search for a specific movie or TV show by title on Overseerr. IMPORTANT: The query MUST be a title (e.g. 'Breaking Bad', 'The Dark Knight'). Do NOT search by year, genre, actor, or keyword — use overseerr_discover for genre/trending browsing. Returns mediaStatus, summary, rating, thumbPath, overseerrId, overseerrMediaType, and seasonCount. NOTE: seasonCount is sourced from the TMDB search API which does not include it for untracked shows — it may be 0 or missing. For TV shows always call overseerr_get_details to get the accurate season count before display_titles. Returns up to 10 results per page with a hasMore flag.",
+    description: "Search for a specific movie or TV show by title on Overseerr. IMPORTANT: The query MUST be a title (e.g. 'Breaking Bad', 'The Dark Knight'). Do NOT search by year, genre, actor, or keyword — use overseerr_discover for genre/trending browsing. Returns full details for each result including cast, imdbId, accurate seasonCount, per-season availability (seasons), mediaStatus, summary, rating, thumbPath, overseerrId, and overseerrMediaType. You can pass these fields directly to display_titles without calling overseerr_get_details first. Returns up to 10 results per page with a hasMore flag.",
     schema: z.object({
       query: z.string().describe("The exact or approximate title to search for (e.g. 'Inception', 'The Office'). Must be a title — not a year, genre, or keyword."),
       page: pageParam,
     }),
-    handler: async (args) => overseerr.search(args.query, args.page ?? 1),
+    handler: async (args) => {
+      const { results, hasMore } = await overseerr.search(args.query, args.page ?? 1);
+      // Enrich each result with cast, imdbId, accurate seasonCount, and per-season
+      // availability by calling getDetails in parallel. Non-fatal: returns the base
+      // search result if the detail fetch fails for any individual title.
+      const enriched = await Promise.all(
+        results.map(async (r) => {
+          try {
+            const mediaType = r.overseerrMediaType === "tv" ? "tv" : "movie";
+            const detail = await overseerr.getDetails(r.overseerrId, mediaType);
+            return {
+              ...r,
+              thumbPath: r.thumbPath ?? detail.thumbPath,
+              cast: detail.cast,
+              imdbId: detail.imdbId,
+              ...(mediaType === "tv" ? {
+                seasonCount: detail.seasonCount ?? r.seasonCount,
+                seasons: detail.seasons,
+              } : {}),
+            };
+          } catch {
+            return r;
+          }
+        }),
+      );
+      return { results: enriched, hasMore };
+    },
     llmSummary: (result: unknown) => {
-      const r = result as { results: OverseerrSearchResult[]; hasMore: boolean };
+      const r = result as { results: (OverseerrSearchResult & { cast?: string[]; imdbId?: string; seasons?: overseerr.OverseerrSeasonStatus[] })[]; hasMore: boolean };
       return {
-        // thumbPath preserved: the LLM needs the poster URL to pass to
-        // display_titles in follow-up turns without re-searching.
-        // summary stripped: 300 chars × 10 results = main token saving.
-        results: r.results.map(({ overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath }) => ({
+        results: r.results.map(({ overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath, cast, imdbId, seasons }) => ({
           overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath,
+          ...(cast && cast.length > 0 ? { cast: cast.slice(0, 3) } : {}),
+          ...(imdbId ? { imdbId } : {}),
+          // Compact seasons string for TV to preserve per-season status without
+          // bloating history with full objects.
+          ...(seasons && seasons.length > 0
+            ? { seasons: seasons.map((s) => `S${s.seasonNumber}:${s.status.toLowerCase().replace(/ /g, "_")}`).join(" ") }
+            : {}),
         })),
         hasMore: r.hasMore,
       };
@@ -30,7 +74,7 @@ export function registerOverseerrTools() {
 
   defineTool({
     name: "overseerr_get_details",
-    description: "Get full details for a specific movie or TV show from Overseerr. For TV shows this MUST be called before display_titles — it returns the accurate seasonCount from TMDB (the search result's seasonCount is unreliable) and a compact per-season availability string needed to set correct mediaStatus on each season card. Also returns cast (top 10), imdbId, genres, and runtime for all media types.",
+    description: "Get full details for a specific movie or TV show from Overseerr. NOTE: overseerr_search already returns cast, imdbId, seasonCount, per-season availability, and thumbPath — you do not need to call this after a search. Use this tool only when you need additional fields not returned by search (genres, runtime, episodeRuntime, full request history) or when you have an overseerrId without a prior search result.",
     schema: z.object({
       id: z.number().int().describe("Overseerr media ID (overseerrId from overseerr_search results)"),
       mediaType: z.enum(["movie", "tv"]).describe("Media type"),
@@ -44,18 +88,7 @@ export function registerOverseerrTools() {
      *  Request history dropped entirely (not needed after initial display). */
     llmSummary: (result: unknown) => {
       const r = result as OverseerrDetails;
-      // Map Overseerr status strings to display_titles mediaStatus values
-      const statusMap: Record<string, string> = {
-        "Available": "available",
-        "Partially Available": "partial",
-        "Pending": "pending",
-        "Processing": "pending",
-      };
-      const seasonsCompact = r.seasons && r.seasons.length > 0
-        ? r.seasons
-            .map((s) => `S${s.seasonNumber}:${statusMap[s.status] ?? "not_requested"}`)
-            .join(" ")
-        : undefined;
+      const seasonsCompact = compactSeasons(r);
       return {
         overseerrId: r.overseerrId,
         overseerrMediaType: r.overseerrMediaType,
@@ -92,19 +125,47 @@ export function registerOverseerrTools() {
 
   defineTool({
     name: "overseerr_discover",
-    description: "Discover movies or TV shows from Overseerr/TMDB without a specific title. Use this when the user asks for trending content, popular titles, upcoming releases, or wants to browse by genre (e.g. 'what movies are trending', 'show me upcoming movies', 'find some action movies'). For TV shows always call overseerr_get_details before display_titles. Returns up to 10 results per page with a hasMore flag.",
+    description: "Discover movies or TV shows from Overseerr/TMDB without a specific title. Use this when the user asks for trending content, popular titles, upcoming releases, or wants to browse by genre (e.g. 'what movies are trending', 'show me upcoming movies', 'find some action movies'). Returns full details for each result including cast, imdbId, accurate seasonCount, per-season availability, mediaStatus, summary, rating, thumbPath, overseerrId, and overseerrMediaType — pass directly to display_titles. Returns up to 10 results per page with a hasMore flag.",
     schema: z.object({
       mediaType: z.enum(["movie", "tv"]).describe("Whether to discover movies or TV shows"),
       genre: z.string().optional().describe("Genre name to filter by (e.g. 'Action', 'Comedy', 'Drama'). Omit for general trending results."),
       category: z.enum(["trending", "upcoming"]).optional().describe("'trending' for popular titles (default), 'upcoming' for titles not yet released"),
       page: pageParam,
     }),
-    handler: async (args) => overseerr.discover(args.mediaType, args.genre, args.category ?? "trending", args.page ?? 1),
+    handler: async (args) => {
+      const { results, hasMore } = await overseerr.discover(args.mediaType, args.genre, args.category ?? "trending", args.page ?? 1);
+      const enriched = await Promise.all(
+        results.map(async (r) => {
+          try {
+            const mediaType = r.overseerrMediaType === "tv" ? "tv" : "movie";
+            const detail = await overseerr.getDetails(r.overseerrId, mediaType);
+            return {
+              ...r,
+              thumbPath: r.thumbPath ?? detail.thumbPath,
+              cast: detail.cast,
+              imdbId: detail.imdbId,
+              ...(mediaType === "tv" ? {
+                seasonCount: detail.seasonCount ?? r.seasonCount,
+                seasons: detail.seasons,
+              } : {}),
+            };
+          } catch {
+            return r;
+          }
+        }),
+      );
+      return { results: enriched, hasMore };
+    },
     llmSummary: (result: unknown) => {
-      const r = result as { results: OverseerrDiscoverResult[]; hasMore: boolean };
+      const r = result as { results: (OverseerrDiscoverResult & { cast?: string[]; imdbId?: string; seasons?: overseerr.OverseerrSeasonStatus[] })[]; hasMore: boolean };
       return {
-        results: r.results.map(({ overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath }) => ({
+        results: r.results.map(({ overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath, cast, imdbId, seasons }) => ({
           overseerrId, overseerrMediaType, title, year, rating, mediaStatus, seasonCount, thumbPath,
+          ...(cast && cast.length > 0 ? { cast: cast.slice(0, 3) } : {}),
+          ...(imdbId ? { imdbId } : {}),
+          ...(seasons && seasons.length > 0
+            ? { seasons: seasons.map((s) => `S${s.seasonNumber}:${s.status.toLowerCase().replace(/ /g, "_")}`).join(" ") }
+            : {}),
         })),
         hasMore: r.hasMore,
       };

--- a/src/lib/tools/radarr-tools.ts
+++ b/src/lib/tools/radarr-tools.ts
@@ -1,18 +1,90 @@
 import { z } from "zod";
 import { defineTool } from "./registry";
 import * as radarr from "@/lib/services/radarr";
+import * as plex from "@/lib/services/plex";
+import * as overseerr from "@/lib/services/overseerr";
 import type { RadarrMovie } from "@/lib/services/radarr";
+
+/**
+ * Enrich a single Radarr movie result with poster, cast, and overseerrId by:
+ * 1. Checking Plex first (gives plexKey, thumbPath, cast — best quality)
+ * 2. Falling back to Overseerr:
+ *    - If tmdbId is available, call getDetails directly (more reliable than title search)
+ *    - Otherwise, search by title and use the first movie match
+ * Non-fatal: returns the unmodified movie if both lookups fail.
+ */
+async function enrichRadarrMovie(m: RadarrMovie): Promise<RadarrMovie> {
+  // --- Plex check ---
+  try {
+    const { results } = await plex.searchLibrary(m.title);
+    const titleLower = m.title.toLowerCase();
+    const match = results.find(
+      (r) =>
+        r.mediaType === "movie" &&
+        r.title.toLowerCase() === titleLower &&
+        (!m.year || !r.year || r.year === m.year),
+    );
+    if (match) {
+      return {
+        ...m,
+        thumbPath: match.thumbPath ? plex.buildThumbUrl(match.thumbPath) : undefined,
+        plexKey: match.plexKey,
+        cast: match.cast,
+      };
+    }
+  } catch { /* Plex not configured or unavailable */ }
+
+  // --- Overseerr fallback ---
+  try {
+    if (m.tmdbId) {
+      // Direct lookup using tmdbId — more reliable than a title search
+      const detail = await overseerr.getDetails(m.tmdbId, "movie");
+      return {
+        ...m,
+        thumbPath: detail.thumbPath,
+        overseerrId: m.tmdbId,
+        cast: detail.cast,
+        imdbId: detail.imdbId,
+      };
+    }
+
+    // No tmdbId — fall back to a title search
+    const { results: ovrResults } = await overseerr.search(m.title, 1);
+    const titleLower = m.title.toLowerCase();
+    const match = ovrResults.find(
+      (r) =>
+        r.overseerrMediaType === "movie" &&
+        r.title.toLowerCase() === titleLower &&
+        (!m.year || !r.year || r.year === String(m.year)),
+    );
+    if (match) {
+      const detail = await overseerr.getDetails(match.overseerrId, "movie");
+      return {
+        ...m,
+        thumbPath: match.thumbPath ?? detail.thumbPath,
+        overseerrId: match.overseerrId,
+        cast: detail.cast,
+        imdbId: detail.imdbId,
+      };
+    }
+  } catch { /* Overseerr not configured or unavailable */ }
+
+  return m;
+}
 
 export function registerRadarrTools() {
   defineTool({
     name: "radarr_search_movie",
-    description: "Search for movies by title. Returns results from Radarr's lookup including whether the movie is in the library, downloaded, and monitored.",
+    description: "Search for movies by title. Returns results from Radarr's lookup including whether the movie is in the library, downloaded, and monitored. Each result is automatically enriched with thumbPath (poster), plexKey (if available in Plex), overseerrId, cast, and imdbId — pass these directly to display_titles. For mediaStatus: use 'available' if the movie is in Plex (plexKey present) or hasFile is true, 'pending' if monitored in Radarr but not downloaded, otherwise 'not_requested'.",
     schema: z.object({
       term: z.string().describe("Search term (movie title)"),
     }),
-    handler: async (args) => radarr.searchMovie(args.term),
+    handler: async (args) => {
+      const results = await radarr.searchMovie(args.term);
+      return Promise.all(results.map(enrichRadarrMovie));
+    },
     /** Strip overview from history — 200-char overview × 10 results is noise once the
-     *  LLM has already acted on the search. Keep all identity and status fields. */
+     *  LLM has already acted on the search. Keep all identity, status, and enrichment fields. */
     llmSummary: (result: unknown) => {
       return (result as RadarrMovie[]).map(
         ({ overview: _ov, ...rest }) => rest,

--- a/src/lib/tools/sonarr-tools.ts
+++ b/src/lib/tools/sonarr-tools.ts
@@ -1,18 +1,76 @@
 import { z } from "zod";
 import { defineTool } from "./registry";
 import * as sonarr from "@/lib/services/sonarr";
+import * as plex from "@/lib/services/plex";
+import * as overseerr from "@/lib/services/overseerr";
 import type { SonarrSeries, SonarrSeriesStatus } from "@/lib/services/sonarr";
+
+/**
+ * Enrich a single Sonarr series result with poster, cast, and overseerrId by:
+ * 1. Checking Plex first (gives plexKey, thumbPath, cast — best quality)
+ * 2. Falling back to Overseerr search + getDetails (gives overseerrId, thumbPath, cast, imdbId)
+ * Non-fatal: returns the unmodified series if both lookups fail.
+ */
+async function enrichSonarrSeries(s: SonarrSeries): Promise<SonarrSeries> {
+  // --- Plex check ---
+  try {
+    const { results } = await plex.searchLibrary(s.title);
+    const titleLower = s.title.toLowerCase();
+    const match = results.find(
+      (r) =>
+        r.mediaType === "tv" &&
+        r.title.toLowerCase() === titleLower &&
+        (!s.year || !r.year || r.year === s.year),
+    );
+    if (match) {
+      return {
+        ...s,
+        thumbPath: match.thumbPath ? plex.buildThumbUrl(match.thumbPath) : undefined,
+        plexKey: match.plexKey,
+        cast: match.cast,
+      };
+    }
+  } catch { /* Plex not configured or unavailable */ }
+
+  // --- Overseerr fallback ---
+  try {
+    const { results: ovrResults } = await overseerr.search(s.title, 1);
+    const titleLower = s.title.toLowerCase();
+    const match = ovrResults.find(
+      (r) =>
+        r.overseerrMediaType === "tv" &&
+        r.title.toLowerCase() === titleLower &&
+        (!s.year || !r.year || r.year === String(s.year)),
+    );
+    if (match) {
+      // getDetails gives accurate cast and imdbId; thumbPath is already on the search result
+      const detail = await overseerr.getDetails(match.overseerrId, "tv");
+      return {
+        ...s,
+        thumbPath: match.thumbPath ?? detail.thumbPath,
+        overseerrId: match.overseerrId,
+        cast: detail.cast,
+        imdbId: detail.imdbId,
+      };
+    }
+  } catch { /* Overseerr not configured or unavailable */ }
+
+  return s;
+}
 
 export function registerSonarrTools() {
   defineTool({
     name: "sonarr_search_series",
-    description: "Search for a TV series by title. Returns results from Sonarr's lookup including monitored status, season count, and whether it's in the Sonarr library.",
+    description: "Search for a TV series by title. Returns results from Sonarr's lookup including monitored status, season count, and whether it's in the Sonarr library. Each result is automatically enriched with thumbPath (poster), plexKey (if available in Plex), overseerrId (if found in Overseerr), cast, and imdbId — pass these directly to display_titles. For mediaStatus: use 'available' if the show is in Plex (plexKey present), 'pending' if monitored in Sonarr but plexKey absent, or derive from the Overseerr mediaStatus field if present.",
     schema: z.object({
       term: z.string().describe("Search term (TV show title)"),
     }),
-    handler: async (args) => sonarr.searchSeries(args.term),
+    handler: async (args) => {
+      const results = await sonarr.searchSeries(args.term);
+      return Promise.all(results.map(enrichSonarrSeries));
+    },
     /** Strip overview from history — 200-char overview × 10 results is noise once the
-     *  LLM has already acted on the search. Keep all identity and status fields. */
+     *  LLM has already acted on the search. Keep all identity, status, and enrichment fields. */
     llmSummary: (result: unknown) => {
       return (result as SonarrSeries[]).map(
         ({ overview: _ov, ...rest }) => rest,


### PR DESCRIPTION
## Changes in this release

- **#236** — Add missing `id`/`name` attributes to all form fields (settings, chat input, report modal)
- **#242** — Raise realtime VAD threshold and silence duration to reduce false triggers from background noise
- **#252** — Realtime conversations now generate a chat name after the first turn
- **#253** — `overseerr_search`, `overseerr_discover`, `sonarr_search_series`, and `radarr_search_movie` now auto-enrich results with cast, imdbId, thumbPath, and season data so `display_titles` works without a separate details call

## Pre-release checklist

- [x] Version bumped: `1.1.4` → `1.1.5-beta.1` (PR #256)
- [x] `npm run security:audit` — passes (0 HIGH/CRITICAL)
- [ ] Semgrep SAST — run locally from WSL2 before merging
- [ ] Trivy Docker image scan — run locally from WSL2 before merging
- [ ] CI passes on this PR

https://claude.ai/code/session_01PFpjQXHBtNVe3CJNT5NGHF