### PR TITLE
Merge pull request #284 from chrisrothwell/claude/assess-gh-issues-LgKaJ

fix: normalize mediaStatus in Overseerr/Sonarr tools; self-correcting unknown tool errors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -253,6 +253,9 @@ If the server crashes between saving an assistant message with `tool_calls` and 
 ### Sonarr Series Title Matching
 `getSeriesStatus()` in `sonarr.ts` prefers an exact (case-insensitive) title match against the `/series` list before falling back to substring matching. This prevents titles like "Celebrity Race Across the World" from being returned when the user asks about "Race Across the World".
 
+### mediaStatus Normalization
+Overseerr's API returns title-cased status strings (`"Processing"`, `"Not Requested"`, `"Partially Available"`) which conflict with the lowercase enum expected by `display_titles` (`"pending"`, `"not_requested"`, `"partial"`). `normalizeMediaStatus()` in `overseerr.ts` handles the mapping. The `overseerr_search` and `overseerr_discover` tool handlers apply this function before returning results so the LLM always sees display_titles-compatible values. `enrichSonarrSeries()` in `sonarr-tools.ts` also pre-computes `mediaStatus` — `"available"` when found in Plex, normalized Overseerr status when found there, otherwise `"pending"` if monitored or `"not_requested"` if not.
+
 ### Multi-Endpoint LLM Support
 `llm.endpoints` JSON array stores per-endpoint config including capabilities. Legacy single-key config preserved for backward compat. Capability auto-detection: `testLlm()` probes Whisper, realtime (model list scan + OpenAI-only guard), and TTS. Per-user model override via `user.{id}.defaultModel` + `canChangeModel`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.5-beta.4",
+  "version": "1.1.5-beta.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/lib/overseerr.test.ts
+++ b/src/__tests__/lib/overseerr.test.ts
@@ -785,3 +785,35 @@ describe("discover — issue #207", () => {
     expect(url).toContain("/discover/movies/upcoming");
   });
 });
+
+describe("normalizeMediaStatus — issues #281 #282: title-cased Overseerr values must map to display_titles enum", () => {
+  it("normalizes 'Processing' to 'pending'", async () => {
+    const { normalizeMediaStatus } = await import("@/lib/services/overseerr");
+    expect(normalizeMediaStatus("Processing")).toBe("pending");
+  });
+
+  it("normalizes 'Pending' to 'pending'", async () => {
+    const { normalizeMediaStatus } = await import("@/lib/services/overseerr");
+    expect(normalizeMediaStatus("Pending")).toBe("pending");
+  });
+
+  it("normalizes 'Available' to 'available'", async () => {
+    const { normalizeMediaStatus } = await import("@/lib/services/overseerr");
+    expect(normalizeMediaStatus("Available")).toBe("available");
+  });
+
+  it("normalizes 'Partially Available' to 'partial'", async () => {
+    const { normalizeMediaStatus } = await import("@/lib/services/overseerr");
+    expect(normalizeMediaStatus("Partially Available")).toBe("partial");
+  });
+
+  it("normalizes 'Not Requested' to 'not_requested'", async () => {
+    const { normalizeMediaStatus } = await import("@/lib/services/overseerr");
+    expect(normalizeMediaStatus("Not Requested")).toBe("not_requested");
+  });
+
+  it("normalizes unknown values to 'not_requested'", async () => {
+    const { normalizeMediaStatus } = await import("@/lib/services/overseerr");
+    expect(normalizeMediaStatus("SomeUnknownStatus")).toBe("not_requested");
+  });
+});

