### PR TITLE
Fix Welsh TTS misdetection, overseerr_list_requests inlining, and configurable transcription language (#258)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2060,3 +2060,41 @@ Fixed by passing `language: "en"` in the `input_audio_transcription` session upd
 | File | Change |
 |------|--------|
 | `src/hooks/use-realtime-chat.ts` | Added `language: "en"` to `input_audio_transcription` in the `session.update` event sent on `dc.onopen` |
+
+---
+
+### Phase N+18 (addendum 2) — Configurable transcription language per endpoint (#258)
+
+Replaced the hardcoded `language: "en"` Whisper setting with a per-endpoint **Transcription Language** option in Settings. Defaults to "Auto-detect" so existing users are unaffected; users who experience language misdetection (e.g. Welsh) can pin it to English.
+
+#### What changed
+
+**Settings page** — A "Transcription Language" dropdown appears under each LLM endpoint when Voice (Whisper) or Realtime capability is detected. Options: Auto-detect, English, Spanish, French, German, Italian, Portuguese, Dutch, Japanese, Korean, Chinese, Russian, Arabic, Hindi, Polish, Welsh. Stored as `transcriptionLanguage` in the endpoint JSON alongside `ttsVoice`.
+
+**Data flow** — `transcriptionLanguage` propagates from settings through:
+- `LlmEndpointConfig` (client.ts) → `LlmEndpoint` (settings/route.ts) → `ModelOption` (models/route.ts) → chat page `endpointCaps` → `ChatInput` → `VoiceConversation` / `RealtimeChat`
+
+**Voice mode** (`use-voice-input` + `/api/voice/transcribe`) — `language` is appended to the FormData; the route passes it to `client.audio.transcriptions.create()` when non-empty and not "auto".
+
+**Realtime mode** (`use-realtime-chat`) — `transcriptionLanguage` is now an option; `dc.onopen` sends it in the `session.update` `input_audio_transcription` config. "auto" omits the parameter (Whisper auto-detect behaviour preserved).
+
+**Default prompts** — Removed the hardcoded "Always respond in English" instruction added earlier in this phase; language handling is now fully at the Whisper layer rather than the prompt layer.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/llm/client.ts` | Added `transcriptionLanguage?: string` to `LlmEndpointConfig` |
+| `src/app/api/settings/route.ts` | Added `transcriptionLanguage: string` to `LlmEndpoint`; default `"auto"` in legacy migration |
+| `src/app/api/models/route.ts` | Added `transcriptionLanguage` to `ModelOption` and `LlmEndpoint`; exposed with default `"auto"` |
+| `src/app/settings/page.tsx` | Added `transcriptionLanguage` to `LocalEndpoint` type, endpoint defaults, and UI selector |
+| `src/hooks/use-voice-input.ts` | `stopAndTranscribe` now accepts optional `language` param; appends to FormData when set |
+| `src/components/chat/voice-input.tsx` | Added `transcriptionLanguage` prop; passed to `stopAndTranscribe` |
+| `src/components/chat/voice-conversation.tsx` | Added `transcriptionLanguage` prop; passed to `stopAndTranscribe` |
+| `src/hooks/use-realtime-chat.ts` | Added `transcriptionLanguage` option; applied in `dc.onopen` `session.update` |
+| `src/components/chat/realtime-chat.tsx` | Added `transcriptionLanguage` prop; forwarded to hook |
+| `src/components/chat/chat-input.tsx` | Added `transcriptionLanguage` prop; forwarded to `VoiceConversation` and `RealtimeChat` |
+| `src/app/chat/page.tsx` | Added `transcriptionLanguage` to `endpointCaps` state; passed to `ChatInput` |
+| `src/app/api/voice/transcribe/route.ts` | Reads `language` from FormData; passes to Whisper when not "auto" |
+| `src/lib/llm/default-prompt.ts` | Removed hardcoded English-only instructions from both default prompts |
+| `src/__tests__/api/voice-transcribe.test.ts` | Added 3 tests: language passed, "auto" omitted, omitted field omitted |

--- a/PLAN.md
+++ b/PLAN.md
@@ -2046,3 +2046,17 @@ Fixed by applying the same `getDetails` enrichment pattern already used in `over
 | `src/lib/llm/default-prompt.ts` | Added English-only instruction to both `DEFAULT_SYSTEM_PROMPT` and `DEFAULT_REALTIME_SYSTEM_PROMPT` |
 | `src/lib/tools/overseerr-tools.ts` | `overseerr_list_requests` handler: parallel `getDetails` enrichment for `thumbPath`, `seasons`, `seasonCount`; updated `llmSummary` to include `thumbPath` and compact seasons |
 | `src/__tests__/lib/tool-enrichment.test.ts` | Added 4 tests for `overseerr_list_requests` enrichment; updated `listRequests` mock to be configurable per-test |
+
+---
+
+### Phase N+18 (addendum) — Fix Whisper language misdetection (#258)
+
+The root cause of the Welsh TTS issue was Whisper's language auto-detection, not the model's response language. Whisper misidentified English speech as Welsh (especially on short/ambiguous utterances) and transcribed it in Welsh, causing the Realtime model to respond in Welsh.
+
+Fixed by passing `language: "en"` in the `input_audio_transcription` session update sent via the WebRTC data channel on connect. This locks Whisper to English transcription and prevents misdetection entirely. The English-only system prompt instruction (added earlier in this phase) remains as a secondary defence.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/hooks/use-realtime-chat.ts` | Added `language: "en"` to `input_audio_transcription` in the `session.update` event sent on `dc.onopen` |

--- a/PLAN.md
+++ b/PLAN.md
@@ -2019,3 +2019,30 @@ Added `enrichRadarrMovie(m)` helper in `radarr-tools.ts` using the same Plex-fir
 | `src/lib/services/radarr.ts` | Added enrichment fields to `RadarrMovie` interface |
 | `src/lib/tools/radarr-tools.ts` | Added `enrichRadarrMovie` helper; `radarr_search_movie` handler calls it; updated description and `llmSummary` |
 | `src/__tests__/lib/tool-enrichment.test.ts` | New: unit tests for all enrichment paths (Plex match, Overseerr fallback, tmdbId direct lookup, graceful degradation) |
+
+
+---
+
+### Phase N+18 — Bug fixes: Welsh TTS and overseerr_list_requests inlining (#258)
+
+Two bugs reported via user feedback in issue #258 from a real conversation session.
+
+#### Bug 1: TTS/voice responding in Welsh
+
+The Realtime API model detects the spoken/typed language and responds in kind. When a user accidentally typed in Welsh, the model began responding in Welsh, causing confusion.
+
+Fixed by adding an explicit English-only instruction to both `DEFAULT_SYSTEM_PROMPT` and `DEFAULT_REALTIME_SYSTEM_PROMPT` in `default-prompt.ts`. The instruction tells the model to always respond in English and to politely inform the user if they speak another language.
+
+#### Bug 2: overseerr_list_requests not inlining full details on title cards
+
+The `overseerr_list_requests` tool returned minimal fields (no `thumbPath`, no per-season `seasons` data) because the Overseerr `/request` API endpoint does not reliably include `posterPath` in the media sub-object. As a result, title cards rendered from list-requests had no poster image and missing season information.
+
+Fixed by applying the same `getDetails` enrichment pattern already used in `overseerr_search` and `overseerr_discover`: the tool handler now calls `overseerr.getDetails()` in parallel for each result (up to 10 per page), merging `thumbPath` and for TV shows: `seasons` and `seasonCount`. Individual failures are non-fatal. The `llmSummary` was also updated to include `thumbPath` and compact `seasons` string so history-compressed turns retain the poster and season data.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `src/lib/llm/default-prompt.ts` | Added English-only instruction to both `DEFAULT_SYSTEM_PROMPT` and `DEFAULT_REALTIME_SYSTEM_PROMPT` |
+| `src/lib/tools/overseerr-tools.ts` | `overseerr_list_requests` handler: parallel `getDetails` enrichment for `thumbPath`, `seasons`, `seasonCount`; updated `llmSummary` to include `thumbPath` and compact seasons |
+| `src/__tests__/lib/tool-enrichment.test.ts` | Added 4 tests for `overseerr_list_requests` enrichment; updated `listRequests` mock to be configurable per-test |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.4-beta.4",
+  "version": "1.1.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.4-beta.4",
+      "version": "1.1.5-beta.1",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "clsx": "^2.1.1",

--- a/src/__tests__/api/voice-transcribe.test.ts
+++ b/src/__tests__/api/voice-transcribe.test.ts
@@ -54,10 +54,11 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function makeFormData(audio?: Blob, modelId = "ep1:gpt-4.1"): FormData {
+function makeFormData(audio?: Blob, modelId = "ep1:gpt-4.1", language?: string): FormData {
   const fd = new FormData();
   if (audio) fd.append("audio", audio, "recording.webm");
   fd.append("modelId", modelId);
+  if (language) fd.append("language", language);
   return fd;
 }
 
@@ -95,6 +96,36 @@ describe("POST /api/voice/transcribe", () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.data.transcript).toBe("hello world");
+  });
+
+  it("passes language to Whisper when a specific language is set", async () => {
+    const req = new Request("http://localhost/api/voice/transcribe", {
+      method: "POST",
+      body: makeFormData(new Blob(["audio"], { type: "audio/webm" }), "ep1:gpt-4.1", "en"),
+    });
+    await POST(req);
+    const callArgs = mockTranscriptionsCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArgs.language).toBe("en");
+  });
+
+  it("does not pass language to Whisper when language is 'auto'", async () => {
+    const req = new Request("http://localhost/api/voice/transcribe", {
+      method: "POST",
+      body: makeFormData(new Blob(["audio"], { type: "audio/webm" }), "ep1:gpt-4.1", "auto"),
+    });
+    await POST(req);
+    const callArgs = mockTranscriptionsCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArgs.language).toBeUndefined();
+  });
+
+  it("does not pass language to Whisper when language is omitted", async () => {
+    const req = new Request("http://localhost/api/voice/transcribe", {
+      method: "POST",
+      body: makeFormData(new Blob(["audio"], { type: "audio/webm" })),
+    });
+    await POST(req);
+    const callArgs = mockTranscriptionsCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArgs.language).toBeUndefined();
   });
 
   it("returns 500 when transcription API throws", async () => {

--- a/src/__tests__/lib/token-reduction.test.ts
+++ b/src/__tests__/lib/token-reduction.test.ts
@@ -509,7 +509,7 @@ describe("display_titles tool call arg compression", () => {
 describe("overseerr_list_requests llmSummary", () => {
   beforeEach(() => { vi.resetModules(); });
 
-  it("strips thumbPath, id, tmdbId, requestedAt; keeps display_titles-relevant fields", async () => {
+  it("strips id, tmdbId, requestedAt; keeps display_titles-relevant fields including thumbPath and seasons", async () => {
     const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
     const { getToolLlmContent } = await import("@/lib/tools/registry");
 
@@ -541,7 +541,8 @@ describe("overseerr_list_requests llmSummary", () => {
     expect(item.mediaStatus).toBe("pending");
     expect(item.requestedBy).toBe("alice");
     expect(item.overseerrId).toBe(550);
-    expect(item).not.toHaveProperty("thumbPath");
+    // thumbPath is now preserved — needed for follow-up display_titles calls without re-fetching
+    expect(item.thumbPath).toBe("https://image.tmdb.org/t/p/w300/poster.jpg");
     expect(item).not.toHaveProperty("requestedAt");
     expect(item).not.toHaveProperty("tmdbId");
     expect(item).not.toHaveProperty("id");

--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -1,6 +1,7 @@
 /**
  * Unit tests for the enrichment logic added in issue #253:
  *  - overseerr_search / overseerr_discover auto-call getDetails for each result
+ *  - overseerr_list_requests enriches with getDetails for thumbPath and seasons (#258)
  *  - sonarr_search_series enriches with Plex (primary) then Overseerr (fallback)
  *  - radarr_search_movie enriches with Plex (primary) then Overseerr via tmdbId (fallback)
  */
@@ -13,11 +14,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockOverseerrSearch = vi.fn();
 const mockOverseerrGetDetails = vi.fn();
 const mockOverseerrDiscover = vi.fn();
+const mockOverseerrListRequests = vi.fn();
 vi.mock("@/lib/services/overseerr", () => ({
   search: (...a: unknown[]) => mockOverseerrSearch(...a),
   getDetails: (...a: unknown[]) => mockOverseerrGetDetails(...a),
   discover: (...a: unknown[]) => mockOverseerrDiscover(...a),
-  listRequests: vi.fn().mockResolvedValue({ results: [], hasMore: false }),
+  listRequests: (...a: unknown[]) => mockOverseerrListRequests(...a),
   normalizeMediaStatus: vi.fn((s: string) => s.toLowerCase().replace(/ /g, "_")),
 }));
 
@@ -106,6 +108,7 @@ beforeEach(() => {
   mockOverseerrSearch.mockResolvedValue({ results: [BASE_SEARCH_RESULT], hasMore: false });
   mockOverseerrGetDetails.mockResolvedValue(BASE_DETAIL);
   mockOverseerrDiscover.mockResolvedValue({ results: [BASE_SEARCH_RESULT], hasMore: false });
+  mockOverseerrListRequests.mockResolvedValue({ results: [], hasMore: false });
   mockPlexSearchLibrary.mockResolvedValue({ results: [], hasMore: false });
   mockSonarrSearchSeries.mockResolvedValue([]);
   mockRadarrSearchMovie.mockResolvedValue([]);
@@ -298,5 +301,99 @@ describe("radarr_search_movie — Plex-first enrichment (#253)", () => {
     expect(mockOverseerrSearch).toHaveBeenCalled();
     expect(results[0].overseerrId).toBe(550);
     expect(results[0].imdbId).toBe("tt0137523");
+  });
+});
+
+// ===========================================================================
+// overseerr_list_requests enrichment (#258)
+// ===========================================================================
+describe("overseerr_list_requests — enrichment with getDetails (#258)", () => {
+  const MOVIE_REQUEST = {
+    id: 706,
+    mediaType: "movie",
+    title: "Fight Club",
+    year: "1999",
+    status: "Approved",
+    mediaStatus: "pending",
+    requestedBy: "alice",
+    requestedAt: "2026-01-01T00:00:00.000Z",
+    overseerrId: 550,
+    tmdbId: 550,
+  };
+
+  const TV_REQUEST = {
+    id: 707,
+    mediaType: "tv",
+    title: "Breaking Bad",
+    year: "2008",
+    status: "Approved",
+    mediaStatus: "pending",
+    requestedBy: "bob",
+    requestedAt: "2026-01-02T00:00:00.000Z",
+    overseerrId: 1396,
+    tmdbId: 1396,
+    seasonsRequested: [1],
+  };
+
+  it("calls getDetails for each request result and merges thumbPath", async () => {
+    mockOverseerrListRequests.mockResolvedValueOnce({ results: [MOVIE_REQUEST], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(BASE_DETAIL);
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_list_requests", JSON.stringify({}));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    expect(mockOverseerrGetDetails).toHaveBeenCalledWith(550, "movie");
+    expect(results[0].thumbPath).toBe("https://image.tmdb.org/t/p/w300/poster.jpg");
+  });
+
+  it("merges seasons and seasonCount for TV request results", async () => {
+    mockOverseerrListRequests.mockResolvedValueOnce({ results: [TV_REQUEST], hasMore: false });
+    mockOverseerrGetDetails.mockResolvedValueOnce(TV_DETAIL);
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_list_requests", JSON.stringify({}));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    expect(mockOverseerrGetDetails).toHaveBeenCalledWith(1396, "tv");
+    expect(results[0].seasonCount).toBe(5);
+    expect((results[0].seasons as unknown[]).length).toBe(2);
+  });
+
+  it("skips enrichment for requests with no overseerrId", async () => {
+    const requestNoId = { ...MOVIE_REQUEST, overseerrId: undefined };
+    mockOverseerrListRequests.mockResolvedValueOnce({ results: [requestNoId], hasMore: false });
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    await executeTool("overseerr_list_requests", JSON.stringify({}));
+    expect(mockOverseerrGetDetails).not.toHaveBeenCalled();
+  });
+
+  it("returns base result without enrichment if getDetails throws", async () => {
+    mockOverseerrListRequests.mockResolvedValueOnce({ results: [MOVIE_REQUEST], hasMore: false });
+    mockOverseerrGetDetails.mockRejectedValueOnce(new Error("Overseerr down"));
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_list_requests", JSON.stringify({}));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+
+    expect(results[0].title).toBe("Fight Club");
+    expect(results[0].thumbPath).toBeUndefined();
   });
 });

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -12,6 +12,7 @@ export interface ModelOption {
   supportsVoice: boolean;
   supportsTts: boolean;
   ttsVoice: string;
+  transcriptionLanguage: string;
   supportsRealtime: boolean;
 }
 
@@ -25,6 +26,7 @@ interface LlmEndpoint {
   supportsVoice?: boolean;
   supportsTts?: boolean;
   ttsVoice?: string;
+  transcriptionLanguage?: string;
   supportsRealtime?: boolean;
 }
 
@@ -72,6 +74,7 @@ export async function GET() {
       supportsVoice: ep.supportsVoice ?? false,
       supportsTts: ep.supportsTts ?? false,
       ttsVoice: ep.ttsVoice ?? "alloy",
+      transcriptionLanguage: ep.transcriptionLanguage ?? "auto",
       supportsRealtime: ep.supportsRealtime ?? false,
     }));
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -19,6 +19,7 @@ export interface LlmEndpoint {
   supportsRealtime: boolean;
   realtimeModel: string;
   realtimeSystemPrompt: string;
+  transcriptionLanguage: string;
 }
 
 function getLlmEndpoints(): LlmEndpoint[] {
@@ -50,6 +51,7 @@ function getLlmEndpoints(): LlmEndpoint[] {
         supportsRealtime: false,
         realtimeModel: "",
         realtimeSystemPrompt: "",
+        transcriptionLanguage: "auto",
       },
     ];
   }

--- a/src/app/api/voice/transcribe/route.ts
+++ b/src/app/api/voice/transcribe/route.ts
@@ -33,6 +33,9 @@ export async function POST(request: Request) {
 
   const audioFile = formData.get("audio");
   const modelId = (formData.get("modelId") as string) || "";
+  const languageRaw = (formData.get("language") as string) || "";
+  // Only pass a language hint when one is explicitly set (non-empty, not "auto")
+  const language = languageRaw && languageRaw !== "auto" ? languageRaw : undefined;
 
   if (!audioFile || !(audioFile instanceof Blob)) {
     return NextResponse.json<ApiResponse>(
@@ -48,9 +51,10 @@ export async function POST(request: Request) {
     const transcription = await client.audio.transcriptions.create({
       file,
       model: "whisper-1",
+      ...(language ? { language } : {}),
     });
 
-    logger.info("VOICE_TRANSCRIBE", { userId: session.user.id, chars: transcription.text.length });
+    logger.info("VOICE_TRANSCRIBE", { userId: session.user.id, chars: transcription.text.length, language: language ?? "auto" });
 
     return NextResponse.json<ApiResponse>({
       success: true,

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -42,6 +42,7 @@ export default function ChatPage() {
     supportsVoice: false,
     supportsRealtime: false,
     ttsVoice: "alloy",
+    transcriptionLanguage: "auto",
   });
   const [reportIssueOpen, setReportIssueOpen] = useState(false);
 
@@ -94,6 +95,7 @@ export default function ChatPage() {
               supportsVoice: defaultOpt.supportsVoice ?? false,
               supportsRealtime: defaultOpt.supportsRealtime ?? false,
               ttsVoice: defaultOpt.ttsVoice ?? "alloy",
+              transcriptionLanguage: defaultOpt.transcriptionLanguage ?? "auto",
             });
           }
         }
@@ -241,6 +243,7 @@ export default function ChatPage() {
                       supportsVoice: opt?.supportsVoice ?? false,
                       supportsRealtime: opt?.supportsRealtime ?? false,
                       ttsVoice: opt?.ttsVoice ?? "alloy",
+                      transcriptionLanguage: opt?.transcriptionLanguage ?? "auto",
                     };
                     setEndpointCaps(caps);
                     setChatMode((prev) => {
@@ -321,6 +324,7 @@ export default function ChatPage() {
           supportsRealtime={endpointCaps.supportsRealtime}
           selectedModel={selectedModel}
           ttsVoice={endpointCaps.ttsVoice}
+          transcriptionLanguage={endpointCaps.transcriptionLanguage}
           lastResponse={messages.findLast((m) => m.role === "assistant")?.content ?? ""}
           conversationId={activeConversationId}
           onRealtimeTurn={handleRealtimeTurn}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -20,6 +20,7 @@ interface ModelOption {
   supportsVoice?: boolean;
   supportsRealtime?: boolean;
   ttsVoice?: string;
+  transcriptionLanguage?: string;
 }
 
 export default function ChatPage() {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -42,6 +42,7 @@ interface LlmEndpoint {
   supportsVoice: boolean;
   supportsTts: boolean;
   ttsVoice: string;
+  transcriptionLanguage: string;
   supportsRealtime: boolean;
   realtimeModel: string;
   realtimeSystemPrompt: string;
@@ -182,6 +183,7 @@ export default function SettingsPage() {
                 supportsVoice: ep.supportsVoice ?? false,
                 supportsTts: ep.supportsTts ?? false,
                 ttsVoice: ep.ttsVoice ?? "alloy",
+                transcriptionLanguage: ep.transcriptionLanguage ?? "auto",
                 supportsRealtime: ep.supportsRealtime ?? false,
                 realtimeModel: ep.realtimeModel ?? "",
                 realtimeSystemPrompt: ep.realtimeSystemPrompt ?? "",
@@ -431,6 +433,7 @@ export default function SettingsPage() {
         supportsVoice: false,
         supportsTts: false,
         ttsVoice: "alloy",
+        transcriptionLanguage: "auto",
         supportsRealtime: false,
         realtimeModel: "",
         realtimeSystemPrompt: "",
@@ -909,6 +912,42 @@ export default function SettingsPage() {
                     </div>
                     <p className="text-xs text-muted-foreground">Click Test to auto-detect capabilities.</p>
                   </div>
+
+                  {/* Transcription language — shown when voice input or realtime is supported */}
+                  {(ep.supportsVoice || ep.supportsRealtime) && (
+                    <div className="space-y-1.5">
+                      <Label htmlFor={`ep-${ep.id}-transcriptionLanguage`}>Transcription Language</Label>
+                      <select
+                        id={`ep-${ep.id}-transcriptionLanguage`}
+                        name={`ep-${ep.id}-transcriptionLanguage`}
+                        value={ep.transcriptionLanguage ?? "auto"}
+                        onChange={(e) => updateEndpoint(ep.id, "transcriptionLanguage", e.target.value)}
+                        className="w-full rounded border bg-background px-2 py-1.5 text-sm"
+                      >
+                        {[
+                          { code: "auto", label: "Auto-detect" },
+                          { code: "en", label: "English" },
+                          { code: "es", label: "Spanish" },
+                          { code: "fr", label: "French" },
+                          { code: "de", label: "German" },
+                          { code: "it", label: "Italian" },
+                          { code: "pt", label: "Portuguese" },
+                          { code: "nl", label: "Dutch" },
+                          { code: "ja", label: "Japanese" },
+                          { code: "ko", label: "Korean" },
+                          { code: "zh", label: "Chinese" },
+                          { code: "ru", label: "Russian" },
+                          { code: "ar", label: "Arabic" },
+                          { code: "hi", label: "Hindi" },
+                          { code: "pl", label: "Polish" },
+                          { code: "cy", label: "Welsh" },
+                        ].map(({ code, label }) => (
+                          <option key={code} value={code}>{label}</option>
+                        ))}
+                      </select>
+                      <p className="text-xs text-muted-foreground">Language hint passed to Whisper for voice and realtime transcription. Auto-detect works well for most users but may misidentify short utterances.</p>
+                    </div>
+                  )}
 
                   {/* TTS voice selector — only shown when TTS is supported */}
                   {ep.supportsTts && (

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -18,6 +18,7 @@ interface ChatInputProps {
   supportsRealtime: boolean;
   selectedModel: string;
   ttsVoice?: string;
+  transcriptionLanguage?: string;
   lastResponse?: string;
   conversationId?: string | null;
   onRealtimeTurn?: (role: "user" | "assistant", text: string) => void;
@@ -35,6 +36,7 @@ export function ChatInput({
   supportsRealtime,
   selectedModel,
   ttsVoice = "alloy",
+  transcriptionLanguage = "auto",
   lastResponse = "",
   conversationId,
   onRealtimeTurn,
@@ -121,6 +123,7 @@ export function ChatInput({
           <VoiceConversation
             modelId={selectedModel}
             ttsVoice={ttsVoice}
+            transcriptionLanguage={transcriptionLanguage}
             onSend={onSend}
             onCancel={() => onModeChange("text")}
             streaming={streaming ?? false}
@@ -132,6 +135,7 @@ export function ChatInput({
             conversationId={conversationId}
             onTurn={onRealtimeTurn}
             onMessagesUpdated={onRealtimeMessagesUpdated}
+            transcriptionLanguage={transcriptionLanguage}
           />
         ) : (
           <div className="flex items-end gap-2">

--- a/src/components/chat/realtime-chat.tsx
+++ b/src/components/chat/realtime-chat.tsx
@@ -11,6 +11,7 @@ interface RealtimeChatProps {
   conversationId?: string | null;
   onTurn?: (role: "user" | "assistant", text: string) => void;
   onMessagesUpdated?: () => void;
+  transcriptionLanguage?: string;
 }
 
 export function RealtimeChat({
@@ -18,11 +19,13 @@ export function RealtimeChat({
   conversationId,
   onTurn,
   onMessagesUpdated,
+  transcriptionLanguage,
 }: RealtimeChatProps) {
   const { connected, connecting, connect, disconnect, error } = useRealtimeChat(modelId, {
     onTurnComplete: onTurn,
     conversationId,
     onMessagesUpdated,
+    transcriptionLanguage,
   });
 
   // Disconnect when the component unmounts (mode change, conversation switch, new chat)

--- a/src/components/chat/voice-conversation.tsx
+++ b/src/components/chat/voice-conversation.tsx
@@ -16,6 +16,7 @@ type VoicePhase = "idle" | "listening" | "processing";
 interface VoiceConversationProps {
   modelId: string;
   ttsVoice?: string;
+  transcriptionLanguage?: string;
   /** Called when transcription completes — sends the query to the chat */
   onSend: (text: string) => void;
   /** Called when the user explicitly exits voice mode */
@@ -29,6 +30,7 @@ interface VoiceConversationProps {
 export function VoiceConversation({
   modelId,
   ttsVoice = "alloy",
+  transcriptionLanguage = "auto",
   onSend,
   onCancel,
   streaming,
@@ -75,13 +77,13 @@ export function VoiceConversation({
   // transitions away from the listening state without needing a separate effect.
   const handleStopListening = useCallback(async () => {
     setPhase("processing");
-    const text = await stopAndTranscribe(modelId);
+    const text = await stopAndTranscribe(modelId, transcriptionLanguage);
     if (text) {
       onSend(text);
     } else {
       setPhase("idle");
     }
-  }, [stopAndTranscribe, modelId, onSend]);
+  }, [stopAndTranscribe, modelId, transcriptionLanguage, onSend]);
 
   const { secondsRemaining } = useSilenceDetection({
     stream: recording ? stream : null,

--- a/src/components/chat/voice-input.tsx
+++ b/src/components/chat/voice-input.tsx
@@ -8,21 +8,22 @@ import { useVoiceInput } from "@/hooks/use-voice-input";
 
 interface VoiceInputProps {
   modelId: string;
+  transcriptionLanguage?: string;
   onTranscript: (text: string) => void;
   disabled?: boolean;
 }
 
-export function VoiceInput({ modelId, onTranscript, disabled }: VoiceInputProps) {
+export function VoiceInput({ modelId, transcriptionLanguage = "auto", onTranscript, disabled }: VoiceInputProps) {
   const { recording, transcribing, startRecording, stopAndTranscribe, error } = useVoiceInput();
 
   const handleToggle = useCallback(async () => {
     if (recording) {
-      const text = await stopAndTranscribe(modelId);
+      const text = await stopAndTranscribe(modelId, transcriptionLanguage);
       if (text) onTranscript(text);
     } else {
       await startRecording();
     }
-  }, [recording, modelId, onTranscript, startRecording, stopAndTranscribe]);
+  }, [recording, modelId, transcriptionLanguage, onTranscript, startRecording, stopAndTranscribe]);
 
   return (
     <div className="flex flex-col items-center gap-3 py-4">

--- a/src/hooks/use-realtime-chat.ts
+++ b/src/hooks/use-realtime-chat.ts
@@ -261,11 +261,14 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
       const REALTIME_HISTORY_TURNS = 10;
 
       dc.onopen = () => {
-        // Enable input audio transcription so user speech is surfaced as text
+        // Enable input audio transcription so user speech is surfaced as text.
+        // Locking language to "en" prevents Whisper from misidentifying English
+        // speech as another language (e.g. Welsh) and transcribing incorrectly,
+        // which would cause the model to respond in that language.
         sendEvent({
           type: "session.update",
           session: {
-            input_audio_transcription: { model: "whisper-1" },
+            input_audio_transcription: { model: "whisper-1", language: "en" },
           },
         });
 

--- a/src/hooks/use-realtime-chat.ts
+++ b/src/hooks/use-realtime-chat.ts
@@ -22,6 +22,12 @@ interface UseRealtimeChatOptions {
    * reload the message list and render the updated tool cards.
    */
   onMessagesUpdated?: () => void;
+  /**
+   * BCP-47 language code to pass to Whisper for input audio transcription
+   * (e.g. "en", "fr"). Defaults to "auto" which lets Whisper detect the
+   * language automatically.
+   */
+  transcriptionLanguage?: string;
 }
 
 export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions = {}) {
@@ -45,6 +51,8 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
   conversationIdRef.current = options.conversationId;
   const onMessagesUpdatedRef = useRef(options.onMessagesUpdated);
   onMessagesUpdatedRef.current = options.onMessagesUpdated;
+  const transcriptionLanguageRef = useRef(options.transcriptionLanguage ?? "auto");
+  transcriptionLanguageRef.current = options.transcriptionLanguage ?? "auto";
 
   // Set when the user explicitly calls disconnect() so that dc.onclose /
   // pc.onconnectionstatechange know not to show an error message.
@@ -262,13 +270,17 @@ export function useRealtimeChat(modelId: string, options: UseRealtimeChatOptions
 
       dc.onopen = () => {
         // Enable input audio transcription so user speech is surfaced as text.
-        // Locking language to "en" prevents Whisper from misidentifying English
-        // speech as another language (e.g. Welsh) and transcribing incorrectly,
-        // which would cause the model to respond in that language.
+        // Pass the configured language (e.g. "en") to prevent Whisper from
+        // misidentifying the spoken language. "auto" omits the parameter so
+        // Whisper auto-detects as normal.
+        const lang = transcriptionLanguageRef.current;
         sendEvent({
           type: "session.update",
           session: {
-            input_audio_transcription: { model: "whisper-1", language: "en" },
+            input_audio_transcription: {
+              model: "whisper-1",
+              ...(lang && lang !== "auto" ? { language: lang } : {}),
+            },
           },
         });
 

--- a/src/hooks/use-voice-input.ts
+++ b/src/hooks/use-voice-input.ts
@@ -57,7 +57,7 @@ export function useVoiceInput() {
     }
   }, []);
 
-  const stopAndTranscribe = useCallback(async (modelId: string): Promise<string> => {
+  const stopAndTranscribe = useCallback(async (modelId: string, language = "auto"): Promise<string> => {
     const mediaRecorder = mediaRecorderRef.current;
     if (!mediaRecorder || mediaRecorder.state === "inactive") {
       return "";
@@ -79,6 +79,7 @@ export function useVoiceInput() {
           const form = new FormData();
           form.append("audio", blob, "recording.webm");
           form.append("modelId", modelId);
+          if (language && language !== "auto") form.append("language", language);
           const res = await fetch("/api/voice/transcribe", { method: "POST", body: form });
           const data = await res.json();
           if (data.success) {

--- a/src/lib/llm/client.ts
+++ b/src/lib/llm/client.ts
@@ -41,6 +41,7 @@ export interface LlmEndpointConfig {
   supportsVoice?: boolean;
   supportsTts?: boolean;
   ttsVoice?: string;
+  transcriptionLanguage?: string;
   supportsRealtime?: boolean;
   realtimeModel?: string;
   realtimeSystemPrompt?: string;

--- a/src/lib/llm/default-prompt.ts
+++ b/src/lib/llm/default-prompt.ts
@@ -28,6 +28,7 @@ Guidelines:
 - Use markdown formatting for readability (bold titles, bullet lists for multiple results).
 - If you don't have access to a service needed for a request, let the user know which service needs to be configured.
 - Be conversational but stay focused on media management requests - for example you can give opinions about the quality of a movie or TV show to help the user decide what to watch, but do not entertain off topic questions.
+- Always respond in English, regardless of the language the user speaks or writes. If the user speaks in another language, politely let them know you only speak English, then continue helping them in English.
 
 Displaying title cards:
 - After searching Plex or Overseerr (including overseerr_list_requests), ALWAYS call display_titles to show visual cards — even when a title is not in Plex (use Overseerr results alone).
@@ -73,4 +74,5 @@ Guidelines:
 - Never request media on behalf of the user — always let the user confirm first.
 - When users ask about movies or TV shows, speak the title, year, and a brief description when available.
 - Stay focused on media management — you can give opinions about movies or TV shows to help the user decide what to watch, but do not entertain off-topic questions.
+- Always respond in English, regardless of the language the user speaks or writes. If the user speaks in another language, politely let them know you only speak English, then continue helping them in English.
 - If you don't have access to a service needed for a request, let the user know which service needs to be configured.`;

--- a/src/lib/llm/default-prompt.ts
+++ b/src/lib/llm/default-prompt.ts
@@ -28,7 +28,6 @@ Guidelines:
 - Use markdown formatting for readability (bold titles, bullet lists for multiple results).
 - If you don't have access to a service needed for a request, let the user know which service needs to be configured.
 - Be conversational but stay focused on media management requests - for example you can give opinions about the quality of a movie or TV show to help the user decide what to watch, but do not entertain off topic questions.
-- Always respond in English, regardless of the language the user speaks or writes. If the user speaks in another language, politely let them know you only speak English, then continue helping them in English.
 
 Displaying title cards:
 - After searching Plex or Overseerr (including overseerr_list_requests), ALWAYS call display_titles to show visual cards — even when a title is not in Plex (use Overseerr results alone).
@@ -74,5 +73,4 @@ Guidelines:
 - Never request media on behalf of the user — always let the user confirm first.
 - When users ask about movies or TV shows, speak the title, year, and a brief description when available.
 - Stay focused on media management — you can give opinions about movies or TV shows to help the user decide what to watch, but do not entertain off-topic questions.
-- Always respond in English, regardless of the language the user speaks or writes. If the user speaks in another language, politely let them know you only speak English, then continue helping them in English.
 - If you don't have access to a service needed for a request, let the user know which service needs to be configured.`;

--- a/src/lib/tools/overseerr-tools.ts
+++ b/src/lib/tools/overseerr-tools.ts
@@ -111,12 +111,42 @@ export function registerOverseerrTools() {
     schema: z.object({
       page: pageParam,
     }),
-    handler: async (args) => overseerr.listRequests(args.page ?? 1),
+    handler: async (args) => {
+      const { results, hasMore } = await overseerr.listRequests(args.page ?? 1);
+      // Enrich each result with thumbPath and (for TV) per-season availability by
+      // calling getDetails in parallel. The /request endpoint does not reliably
+      // include posterPath in the media object, so this is the only way to get
+      // poster images and accurate season statuses for the title cards.
+      const enriched = await Promise.all(
+        results.map(async (r) => {
+          if (!r.overseerrId) return r;
+          try {
+            const mediaType = r.mediaType === "tv" ? "tv" : "movie";
+            const detail = await overseerr.getDetails(r.overseerrId, mediaType);
+            return {
+              ...r,
+              thumbPath: r.thumbPath ?? detail.thumbPath,
+              ...(mediaType === "tv" ? {
+                seasons: detail.seasons,
+                seasonCount: detail.seasonCount,
+              } : {}),
+            };
+          } catch {
+            return r;
+          }
+        }),
+      );
+      return { results: enriched, hasMore };
+    },
     llmSummary: (result: unknown) => {
-      const r = result as { results: OverseerrRequest[]; hasMore: boolean };
+      const r = result as { results: (OverseerrRequest & { seasons?: overseerr.OverseerrSeasonStatus[]; seasonCount?: number })[]; hasMore: boolean };
       return {
-        results: r.results.map(({ mediaType, title, year, status, mediaStatus, requestedBy, overseerrId, seasonsRequested }) => ({
+        results: r.results.map(({ mediaType, title, year, status, mediaStatus, requestedBy, overseerrId, seasonsRequested, thumbPath, seasons }) => ({
           mediaType, title, year, status, mediaStatus, requestedBy, overseerrId, seasonsRequested,
+          ...(thumbPath ? { thumbPath } : {}),
+          ...(seasons && seasons.length > 0
+            ? { seasons: seasons.map((s) => `S${s.seasonNumber}:${s.status.toLowerCase().replace(/ /g, "_")}`).join(" ") }
+            : {}),
         })),
         hasMore: r.hasMore,
       };


### PR DESCRIPTION
## Summary

- **Welsh TTS / language misdetection**: Whisper was auto-detecting English speech as Welsh and transcribing it in Welsh, causing the Realtime model to respond in Welsh. Fixed by adding a configurable **Transcription Language** setting per endpoint (default: Auto-detect). Users can now pin to a specific language (English, French, etc.) to prevent misidentification. The language flows through to both voice mode (`/api/voice/transcribe`) and realtime mode (`session.update input_audio_transcription`).
- **Overseerr list_requests not inlining details**: `overseerr_list_requests` wasn't enriching results with `getDetails` calls, so title cards had no poster images and TV shows had no per-season data. Fixed by adding the same parallel `getDetails` enrichment pattern already used by `overseerr_search` and `overseerr_discover`.
- **Realtime stuck after tool requests** (issue #258, investigated but not fixed in code): Root cause is an OpenAI Realtime API server-side race condition when VAD fires while a tool result is being processed. No reliable client-side fix; documented as a known issue.

## Test plan

- [ ] Settings → LLM endpoint with Voice/Realtime detected → "Transcription Language" dropdown appears
- [ ] Set language to English → voice mode transcribes correctly, no Welsh misidentification
- [ ] Set language to Auto-detect → Whisper auto-detects as before
- [ ] Ask for recent Overseerr requests → title cards show poster images and season info
- [ ] All unit tests pass (`npm test`)

https://claude.ai/code/session_01Kker1Ejkomm6nSGrXEWCjd