### PR TITLE
dev → beta (1.1.5-beta.2)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -22,3 +22,10 @@ CVE-2026-24842
 CVE-2026-26960
 CVE-2026-29786
 CVE-2026-31802
+
+# picomatch: ReDoS (CVE-2026-33671) — Trivy false positive in dev-only deps
+# Trivy reads node_modules/tinyglobby/package.json and extracts "4.0.3" from the
+# "^4.0.3" dep spec as the installed version. npm ci actually resolves and installs
+# 4.0.4 (fixed). tinyglobby, vite, and vitest are devDependencies and do not reach
+# the .next/standalone runner image.
+CVE-2026-33671


### PR DESCRIPTION
## Summary

- #268 — Suppress CVE-2026-33671 (picomatch ReDoS) in `.trivyignore` — Trivy false positive caused by reading `^4.0.3` dep spec from `tinyglobby/package.json`; actual installed version is 4.0.4 (fixed), and tinyglobby is a devDependency not present in the runner image

> **Version bump waived** — both dev and beta are at `1.1.5-beta.2` and this merge carries only a CI/security-scan fix (`.trivyignore` addition). Exception per CLAUDE.md applies.

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

- [ ] Trivy scan exits 0 with the updated `.trivyignore`

https://claude.ai/code/session_013s56UesLERQdD4WcYekEci