### PR TITLE
Fix Trivy false positive: suppress CVE-2026-33671 (picomatch ReDoS)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -22,3 +22,10 @@ CVE-2026-24842
 CVE-2026-26960
 CVE-2026-29786
 CVE-2026-31802
+
+# picomatch: ReDoS (CVE-2026-33671) — Trivy false positive in dev-only deps
+# Trivy reads node_modules/tinyglobby/package.json and extracts "4.0.3" from the
+# "^4.0.3" dep spec as the installed version. npm ci actually resolves and installs
+# 4.0.4 (fixed). tinyglobby, vite, and vitest are devDependencies and do not reach
+# the .next/standalone runner image.
+CVE-2026-33671


### PR DESCRIPTION
## Summary

Adds CVE-2026-33671 to `.trivyignore` to fix a failing Docker image scan.

**Why it's a false positive:** Trivy reads `node_modules/tinyglobby/package.json` and extracts `4.0.3` from the `"picomatch": "^4.0.3"` dependency spec as the installed version. `npm ci` actually resolves and installs picomatch **4.0.4** (which is a fixed version per the CVE advisory). Furthermore, tinyglobby, vite, and vitest are `devDependencies` — none of them are present in the `.next/standalone` runner image that Trivy scans.

Same pattern as the existing entries for npm's bundled tar/minimatch/glob.

## Test plan

- [ ] `docker build -t thinkarr:local-test . && trivy image thinkarr:local-test --exit-code 1 --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore` exits 0

https://claude.ai/code/session_013s56UesLERQdD4WcYekEci