### PR TITLE
Fix user-reported issues #270 and #272

### DIFF
--- a/.claude/commands/beta-logs.md
+++ b/.claude/commands/beta-logs.md
@@ -5,8 +5,23 @@ available (richer trace data); falls back to application logs otherwise.
 
 ## Step 1 — Check whether Langfuse is configured
 
-If `LANGFUSE_SECRET_KEY` and `LANGFUSE_PUBLIC_KEY` are set in your environment,
-use the Langfuse API (§ A). Otherwise use application logs (§ B).
+Check whether `LANGFUSE_SECRET_KEY` and `LANGFUSE_PUBLIC_KEY` are set in your
+environment (e.g. via `.claude/settings.json` `env` block).
+
+- **If both keys are present** → use the Langfuse API (§ A).
+- **If either key is missing** → use `AskUserQuestion` to request them from the
+  user before proceeding. Ask:
+
+  > "Langfuse credentials aren't configured. Please provide your
+  > `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` (find them in the beta admin
+  > UI under **Settings → Logs → Langfuse Observability**), and I'll add them to
+  > `.claude/settings.json` for you."
+
+  Once the user supplies the keys, write them into `.claude/settings.json` under
+  `env` (creating the file if it doesn't exist), then proceed to § A.
+  Do **not** fall back to application logs (§ B) when Langfuse credentials are
+  missing and a Langfuse trace ID or session ID is available — logs lack the
+  per-trace detail needed to diagnose LLM issues.
 
 ---
 
@@ -38,19 +53,18 @@ curl -s -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
 
 ### If Langfuse credentials are missing:
 
-1. Open the beta admin UI and go to **Settings → Logs → Langfuse Observability**
-2. Copy the Secret Key and Public Key
-3. Add them to `.claude/settings.json` under `env`:
-   ```json
-   {
-     "env": {
-       "LANGFUSE_PUBLIC_KEY": "pk-lf-...",
-       "LANGFUSE_SECRET_KEY": "sk-lf-...",
-       "LANGFUSE_HOST": "https://cloud.langfuse.com"
-     }
-   }
-   ```
-4. Re-run this command
+This case is handled in Step 1 — use `AskUserQuestion` to request the keys from
+the user, then write them to `.claude/settings.json` under `env`:
+
+```json
+{
+  "env": {
+    "LANGFUSE_PUBLIC_KEY": "pk-lf-...",
+    "LANGFUSE_SECRET_KEY": "sk-lf-...",
+    "LANGFUSE_HOST": "https://cloud.langfuse.com"
+  }
+}
+```
 
 Do not commit or log key values.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,7 +226,7 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
 | Plex | `plex_search_library`, `plex_get_on_deck`, `plex_get_recently_added`, `plex_check_availability`, `plex_search_collection`, `plex_search_by_tag`, `plex_get_title_tags` |
 | Sonarr | `sonarr_search_series`, `sonarr_get_series_status`, `sonarr_get_calendar`, `sonarr_get_queue` |
 | Radarr | `radarr_search_movie`, `radarr_get_movie_status`, `radarr_get_queue` |
-| Overseerr | `overseerr_search`, `overseerr_list_requests` |
+| Overseerr | `overseerr_search`, `overseerr_get_details`, `overseerr_list_requests`, `overseerr_discover`, `overseerr_get_season_episodes` |
 | Built-in | `display_titles` — renders TitleCarousel in chat (always registered) |
 
 External MCP access via bearer token (`mcp.bearerToken`). Optional `X-User-Id` header scopes operations to a user's permission level. Per-user tokens stored as `user.{id}.mcpToken`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -247,6 +247,12 @@ Tools defined with Zod schemas, converted to JSON Schema → OpenAI function for
 ### Orphaned Tool Call Repair
 If the server crashes between saving an assistant message with `tool_calls` and saving the tool results, the LLM rejects the conversation on next load. `loadHistory()` in the orchestrator detects orphaned `tool_call_ids` and injects synthetic error tool messages so the conversation is always recoverable.
 
+### Agentic Tool Call Limit
+`MAX_TOOL_ROUNDS = 8` in `orchestrator.ts`. If the loop exhausts all rounds without the LLM producing a final text response, the stream ends with `{ type: "error", message: "Tool call limit reached" }` and the Langfuse trace is updated accordingly.
+
+### Sonarr Series Title Matching
+`getSeriesStatus()` in `sonarr.ts` prefers an exact (case-insensitive) title match against the `/series` list before falling back to substring matching. This prevents titles like "Celebrity Race Across the World" from being returned when the user asks about "Race Across the World".
+
 ### Multi-Endpoint LLM Support
 `llm.endpoints` JSON array stores per-endpoint config including capabilities. Legacy single-key config preserved for backward compat. Capability auto-detection: `testLlm()` probes Whisper, realtime (model list scan + OpenAI-only guard), and TTS. Per-user model override via `user.{id}.defaultModel` + `canChangeModel`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.5-beta.1",
+  "version": "1.1.5-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.5-beta.1",
+      "version": "1.1.5-beta.2",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "clsx": "^2.1.1",
@@ -9505,6 +9505,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/__tests__/lib/overseerr.test.ts
+++ b/src/__tests__/lib/overseerr.test.ts
@@ -633,6 +633,73 @@ describe("listRequests — issue #89: titles should not return Unknown", () => {
   });
 });
 