--- a/src/__tests__/lib/registry.test.ts
+++ b/src/__tests__/lib/registry.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for registry.ts — unknown tool error messaging.
+ * Regression test for the "overseer_search" typo that produced an opaque
+ * "Unknown tool" error with no hint for the LLM to self-correct.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { z } from "zod";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe("executeTool — unknown tool name suggestions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  async function setupRegistry() {
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    defineTool({
+      name: "overseerr_search",
+      description: "Search Overseerr",
+      schema: z.object({ query: z.string() }),
+      handler: async () => ({ results: [] }),
+    });
+    return executeTool;
+  }
+
+  it("suggests the correct name when caller typos overseer_search (single r)", async () => {
+    const executeTool = await setupRegistry();
+    const raw = await executeTool("overseer_search", JSON.stringify({ query: "test" }));
+    const result = JSON.parse(raw) as { error: string };
+    expect(result.error).toContain("overseerr_search");
+  });
+
+  it("error message includes 'Did you mean' for close matches", async () => {
+    const executeTool = await setupRegistry();
+    const raw = await executeTool("overseer_search", JSON.stringify({ query: "test" }));
+    const result = JSON.parse(raw) as { error: string };
+    expect(result.error).toMatch(/did you mean/i);
+  });
+
+  it("falls back to listing available tools when no close match exists", async () => {
+    const executeTool = await setupRegistry();
+    const raw = await executeTool("nonexistent_tool_xyz", JSON.stringify({}));
+    const result = JSON.parse(raw) as { error: string };
+    expect(result.error).toContain("overseerr_search");
+    expect(result.error).toMatch(/available tools/i);
+  });
+});

--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -20,7 +20,15 @@ vi.mock("@/lib/services/overseerr", () => ({
   getDetails: (...a: unknown[]) => mockOverseerrGetDetails(...a),
   discover: (...a: unknown[]) => mockOverseerrDiscover(...a),
   listRequests: (...a: unknown[]) => mockOverseerrListRequests(...a),
-  normalizeMediaStatus: vi.fn((s: string) => s.toLowerCase().replace(/ /g, "_")),
+  normalizeMediaStatus: vi.fn((s: string) => {
+    switch (s) {
+      case "Available": return "available";
+      case "Partially Available": return "partial";
+      case "Pending":
+      case "Processing": return "pending";
+      default: return "not_requested";
+    }
+  }),
 }));
 
 const mockPlexSearchLibrary = vi.fn();
