### PR TITLE
fix: key streaming tool call deltas by id to handle Gemini parallel calls

### DIFF
--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -901,42 +901,52 @@ describe("orchestrator — Gemini parallel tool calls at same index", () => {
   it("executes both tool calls separately when Gemini sends parallel calls at index 0", async () => {
     // Gemini sends two tool calls both at index: 0 with distinct ids.
     // The fix keys by id (not index) so each call gets its own entry.
+    let llmCallCount = 0;
     vi.doMock("@/lib/llm/client", () => ({
       getLlmClient: () => ({
         chat: {
           completions: {
             create: vi.fn(async () => {
-              return (async function* () {
+              llmCallCount++;
+              if (llmCallCount === 1) {
                 // Round 1: two parallel tool calls, both at index 0
-                yield {
-                  choices: [{
-                    delta: {
-                      tool_calls: [{
-                        index: 0,
-                        id: "call_sonarr",
-                        function: { name: "sonarr_search_series", arguments: '{"term":"The Young Offenders"}' },
-                      }],
-                    },
-                  }],
-                  usage: null,
-                };
-                yield {
-                  choices: [{
-                    delta: {
-                      tool_calls: [{
-                        index: 0,
-                        id: "call_plex",
-                        function: { name: "plex_search_library", arguments: '{"query":"The Young Offenders"}' },
-                      }],
-                    },
-                  }],
-                  usage: null,
-                };
-                yield {
-                  choices: [{ delta: {} }],
-                  usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
-                };
-              })();
+                return (async function* () {
+                  yield {
+                    choices: [{
+                      delta: {
+                        tool_calls: [{
+                          index: 0,
+                          id: "call_sonarr",
+                          function: { name: "sonarr_search_series", arguments: '{"term":"The Young Offenders"}' },
+                        }],
+                      },
+                    }],
+                    usage: null,
+                  };
+                  yield {
+                    choices: [{
+                      delta: {
+                        tool_calls: [{
+                          index: 0,
+                          id: "call_plex",
+                          function: { name: "plex_search_library", arguments: '{"query":"The Young Offenders"}' },
+                        }],
+                      },
+                    }],
+                    usage: null,
+                  };
+                  yield {
+                    choices: [{ delta: {} }],
+                    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+                  };
+                })();
+              } else {
+                // Round 2+: text response after seeing tool results
+                return (async function* () {
+                  yield { choices: [{ delta: { content: "The Young Offenders is available." } }], usage: null };
+                  yield { choices: [{ delta: {} }], usage: { prompt_tokens: 20, completion_tokens: 8, total_tokens: 28 } };
+                })();
+              }
             }),
           },
         },

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -882,3 +882,97 @@ describe("orchestrator — 429 rate-limit retry", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Gemini parallel tool calls at index 0 (trace 84002b4f)
+// ---------------------------------------------------------------------------
+
+describe("orchestrator — Gemini parallel tool calls at same index", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sqlite = new Database(":memory:");
+    testDb = drizzle(sqlite, { schema });
+    migrate(testDb, { migrationsFolder: path.resolve(process.cwd(), "drizzle") });
+  });
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("executes both tool calls separately when Gemini sends parallel calls at index 0", async () => {
+    // Gemini sends two tool calls both at index: 0 with distinct ids.
+    // The fix keys by id (not index) so each call gets its own entry.
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async () => {
+              return (async function* () {
+                // Round 1: two parallel tool calls, both at index 0
+                yield {
+                  choices: [{
+                    delta: {
+                      tool_calls: [{
+                        index: 0,
+                        id: "call_sonarr",
+                        function: { name: "sonarr_search_series", arguments: '{"term":"The Young Offenders"}' },
+                      }],
+                    },
+                  }],
+                  usage: null,
+                };
+                yield {
+                  choices: [{
+                    delta: {
+                      tool_calls: [{
+                        index: 0,
+                        id: "call_plex",
+                        function: { name: "plex_search_library", arguments: '{"query":"The Young Offenders"}' },
+                      }],
+                    },
+                  }],
+                  usage: null,
+                };
+                yield {
+                  choices: [{ delta: {} }],
+                  usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+                };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gemini-2.5-flash-lite",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+
+    const mockExecuteTool = vi.fn().mockResolvedValue(JSON.stringify({ results: [] }));
+    vi.doMock("@/lib/tools/registry", () => ({
+      hasTools: () => true,
+      getOpenAITools: () => [
+        { type: "function", function: { name: "sonarr_search_series", description: "", parameters: {} } },
+        { type: "function", function: { name: "plex_search_library", description: "", parameters: {} } },
+      ],
+      executeTool: mockExecuteTool,
+      getToolLlmContent: (_name: string, result: string) => result,
+    }));
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+
+    const events: { type: string; toolName?: string }[] = [];
+    for await (const event of orchestrate({ conversationId, userMessage: "Is there a new series of young offenders?" })) {
+      events.push(event as { type: string; toolName?: string });
+    }
+
+    const toolStartEvents = events.filter((e) => e.type === "tool_call_start");
+    // Both tool calls must be executed separately — not concatenated into one
+    expect(toolStartEvents).toHaveLength(2);
+    const toolNames = toolStartEvents.map((e) => e.toolName).sort();
+    expect(toolNames).toEqual(["plex_search_library", "sonarr_search_series"]);
+
+    // executeTool must be called with each individual tool name
+    const calledNames = mockExecuteTool.mock.calls.map((c: unknown[]) => c[0]).sort();
+    expect(calledNames).toEqual(["plex_search_library", "sonarr_search_series"]);
+  });
+});

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -441,7 +441,13 @@ export async function* orchestrate(
       );
 
       // Accumulate streaming chunks
-      const toolCallDeltas: Map<number, { id: string; name: string; args: string }> = new Map();
+      // Key by tool-call id rather than stream index. OpenAI uses distinct
+      // indices for parallel tool calls; Gemini sends all at index 0 with
+      // distinct ids. Keying by id handles both — indexToCurrentId maps an
+      // index to whichever id arrived most recently at that index, so
+      // continuation chunks (empty id) are associated correctly.
+      const toolCallDeltas: Map<string, { id: string; name: string; args: string }> = new Map();
+      const indexToCurrentId: Map<number, string> = new Map();
 
       for await (const chunk of stream) {
         // Token usage is sent in the final chunk
@@ -470,11 +476,18 @@ export async function* orchestrate(
         if (delta?.tool_calls) {
           for (const tc of delta.tool_calls) {
             const idx = tc.index;
-            if (!toolCallDeltas.has(idx)) {
-              toolCallDeltas.set(idx, { id: tc.id || "", name: "", args: "" });
+            // A non-empty id signals the start of a new tool call at this index.
+            // Update the index→id mapping so subsequent continuation chunks
+            // (which arrive with an empty id) attach to the right entry.
+            if (tc.id) {
+              indexToCurrentId.set(idx, tc.id);
+              if (!toolCallDeltas.has(tc.id)) {
+                toolCallDeltas.set(tc.id, { id: tc.id, name: "", args: "" });
+              }
             }
-            const entry = toolCallDeltas.get(idx)!;
-            if (tc.id) entry.id = tc.id;
+            const currentId = indexToCurrentId.get(idx);
+            if (!currentId) continue;
+            const entry = toolCallDeltas.get(currentId)!;
             if (tc.function?.name) entry.name += tc.function.name;
             if (tc.function?.arguments) entry.args += tc.function.arguments;
           }


### PR DESCRIPTION
## Summary

- Gemini sends parallel tool calls with all deltas at `index: 0` but with distinct `id`s per call. The previous accumulator keyed by `index` caused the second tool's name and arguments to be appended to the first entry, producing an unknown concatenated tool name (e.g. `sonarr_search_seriesplex_search_library`) and an `llm_error`.
- Switch the streaming delta accumulator in `orchestrator.ts` from `Map<index, entry>` to `Map<id, entry>`, with a separate `indexToCurrentId` map to route continuation chunks (which arrive with an empty `id`) back to the correct entry.
- OpenAI uses distinct indices for each parallel call so is unaffected. Gemini uses `index: 0` for all parallel calls but sends distinct `id`s, which now work correctly.

Diagnosed via Langfuse trace `84002b4f-f4f8-4fca-a8de-6e178aa25cfa`.

## Test plan

- [ ] New unit test in `orchestrator.test.ts` simulates Gemini-style parallel tool calls at `index: 0` and asserts both tools are executed separately with the correct names
- [ ] Existing orchestrator tests pass (OpenAI-style distinct-index parallel calls unaffected)
- [ ] Test on beta with Gemini Flash: query requiring parallel tool calls (e.g. "Is there a new series of young offenders?") should return title cards instead of an error

https://claude.ai/code/session_01N2YYN4TpcyYLR7FX3GsAEP