+describe("getSeasonEpisodes — issue #272: episode air dates for pending shows", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns episode list with air dates and runtimes", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        seasonNumber: 1,
+        episodes: [
+          { episodeNumber: 1, name: "Pilot", airDate: "2026-03-15", overview: "The beginning.", runtime: 60 },
+          { episodeNumber: 2, name: "Episode Two", airDate: "2026-03-22", overview: "Things escalate.", runtime: 55 },
+        ],
+      }),
+    }));
+
+    const { getSeasonEpisodes } = await import("@/lib/services/overseerr");
+    const result = await getSeasonEpisodes(252107, 1);
+    expect(result.seasonNumber).toBe(1);
+    expect(result.episodes).toHaveLength(2);
+    expect(result.episodes[0]).toMatchObject({ episodeNumber: 1, name: "Pilot", airDate: "2026-03-15", runtime: 60 });
+    expect(result.episodes[1]).toMatchObject({ episodeNumber: 2, name: "Episode Two", airDate: "2026-03-22" });
+  });
+
+  it("omits undefined fields (no airDate or runtime)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        seasonNumber: 1,
+        episodes: [
+          { episodeNumber: 1, name: "TBA", airDate: null, overview: null, runtime: 0 },
+        ],
+      }),
+    }));
+
+    const { getSeasonEpisodes } = await import("@/lib/services/overseerr");
+    const result = await getSeasonEpisodes(252107, 1);
+    expect(result.episodes[0].airDate).toBeUndefined();
+    expect(result.episodes[0].runtime).toBeUndefined();
+    expect(result.episodes[0].overview).toBeUndefined();
+  });
+
+  it("returns empty episodes array when API returns no episodes", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ seasonNumber: 1 }),
+    }));
+
+    const { getSeasonEpisodes } = await import("@/lib/services/overseerr");
+    const result = await getSeasonEpisodes(252107, 1);
+    expect(result.episodes).toHaveLength(0);
+  });
+
+  it("calls the correct Overseerr endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ seasonNumber: 2, episodes: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getSeasonEpisodes } = await import("@/lib/services/overseerr");
+    await getSeasonEpisodes(252107, 2);
+    expect(fetchMock.mock.calls[0][0]).toContain("/tv/252107/season/2");
+  });
+});
+
 describe("discover — issue #207", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/__tests__/lib/services/sonarr.test.ts
+++ b/src/__tests__/lib/services/sonarr.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for sonarr.ts — specifically the title-matching logic in
+ * getSeriesStatus() (issue #270).
+ *
+ * The original implementation used substring matching (.includes()), which
+ * caused "Celebrity Race Across the World" to be returned when the user asked
+ * about "Race Across the World", exhausting tool call rounds on a wrong match.
+ *
+ * The fix: prefer exact (case-insensitive) match; fall back to substring only
+ * when no exact match exists.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Minimal stubs
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/config", () => ({ getConfig: vi.fn((key: string) => (key === "sonarr.url" ? "http://sonarr" : "apikey")) }));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+// ---------------------------------------------------------------------------
+// Fake series list returned by the /series endpoint
+// ---------------------------------------------------------------------------
+const FAKE_SERIES = [
+  { id: 1, title: "Celebrity Race Across the World", year: 2023, status: "continuing", monitored: false, seasons: [], statistics: { totalEpisodeCount: 18, episodeCount: 6 } },
+  { id: 2, title: "Race Across the World", year: 2019, status: "continuing", monitored: true, seasons: [], statistics: { totalEpisodeCount: 24, episodeCount: 24 } },
+  { id: 3, title: "The Amazing Race", year: 2001, status: "continuing", monitored: false, seasons: [], statistics: { totalEpisodeCount: 100, episodeCount: 50 } },
+];
+
+// ---------------------------------------------------------------------------
+// Mock fetch — /series returns FAKE_SERIES; /series/:id returns the matching entry
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      const match = FAKE_SERIES.find((s) => url.endsWith(`/series/${s.id}`));
+      const body = match ?? FAKE_SERIES;
+      return { ok: true, status: 200, json: async () => body };
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+import { getSeriesStatus } from "@/lib/services/sonarr";
+
+describe("getSeriesStatus — title matching", () => {
+  it("returns the exact match when a more specific title also contains the search term", async () => {
+    const result = await getSeriesStatus("Race Across the World");
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Race Across the World");
+  });
+
+  it("is case-insensitive for exact match", async () => {
+    const result = await getSeriesStatus("race across the world");
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Race Across the World");
+  });
+
+  it("falls back to substring match when no exact match exists", async () => {
+    // "Celebrity" alone won't exact-match anything but will substring-match "Celebrity Race Across the World"
+    const result = await getSeriesStatus("Celebrity Race");
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Celebrity Race Across the World");
+  });
+
+  it("returns null when the series is not in Sonarr at all", async () => {
+    const result = await getSeriesStatus("Nonexistent Show");
+    expect(result).toBeNull();
+  });
+});

--- a/src/components/chat/title-card.tsx
+++ b/src/components/chat/title-card.tsx
@@ -93,6 +93,12 @@ export function TitleCard({ title }: TitleCardProps) {
     title.overseerrId != null &&
     title.overseerrMediaType != null;
 
+  const moreInfoHref = title.imdbId
+    ? `https://www.imdb.com/title/${title.imdbId}`
+    : title.overseerrId && title.overseerrMediaType
+      ? `https://www.themoviedb.org/${title.overseerrMediaType === "movie" ? "movie" : "tv"}/${title.overseerrId}`
+      : null;
+
   return (
     <div className="flex gap-3 rounded-xl border border-border bg-card p-3 w-full" data-testid="title-card">
       {/* Thumbnail */}
@@ -156,19 +162,29 @@ export function TitleCard({ title }: TitleCardProps) {
             </a>
           )}
 
+          {/* More Info standalone: show for pending/partial/available titles (no request button) */}
+          {!showRequestButton && moreInfoHref && (
+            <a
+              href={moreInfoHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs px-3 py-1 rounded-lg bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors font-medium whitespace-nowrap"
+              data-testid="more-info-button"
+            >
+              More Info
+            </a>
+          )}
+
           {/* More Info + Request/Requested kept together so they never split across lines */}
           {showRequestButton && (
             <div className="flex gap-2 flex-nowrap">
-              {(title.imdbId || (title.overseerrId && title.overseerrMediaType)) && (
+              {moreInfoHref && (
                 <a
-                  href={
-                    title.imdbId
-                      ? `https://www.imdb.com/title/${title.imdbId}`
-                      : `https://www.themoviedb.org/${title.overseerrMediaType === "movie" ? "movie" : "tv"}/${title.overseerrId}`
-                  }
+                  href={moreInfoHref}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs px-3 py-1 rounded-lg bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors font-medium whitespace-nowrap"
+                  data-testid="more-info-button"
                 >
                   More Info
                 </a>

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -33,7 +33,7 @@ interface OrchestratorParams {
 
 type ChatMessage = OpenAI.ChatCompletionMessageParam;
 
-const MAX_TOOL_ROUNDS = 5;
+const MAX_TOOL_ROUNDS = 8;
 
 /**
  * Retry an LLM API call on 429 rate-limit responses with exponential backoff.

--- a/src/lib/services/overseerr.ts
+++ b/src/lib/services/overseerr.ts
@@ -378,6 +378,30 @@ export async function discover(
   return { results, hasMore };
 }
 
+export interface OverseerrEpisode {
+  episodeNumber: number;
+  name: string;
+  airDate?: string;
+  overview?: string;
+  runtime?: number;
+}
+
+export async function getSeasonEpisodes(
+  tvId: number,
+  seasonNumber: number,
+): Promise<{ seasonNumber: number; episodes: OverseerrEpisode[] }> {
+  const data = await overseerrFetch(`/tv/${tvId}/season/${seasonNumber}`);
+  const rawEpisodes = (data?.episodes as Record<string, unknown>[]) ?? [];
+  const episodes: OverseerrEpisode[] = rawEpisodes.map((ep) => ({
+    episodeNumber: ep.episodeNumber as number,
+    name: ep.name as string,
+    airDate: (ep.airDate as string | undefined) || undefined,
+    overview: (ep.overview as string | undefined)?.substring(0, 200) || undefined,
+    runtime: (ep.runtime as number | undefined) || undefined,
+  }));
+  return { seasonNumber, episodes };
+}
+
 function requestStatusLabel(status: number): string {
   switch (status) {
     case 1: return "Pending Approval";

--- a/src/lib/services/sonarr.ts
+++ b/src/lib/services/sonarr.ts
@@ -93,8 +93,15 @@ export interface SonarrSeriesStatus {
  */
 export async function getSeriesStatus(title: string): Promise<SonarrSeriesStatus | null> {
   const allSeries = await sonarrFetch("/series");
-  const match = (allSeries || []).find((s: Record<string, unknown>) =>
-    (s.title as string).toLowerCase().includes(title.toLowerCase()),
+  const needle = title.toLowerCase();
+  // Prefer exact title match; fall back to substring only if nothing exact is found.
+  const match = (
+    (allSeries || []).find((s: Record<string, unknown>) =>
+      (s.title as string).toLowerCase() === needle,
+    ) ??
+    (allSeries || []).find((s: Record<string, unknown>) =>
+      (s.title as string).toLowerCase().includes(needle),
+    )
   ) as Record<string, unknown> | undefined;
 
   if (!match || !match.id) return null;

--- a/src/lib/tools/overseerr-tools.ts
+++ b/src/lib/tools/overseerr-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { defineTool } from "./registry";
 import * as overseerr from "@/lib/services/overseerr";
-import type { OverseerrSearchResult, OverseerrRequest, OverseerrDetails, OverseerrDiscoverResult } from "@/lib/services/overseerr";
+import type { OverseerrSearchResult, OverseerrRequest, OverseerrDetails, OverseerrDiscoverResult, OverseerrEpisode } from "@/lib/services/overseerr";
 
 const pageParam = z.number().int().min(1).optional().describe("Page number (1-based). Omit or use 1 for the first page. Use hasMore from the previous response to know whether a next page exists.");
 
@@ -149,6 +149,28 @@ export function registerOverseerrTools() {
             : {}),
         })),
         hasMore: r.hasMore,
+      };
+    },
+  });
+
+  defineTool({
+    name: "overseerr_get_season_episodes",
+    description: "Get episode-level details (air dates, names, runtimes) for a specific season of a TV show from Overseerr. Use this when the user asks about episode air dates, premiere dates, or individual episode schedules — especially for pending or requested shows not yet in the library. Requires overseerrId and season number from a prior overseerr_search or overseerr_get_details call.",
+    schema: z.object({
+      id: z.number().int().describe("Overseerr TV show ID (overseerrId from search or details)"),
+      seasonNumber: z.number().int().min(1).describe("Season number to fetch episodes for"),
+    }),
+    handler: async (args) => overseerr.getSeasonEpisodes(args.id, args.seasonNumber),
+    llmSummary: (result: unknown) => {
+      const r = result as { seasonNumber: number; episodes: OverseerrEpisode[] };
+      return {
+        seasonNumber: r.seasonNumber,
+        episodes: r.episodes.map(({ episodeNumber, name, airDate, runtime }) => ({
+          episodeNumber,
+          name,
+          ...(airDate ? { airDate } : {}),
+          ...(runtime ? { runtime } : {}),
+        })),
       };
     },
   });

--- a/tests/e2e/helpers/mock-servers.ts
+++ b/tests/e2e/helpers/mock-servers.ts
@@ -31,6 +31,8 @@ export const TRIGGER_AVAILABLE = "e2e show available movie";
 export const TRIGGER_UNAVAILABLE = "e2e show unavailable movie";
 /** User message trigger → LLM returns display_titles with multiple movies (carousel) */
 export const TRIGGER_MULTIPLE = "e2e show multiple movies";
+/** User message trigger → LLM returns display_titles with a pending TV show (has overseerrId + imdbId, no plexKey) */
+export const TRIGGER_PENDING = "e2e show pending tv";
 
 // ---------------------------------------------------------------------------
 // Plex mock
@@ -284,6 +286,26 @@ function llmHandler(req: http.IncomingMessage, res: http.ServerResponse) {
                 overseerrMediaType: "movie",
                 rating: 8.8,
                 summary: "Dreams within dreams.",
+              },
+            ],
+          });
+          sendToolCallResponse(res, args);
+          return;
+        }
+
+        if (lastUserContent.includes(TRIGGER_PENDING)) {
+          // Return a display_titles tool call: single pending TV show with overseerrId + imdbId
+          const args = JSON.stringify({
+            titles: [
+              {
+                mediaType: "tv",
+                title: "Star City",
+                year: 2026,
+                mediaStatus: "pending",
+                overseerrId: 252107,
+                overseerrMediaType: "tv",
+                imdbId: "tt32140872",
+                summary: "A space race drama set behind the Iron Curtain.",
               },
             ],
           });

--- a/tests/e2e/title-cards.spec.ts
+++ b/tests/e2e/title-cards.spec.ts
@@ -21,6 +21,7 @@ import {
   TRIGGER_AVAILABLE,
   TRIGGER_UNAVAILABLE,
   TRIGGER_MULTIPLE,
+  TRIGGER_PENDING,
 } from "./helpers/mock-servers";
 
 // ---------------------------------------------------------------------------
@@ -163,6 +164,37 @@ test.describe("Title card — multiple titles (carousel)", () => {
     await expect(cards.nth(0).getByTestId("title-status")).toHaveText("Available");
     await expect(cards.nth(1).getByTestId("title-status")).toHaveText("Pending");
     await expect(cards.nth(2).getByTestId("title-status")).toHaveText("Not Requested");
+  });
+});
+
+test.describe("Title card — pending TV show", () => {
+  test("renders 'More Info' button but no Request button for pending items", async ({ page }) => {
+    await page.goto("/chat");
+
+    await sendMessage(page, TRIGGER_PENDING);
+
+    await expect(page.getByTestId("message-assistant")).toBeVisible({ timeout: 20_000 });
+
+    const card = page.getByTestId("title-card").first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    await expect(card).toContainText("Star City");
+
+    // Status badge shows "Pending"
+    await expect(card.getByTestId("title-status")).toHaveText("Pending");
+
+    // More Info button is visible (imdbId is set)
+    await expect(card.getByTestId("more-info-button")).toBeVisible();
+
+    // More Info links to IMDb when imdbId is present
+    const moreInfoHref = await card.getByTestId("more-info-button").getAttribute("href");
+    expect(moreInfoHref).toContain("imdb.com/title/tt32140872");
+
+    // Request button must NOT appear — item is already requested
+    await expect(card.getByTestId("request-button")).not.toBeVisible();
+
+    // Watch Now button absent — not in Plex yet
+    await expect(card.getByTestId("watch-now-button")).not.toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes from two user-reported issues investigated via Langfuse traces.

### Issue #270 — Race Across the World: tool call limit reached (trace `53592b0f`)

- **`sonarr.ts`**: `getSeriesStatus()` now prefers exact case-insensitive title match before falling back to substring matching. Previously "Race Across the World" matched "Celebrity Race Across the World" (substring), causing the LLM to retry the same broken call and waste tool rounds.
- **`orchestrator.ts`**: Raised `MAX_TOOL_ROUNDS` from 5 to 8. Multi-service queries (Overseerr + Sonarr + calendar + `display_titles`) legitimately need more headroom.
- **New test**: `src/__tests__/lib/services/sonarr.test.ts` covers exact match, case-insensitivity, substring fallback, and no-match cases.

Tool call sequence that triggered the issue:

| Round | Tool | Result |
|-------|------|--------|
| 0 | `overseerr_search` | Found show |
| 1 | `overseerr_get_details` | 6-season detail |
| 2 | `sonarr_get_series_status` | Wrong match: "Celebrity Race Across the World" |
| 3 | `sonarr_get_series_status` | Same wrong result (LLM retried) |
| 4 | `sonarr_get_calendar` | Calendar data |
| — | **Tool call limit reached** | Stream errored |

---

### Issue #272 — Star City: premiere date unavailable + missing More Info button (trace `66ed455c`)

- **`title-card.tsx`**: "More Info" button is now shown for pending/partial items. Previously it was nested inside the `showRequestButton` conditional so only appeared for `not_requested` titles. Extracted `moreInfoHref` as a variable; renders standalone for non-requestable items, grouped with "Request" for `not_requested` items (preserves the no-line-wrap layout).
- **`overseerr.ts`** + **`overseerr-tools.ts`**: New `overseerr_get_season_episodes` tool calling `/api/v1/tv/{id}/season/{seasonNumber}`. Returns per-episode air dates, names, and runtimes. Previously the LLM had no way to retrieve episode-level data for pending shows — Overseerr's `/tv/{id}` endpoint only returns season-level status.
- **New tests**: 4 unit tests for `getSeasonEpisodes`; E2E test verifying More Info is visible and Request is absent on pending title cards.

## Test plan

- [ ] Run `npm test` — all tests pass including new sonarr and overseerr episode tests
- [ ] "Race Across the World" no longer matches "Celebrity Race Across the World" in Sonarr
- [ ] Multi-step media queries complete without hitting the tool call limit
- [ ] Pending title cards show "More Info" button linking to IMDb/TMDB
- [ ] Pending title cards do not show "Request" button
- [ ] Asking for premiere/episode dates on a pending show now triggers `overseerr_get_season_episodes`

https://claude.ai/code/session_01HS9cXDxhhN8B7fi1bDAWWR