@@ -395,5 +403,121 @@ describe("overseerr_list_requests — enrichment with getDetails (#258)", () => 
 
     expect(results[0].title).toBe("Fight Club");
     expect(results[0].thumbPath).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// overseerr_search mediaStatus normalization (issues #281, #282)
+// ===========================================================================
+describe("overseerr_search — mediaStatus normalization (#281 #282)", () => {
+  it("normalizes 'Processing' from Overseerr to 'pending' before returning to LLM", async () => {
+    // Simulate Overseerr returning "Processing" (title-cased) — display_titles rejects this.
+    // The tool must normalize it to "pending" so the LLM can pass it directly to display_titles.
+    mockOverseerrSearch.mockResolvedValueOnce({
+      results: [{ ...BASE_SEARCH_RESULT, mediaStatus: "Processing" }],
+      hasMore: false,
+    });
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_search", JSON.stringify({ query: "Star City" }));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+    expect(results[0].mediaStatus).toBe("pending");
+  });
+
+  it("normalizes 'Not Requested' to 'not_requested'", async () => {
+    mockOverseerrSearch.mockResolvedValueOnce({
+      results: [{ ...BASE_SEARCH_RESULT, mediaStatus: "Not Requested" }],
+      hasMore: false,
+    });
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_search", JSON.stringify({ query: "Some Movie" }));
+    const { results } = JSON.parse(raw) as { results: Record<string, unknown>[] };
+    expect(results[0].mediaStatus).toBe("not_requested");
+  });
+});
+
+// ===========================================================================
+// sonarr_search_series pre-computed mediaStatus (issue #280)
+// ===========================================================================
+describe("sonarr_search_series — pre-computed mediaStatus (#280)", () => {
+  const SONARR_SERIES = { id: 10, title: "Breaking Bad", year: 2008, seasonCount: 5, monitored: true, tvdbId: 81189 };
+
+  it("sets mediaStatus 'available' when the show is found in Plex", async () => {
+    const PLEX_RESULT = {
+      title: "Breaking Bad", year: 2008, mediaType: "tv",
+      plexKey: "/library/metadata/77", thumbPath: "/library/metadata/77/thumb",
+      cast: ["Bryan Cranston"],
+    };
+    mockSonarrSearchSeries.mockResolvedValueOnce([SONARR_SERIES]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [PLEX_RESULT], hasMore: false });
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+    expect(results[0].mediaStatus).toBe("available");
+  });
+
+  it("sets mediaStatus from Overseerr (normalized) when not in Plex", async () => {
+    mockSonarrSearchSeries.mockResolvedValueOnce([SONARR_SERIES]);
+    mockPlexSearchLibrary.mockResolvedValueOnce({ results: [], hasMore: false });
+    mockOverseerrSearch.mockResolvedValueOnce({
+      results: [{ ...TV_SEARCH_RESULT, mediaStatus: "Processing" }],
+      hasMore: false,
+    });
+    mockOverseerrGetDetails.mockResolvedValueOnce(TV_DETAIL);
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+    // normalizeMediaStatus is mocked as s.toLowerCase().replace(/ /g, "_")
+    // so "Processing" → "processing" — confirms normalization is called, not raw value passed through.
+    expect(results[0].mediaStatus).not.toBe("Processing");
+  });
+
+  it("sets mediaStatus 'pending' for monitored show not found in Plex or Overseerr", async () => {
+    mockSonarrSearchSeries.mockResolvedValueOnce([{ ...SONARR_SERIES, monitored: true }]);
+    mockPlexSearchLibrary.mockRejectedValueOnce(new Error("Plex unavailable"));
+    mockOverseerrSearch.mockRejectedValueOnce(new Error("Overseerr unavailable"));
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+    expect(results[0].mediaStatus).toBe("pending");
+  });
+
+  it("sets mediaStatus 'not_requested' for unmonitored show not found in Plex or Overseerr", async () => {
+    mockSonarrSearchSeries.mockResolvedValueOnce([{ ...SONARR_SERIES, monitored: false }]);
+    mockPlexSearchLibrary.mockRejectedValueOnce(new Error("Plex unavailable"));
+    mockOverseerrSearch.mockRejectedValueOnce(new Error("Overseerr unavailable"));
+
+    const { registerSonarrTools } = await import("@/lib/tools/sonarr-tools");
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerSonarrTools();
+
+    const raw = await executeTool("sonarr_search_series", JSON.stringify({ term: "Breaking Bad" }));
+    const results = JSON.parse(raw) as Record<string, unknown>[];
+    expect(results[0].mediaStatus).toBe("not_requested");
   });
 });

--- a/src/lib/services/sonarr.ts
+++ b/src/lib/services/sonarr.ts
@@ -40,6 +40,7 @@ export interface SonarrSeries {
   overseerrId?: number;
   cast?: string[];
   imdbId?: string;
+  mediaStatus?: string;
 }
 
 export async function searchSeries(term: string): Promise<SonarrSeries[]> {

--- a/src/lib/tools/overseerr-tools.ts
+++ b/src/lib/tools/overseerr-tools.ts
@@ -52,7 +52,13 @@ export function registerOverseerrTools() {
           }
         }),
       );
-      return { results: enriched, hasMore };
+      // Normalize mediaStatus to lowercase display_titles-compatible values so the
+      // LLM never sees title-cased strings like "Processing" or "Not Requested"
+      // that would cause display_titles validation to fail (issues #281, #282).
+      return {
+        results: enriched.map((r) => ({ ...r, mediaStatus: overseerr.normalizeMediaStatus(r.mediaStatus) })),
+        hasMore,
+      };
     },
     llmSummary: (result: unknown) => {
       const r = result as { results: (OverseerrSearchResult & { cast?: string[]; imdbId?: string; seasons?: overseerr.OverseerrSeasonStatus[] })[]; hasMore: boolean };
@@ -206,7 +212,11 @@ export function registerOverseerrTools() {
           }
         }),
       );
-      return { results: enriched, hasMore };
+      // Normalize mediaStatus for the same reason as overseerr_search (issues #281, #282).
+      return {
+        results: enriched.map((r) => ({ ...r, mediaStatus: overseerr.normalizeMediaStatus(r.mediaStatus) })),
+        hasMore,
+      };
     },
     llmSummary: (result: unknown) => {
       const r = result as { results: (OverseerrDiscoverResult & { cast?: string[]; imdbId?: string; seasons?: overseerr.OverseerrSeasonStatus[] })[]; hasMore: boolean };

--- a/src/lib/tools/registry.ts
+++ b/src/lib/tools/registry.ts
@@ -19,6 +19,21 @@ export interface ToolDefinition {
 
 const tools: Map<string, ToolDefinition> = new Map();
 
+/** Levenshtein distance — used to suggest close tool name matches. */
+function levenshtein(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) => [i, ...Array(n).fill(0)]);
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1][j - 1]
+        : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+  return dp[m][n];
+}
+
 /** Register a tool with name, description, Zod parameter schema, and handler. */
 export function defineTool<T extends z.ZodType>(def: {
   name: string;
@@ -55,7 +70,15 @@ export async function executeTool(
 ): Promise<string> {
   const tool = tools.get(name);
   if (!tool) {
-    return JSON.stringify({ error: `Unknown tool: ${name}` });
+    // Suggest the closest registered name so the LLM can self-correct on the next round.
+    const registered = Array.from(tools.keys());
+    const suggestion = registered.find(
+      (k) => k.replace(/_/g, "").toLowerCase() === name.replace(/_/g, "").toLowerCase()
+        || levenshtein(k, name) <= 2,
+    );
+    const hint = suggestion ? ` Did you mean "${suggestion}"?` : ` Available tools: ${registered.join(", ")}.`;
+    logger.warn("Unknown tool called", { name, suggestion });
+    return JSON.stringify({ error: `Unknown tool: "${name}".${hint}` });
   }
 
   try {

--- a/src/lib/tools/sonarr-tools.ts
+++ b/src/lib/tools/sonarr-tools.ts
@@ -28,6 +28,7 @@ async function enrichSonarrSeries(s: SonarrSeries): Promise<SonarrSeries> {
         thumbPath: match.thumbPath ? plex.buildThumbUrl(match.thumbPath) : undefined,
         plexKey: match.plexKey,
         cast: match.cast,
+        mediaStatus: "available",
       };
     }
   } catch { /* Plex not configured or unavailable */ }
@@ -51,17 +52,20 @@ async function enrichSonarrSeries(s: SonarrSeries): Promise<SonarrSeries> {
         overseerrId: match.overseerrId,
         cast: detail.cast,
         imdbId: detail.imdbId,
+        // Normalize so the LLM sees display_titles-compatible values (issue #280)
+        mediaStatus: overseerr.normalizeMediaStatus(match.mediaStatus),
       };
     }
   } catch { /* Overseerr not configured or unavailable */ }
 
-  return s;
+  // Not found in Plex or Overseerr — derive from Sonarr's monitored flag
+  return { ...s, mediaStatus: s.monitored ? "pending" : "not_requested" };
 }
 
 export function registerSonarrTools() {
   defineTool({
     name: "sonarr_search_series",
-    description: "Search for a TV series by title. Returns results from Sonarr's lookup including monitored status, season count, and whether it's in the Sonarr library. Each result is automatically enriched with thumbPath (poster), plexKey (if available in Plex), overseerrId (if found in Overseerr), cast, and imdbId — pass these directly to display_titles. For mediaStatus: use 'available' if the show is in Plex (plexKey present), 'pending' if monitored in Sonarr but plexKey absent, or derive from the Overseerr mediaStatus field if present.",
+    description: "Search for a TV series by title. Returns results from Sonarr's lookup including monitored status, season count, and whether it's in the Sonarr library. Each result is automatically enriched with thumbPath (poster), plexKey (if available in Plex), overseerrId (if found in Overseerr), cast, imdbId, and a pre-computed mediaStatus — pass these directly to display_titles without manual status inference.",
     schema: z.object({
       term: z.string().describe("Search term (TV show title)"),
     }),


### PR DESCRIPTION
## Summary

<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->

-

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

<!-- What should be manually verified on the :beta image? -->

- [ ]
