### PR TITLE
Fix #290 #291: Gemini tool normalization, episode thumbnails, guaranteed card buttons

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -288,3 +288,15 @@ Last 20 messages sent to LLM. Prevents unbounded token growth on long conversati
 
 ### Gemini Parallel Tool-Call Concatenation Repair
 Some Gemini variants (e.g. `gemini-2.5-flash-lite`) emit parallel tool calls as a single concatenated call: the tool name becomes two registered names joined (e.g. `sonarr_search_seriesplex_search_library`) and the arguments become two JSON objects concatenated (`{"term":"X"}{"query":"X"}`). `trySplitConcatenatedCall()` and `trySplitJsonArgs()` in `orchestrator.ts` detect this pattern and split it back into two valid calls before execution. The system prompt also includes an explicit instruction not to concatenate tool calls.
+
+### Gemini Tool Name & Argument Normalization
+`gemini-2.5-flash-lite` sometimes emits PascalCase tool names (e.g. `DisplayTitles`) or appends the first parameter name to the tool name (e.g. `DisplayTitlesTitles` = `display_titles` + `titles` param). `resolveToolName()` in `registry.ts` handles this via:
+1. Direct lookup
+2. Case-insensitive/underscore-stripped exact match
+3. PascalCase → snake_case conversion (`DisplayTitles` → `display_titles`)
+4. Prefix match after snake_case conversion (`display_titles_titles` starts with `display_titles`)
+
+Additionally, `executeTool()` detects when `display_titles` receives a flat single-title object (e.g. `{title: "...", mediaStatus: "..."}`) instead of the correct `{titles: [{...}]}` wrapper and auto-wraps it before Zod parsing.
+
+### Episode Thumbnails from Overseerr
+`overseerr.getSeasonEpisodes()` now maps the `stillPath` field from the TMDB/Overseerr season endpoint to a full `thumbPath` URL (`https://image.tmdb.org/t/p/w300{stillPath}`) on each `OverseerrEpisode`. The `overseerr_get_season_episodes` tool's `llmSummary` includes `thumbPath` so the LLM passes it to `display_titles` for episode cards.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.5-beta.6",
+  "version": "1.1.5-beta.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/lib/display-titles-tool.test.ts
+++ b/src/__tests__/lib/display-titles-tool.test.ts
@@ -230,3 +230,78 @@ describe("display_titles — issue #117: Plex side-query for available titles wi
     expect(displayTitles[0].plexKey).toBe("/library/metadata/300");
   });
 });
+
+describe("display_titles — overseerrMediaType inference", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  const noPlexFetch = vi.fn().mockResolvedValue({
+    ok: true, json: async () => ({ MediaContainer: { machineIdentifier: "server1" } }),
+  });
+
+  it("infers overseerrMediaType 'movie' from mediaType when not provided", async () => {
+    vi.stubGlobal("fetch", noPlexFetch);
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "movie", title: "Inception", mediaStatus: "not_requested", overseerrId: 27205 }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ overseerrMediaType?: string }> };
+    expect(displayTitles[0].overseerrMediaType).toBe("movie");
+  });
+
+  it("infers overseerrMediaType 'tv' from mediaType 'tv' when not provided", async () => {
+    vi.stubGlobal("fetch", noPlexFetch);
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "tv", title: "Severance", mediaStatus: "not_requested", overseerrId: 88329 }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ overseerrMediaType?: string }> };
+    expect(displayTitles[0].overseerrMediaType).toBe("tv");
+  });
+
+  it("infers overseerrMediaType 'tv' from mediaType 'episode' when not provided", async () => {
+    vi.stubGlobal("fetch", noPlexFetch);
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "episode", title: "Pilot", mediaStatus: "available", overseerrId: 88329 }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ overseerrMediaType?: string }> };
+    expect(displayTitles[0].overseerrMediaType).toBe("tv");
+  });
+
+  it("does not set overseerrMediaType when overseerrId is absent", async () => {
+    vi.stubGlobal("fetch", noPlexFetch);
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "movie", title: "Fight Club", mediaStatus: "available" }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ overseerrMediaType?: string }> };
+    expect(displayTitles[0].overseerrMediaType).toBeUndefined();
+  });
+
+  it("does not override an explicitly provided overseerrMediaType", async () => {
+    vi.stubGlobal("fetch", noPlexFetch);
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "tv", title: "The Office", mediaStatus: "available", overseerrId: 2316, overseerrMediaType: "tv" }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ overseerrMediaType?: string }> };
+    expect(displayTitles[0].overseerrMediaType).toBe("tv");
+  });
+});

--- a/src/__tests__/lib/llm-summary-thumbpath.test.ts
+++ b/src/__tests__/lib/llm-summary-thumbpath.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression test: every tool whose llmSummary is called with a result that
+ * contains thumbPath must preserve thumbPath in the summary output.
+ *
+ * This acts as an automated lint rule to prevent the recurring "thumbnail
+ * stripped by llmSummary" bug (issues #291, previously seen in #258).
+ * When a new tool is added with an llmSummary, add a case here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/config", () => ({
+  getConfig: (key: string) => {
+    if (key === "overseerr.url") return "http://overseerr.local:5055";
+    if (key === "overseerr.apiKey") return "test-key";
+    if (key === "sonarr.url") return null;
+    if (key === "radarr.url") return null;
+    if (key === "plex.url") return null;
+    return null;
+  },
+}));
+vi.mock("@/lib/services/plex", () => ({
+  searchLibrary: vi.fn().mockResolvedValue({ results: [] }),
+  findShowPlexKey: vi.fn().mockResolvedValue(undefined),
+  buildThumbUrl: vi.fn((p: string) => `http://plex/thumb?path=${p}`),
+  getPlexMachineId: vi.fn().mockResolvedValue("machine-id"),
+}));
+
+const THUMB = "https://image.tmdb.org/t/p/w300/poster.jpg";
+
+/** Invoke a tool's llmSummary function by calling executeTool and extracting the
+ *  summary via getToolLlmContent (same path the orchestrator uses). */
+async function getSummary(toolName: string, fullResult: unknown): Promise<unknown> {
+  const { getToolLlmContent } = await import("@/lib/tools/registry");
+  const summary = getToolLlmContent(toolName, JSON.stringify(fullResult));
+  return JSON.parse(summary);
+}
+
+// ---------------------------------------------------------------------------
+// overseerr_search
+// ---------------------------------------------------------------------------
+describe("overseerr_search llmSummary preserves thumbPath", () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it("includes thumbPath when present in each result", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const fullResult = {
+      results: [{
+        overseerrId: 550, overseerrMediaType: "movie", title: "Fight Club",
+        year: 1999, rating: 8.4, mediaStatus: "available", seasonCount: undefined,
+        thumbPath: THUMB, cast: ["Brad Pitt"], imdbId: "tt0137523", seasons: undefined,
+      }],
+      hasMore: false,
+    };
+    const summary = await getSummary("overseerr_search", fullResult) as { results: Array<{ thumbPath?: string }> };
+    expect(summary.results[0].thumbPath).toBe(THUMB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// overseerr_get_details
+// ---------------------------------------------------------------------------
+describe("overseerr_get_details llmSummary preserves thumbPath", () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it("includes thumbPath when present in the details result", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const fullResult = {
+      overseerrId: 550, overseerrMediaType: "movie", title: "Fight Club",
+      year: 1999, imdbId: "tt0137523", cast: ["Brad Pitt", "Edward Norton"],
+      genres: ["Drama"], runtime: 139, episodeRuntime: undefined,
+      seasonCount: undefined, seasons: undefined, thumbPath: THUMB, requests: [],
+    };
+    const summary = await getSummary("overseerr_get_details", fullResult) as { thumbPath?: string };
+    expect(summary.thumbPath).toBe(THUMB);
+  });
+
+  it("omits thumbPath key when not present in result (no undefined noise)", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const fullResult = {
+      overseerrId: 550, overseerrMediaType: "movie", title: "Fight Club",
+      year: 1999, imdbId: "tt0137523", cast: [], genres: [], runtime: 139,
+      seasonCount: undefined, seasons: undefined, thumbPath: undefined, requests: [],
+    };
+    const summary = await getSummary("overseerr_get_details", fullResult) as Record<string, unknown>;
+    expect(summary).not.toHaveProperty("thumbPath");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// overseerr_list_requests
+// ---------------------------------------------------------------------------
+describe("overseerr_list_requests llmSummary preserves thumbPath", () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it("includes thumbPath when present in each request", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const fullResult = {
+      results: [{
+        mediaType: "movie", title: "Fight Club", year: 1999,
+        status: "Approved", mediaStatus: "pending", requestedBy: "alice",
+        overseerrId: 550, seasonsRequested: undefined, thumbPath: THUMB, seasons: undefined,
+      }],
+      hasMore: false,
+    };
+    const summary = await getSummary("overseerr_list_requests", fullResult) as { results: Array<{ thumbPath?: string }> };
+    expect(summary.results[0].thumbPath).toBe(THUMB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// overseerr_get_season_episodes
+// ---------------------------------------------------------------------------
+describe("overseerr_get_season_episodes llmSummary preserves thumbPath per episode", () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it("includes thumbPath for episodes that have it", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const EPISODE_THUMB = "https://image.tmdb.org/t/p/w300/still1.jpg";
+    const fullResult = {
+      seasonNumber: 1,
+      episodes: [
+        { episodeNumber: 1, name: "Pilot", airDate: "2008-01-20", runtime: 58, thumbPath: EPISODE_THUMB },
+        { episodeNumber: 2, name: "Ep 2", airDate: "2008-01-27", runtime: 48, thumbPath: undefined },
+      ],
+    };
+    const summary = await getSummary("overseerr_get_season_episodes", fullResult) as {
+      episodes: Array<{ thumbPath?: string }>
+    };
+    expect(summary.episodes[0].thumbPath).toBe(EPISODE_THUMB);
+    expect(summary.episodes[1]).not.toHaveProperty("thumbPath");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// overseerr_discover
+// ---------------------------------------------------------------------------
+describe("overseerr_discover llmSummary preserves thumbPath", () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it("includes thumbPath when present in each result", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { defineTool } = await import("@/lib/tools/registry");
+    (defineTool as unknown as { _registry?: Map<string, unknown> })._registry?.clear?.();
+    registerOverseerrTools();
+
+    const fullResult = {
+      results: [{
+        overseerrId: 238, overseerrMediaType: "movie", title: "The Godfather",
+        year: 1972, rating: 9.2, mediaStatus: "not_requested", seasonCount: undefined,
+        thumbPath: THUMB, cast: ["Marlon Brando"], imdbId: "tt0068646", seasons: undefined,
+      }],
+      hasMore: false,
+    };
+    const summary = await getSummary("overseerr_discover", fullResult) as { results: Array<{ thumbPath?: string }> };
+    expect(summary.results[0].thumbPath).toBe(THUMB);
+  });
+});

--- a/src/__tests__/lib/overseerr.test.ts
+++ b/src/__tests__/lib/overseerr.test.ts
@@ -817,3 +817,65 @@ describe("normalizeMediaStatus — issues #281 #282: title-cased Overseerr value
     expect(normalizeMediaStatus("SomeUnknownStatus")).toBe("not_requested");
   });
 });
+
+describe("getSeasonEpisodes — issue #291: includes thumbPath from stillPath", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("maps stillPath to a full TMDB thumbPath URL for each episode", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        episodes: [
+          {
+            episodeNumber: 1,
+            name: "Pilot",
+            airDate: "2008-01-20",
+            overview: "A chemistry teacher is diagnosed with cancer.",
+            runtime: 58,
+            stillPath: "/still1.jpg",
+          },
+          {
+            episodeNumber: 2,
+            name: "Cat's in the Bag",
+            airDate: "2008-01-27",
+            overview: null,
+            runtime: 48,
+            stillPath: null,
+          },
+        ],
+      }),
+    }));
+
+    const { getSeasonEpisodes } = await import("@/lib/services/overseerr");
+    const result = await getSeasonEpisodes(1396, 1);
+    expect(result.seasonNumber).toBe(1);
+    expect(result.episodes).toHaveLength(2);
+
+    // Episode with stillPath → full TMDB URL
+    expect(result.episodes[0].thumbPath).toBe("https://image.tmdb.org/t/p/w300/still1.jpg");
+    expect(result.episodes[0].episodeNumber).toBe(1);
+    expect(result.episodes[0].name).toBe("Pilot");
+    expect(result.episodes[0].airDate).toBe("2008-01-20");
+    expect(result.episodes[0].runtime).toBe(58);
+
+    // Episode without stillPath → thumbPath is undefined
+    expect(result.episodes[1].thumbPath).toBeUndefined();
+  });
+
+  it("returns thumbPath as undefined when stillPath is missing from episode data", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        episodes: [
+          { episodeNumber: 1, name: "Episode 1", airDate: "2024-01-01" },
+        ],
+      }),
+    }));
+
+    const { getSeasonEpisodes } = await import("@/lib/services/overseerr");
+    const result = await getSeasonEpisodes(999, 2);
+    expect(result.episodes[0].thumbPath).toBeUndefined();
+  });
+});

--- a/src/__tests__/lib/registry.test.ts
+++ b/src/__tests__/lib/registry.test.ts
@@ -1,7 +1,10 @@
 /**
- * Unit tests for registry.ts — unknown tool error messaging.
- * Regression test for the "overseer_search" typo that produced an opaque
- * "Unknown tool" error with no hint for the LLM to self-correct.
+ * Unit tests for registry.ts — tool name normalization and argument repair.
+ *
+ * Covers:
+ * - Unknown tool error messaging (regression for "overseer_search" typo)
+ * - PascalCase/CamelCase name normalization (issue #290)
+ * - Flat display_titles argument wrapping (issue #290)
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -48,5 +51,106 @@ describe("executeTool — unknown tool name suggestions", () => {
     const result = JSON.parse(raw) as { error: string };
     expect(result.error).toContain("overseerr_search");
     expect(result.error).toMatch(/available tools/i);
+  });
+});
+
+describe("executeTool — issue #290: PascalCase tool name normalization", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  async function setupRegistryWithDisplayTitles() {
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    defineTool({
+      name: "display_titles",
+      description: "Display title cards",
+      schema: z.object({
+        titles: z.array(
+          z.object({
+            mediaType: z.enum(["movie", "tv", "episode"]),
+            title: z.string(),
+            mediaStatus: z.enum(["available", "partial", "pending", "not_requested"]),
+          }),
+        ).min(1),
+      }),
+      handler: async (args) => ({ displayTitles: args.titles }),
+    });
+    return executeTool;
+  }
+
+  it("resolves PascalCase 'DisplayTitles' to 'display_titles'", async () => {
+    const executeTool = await setupRegistryWithDisplayTitles();
+    const args = JSON.stringify({ titles: [{ mediaType: "movie", title: "Inception", mediaStatus: "available" }] });
+    const raw = await executeTool("DisplayTitles", args);
+    const result = JSON.parse(raw) as { displayTitles: unknown[] };
+    expect(result.displayTitles).toHaveLength(1);
+  });
+
+  it("resolves 'DisplayTitlesTitles' (Gemini param-name suffix hallucination) to 'display_titles'", async () => {
+    const executeTool = await setupRegistryWithDisplayTitles();
+    const args = JSON.stringify({ titles: [{ mediaType: "movie", title: "Inception", mediaStatus: "available" }] });
+    const raw = await executeTool("DisplayTitlesTitles", args);
+    const result = JSON.parse(raw) as { displayTitles: unknown[] };
+    expect(result.displayTitles).toHaveLength(1);
+  });
+
+  it("resolves snake_case 'display_titles_titles' to 'display_titles'", async () => {
+    const executeTool = await setupRegistryWithDisplayTitles();
+    const args = JSON.stringify({ titles: [{ mediaType: "tv", title: "Severance", mediaStatus: "not_requested" }] });
+    const raw = await executeTool("display_titles_titles", args);
+    const result = JSON.parse(raw) as { displayTitles: unknown[] };
+    expect(result.displayTitles).toHaveLength(1);
+  });
+});
+
+describe("executeTool — issue #290: flat display_titles argument wrapping", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  async function setupRegistryWithDisplayTitles() {
+    const { defineTool, executeTool } = await import("@/lib/tools/registry");
+    defineTool({
+      name: "display_titles",
+      description: "Display title cards",
+      schema: z.object({
+        titles: z.array(
+          z.object({
+            mediaType: z.enum(["movie", "tv", "episode"]),
+            title: z.string(),
+            mediaStatus: z.enum(["available", "partial", "pending", "not_requested"]),
+            seasonNumber: z.number().nullish(),
+          }),
+        ).min(1),
+      }),
+      handler: async (args) => ({ displayTitles: args.titles }),
+    });
+    return executeTool;
+  }
+
+  it("wraps a flat title object into {titles: [...]} automatically", async () => {
+    const executeTool = await setupRegistryWithDisplayTitles();
+    // Gemini sends flat args instead of {titles: [{...}]}
+    const flat = JSON.stringify({ mediaType: "movie", title: "Inception", mediaStatus: "available" });
+    const raw = await executeTool("display_titles", flat);
+    const result = JSON.parse(raw) as { displayTitles: Array<{ title: string }> };
+    expect(result.displayTitles).toHaveLength(1);
+    expect(result.displayTitles[0].title).toBe("Inception");
+  });
+
+  it("wraps flat season-card args (title + seasonNumber) correctly", async () => {
+    const executeTool = await setupRegistryWithDisplayTitles();
+    const flat = JSON.stringify({ mediaType: "tv", title: "Severance — Season 1", mediaStatus: "not_requested", seasonNumber: 1 });
+    const raw = await executeTool("display_titles", flat);
+    const result = JSON.parse(raw) as { displayTitles: Array<{ title: string; seasonNumber?: number }> };
+    expect(result.displayTitles[0].seasonNumber).toBe(1);
+  });
+
+  it("does not double-wrap when titles array is already present", async () => {
+    const executeTool = await setupRegistryWithDisplayTitles();
+    const correct = JSON.stringify({ titles: [{ mediaType: "movie", title: "Dune", mediaStatus: "available" }] });
+    const raw = await executeTool("display_titles", correct);
+    const result = JSON.parse(raw) as { displayTitles: unknown[] };
+    expect(result.displayTitles).toHaveLength(1);
   });
 });

--- a/src/components/chat/title-card.tsx
+++ b/src/components/chat/title-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Star } from "lucide-react";
+import { Star, Film, Tv } from "lucide-react";
 import type { DisplayTitle } from "@/types/titles";
 import { clientLog } from "@/lib/client-logger";
 
@@ -93,11 +93,13 @@ export function TitleCard({ title }: TitleCardProps) {
     title.overseerrId != null &&
     title.overseerrMediaType != null;
 
+  // More Info: prefer IMDb, fall back to TMDB direct page, then TMDB search.
+  // Always produces a non-null href so the button is always visible.
   const moreInfoHref = title.imdbId
     ? `https://www.imdb.com/title/${title.imdbId}`
     : title.overseerrId && title.overseerrMediaType
       ? `https://www.themoviedb.org/${title.overseerrMediaType === "movie" ? "movie" : "tv"}/${title.overseerrId}`
-      : null;
+      : `https://www.themoviedb.org/search/${title.mediaType === "movie" ? "movie" : "tv"}?query=${encodeURIComponent(title.title)}`;
 
   return (
     <div className="flex gap-3 rounded-xl border border-border bg-card p-3 w-full" data-testid="title-card">
@@ -110,8 +112,8 @@ export function TitleCard({ title }: TitleCardProps) {
           className="w-24 h-36 object-cover rounded-lg shrink-0 bg-muted"
         />
       ) : (
-        <div className="w-24 h-36 rounded-lg shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs text-center px-1">
-          No Image
+        <div className="w-24 h-36 rounded-lg shrink-0 bg-muted flex items-center justify-center text-muted-foreground/40">
+          {title.mediaType === "movie" ? <Film size={32} /> : <Tv size={32} />}
         </div>
       )}
 
@@ -150,75 +152,58 @@ export function TitleCard({ title }: TitleCardProps) {
 
         {/* Buttons */}
         <div className="flex flex-wrap gap-2 mt-auto pt-1">
+          {/* Watch Now — available or partial titles that have a Plex URL */}
           {(title.mediaStatus === "available" || title.mediaStatus === "partial") && plexWebUrl && (
             <a
               href={plexWebUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs px-3 py-1 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium"
+              className="text-xs px-3 py-1 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium whitespace-nowrap"
               data-testid="watch-now-button"
             >
               Watch Now
             </a>
           )}
 
-          {/* More Info standalone: show for pending/partial/available titles (no request button) */}
-          {!showRequestButton && moreInfoHref && (
-            <a
-              href={moreInfoHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs px-3 py-1 rounded-lg bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors font-medium whitespace-nowrap"
-              data-testid="more-info-button"
+          {/* Request — not_requested titles with an Overseerr ID */}
+          {showRequestButton && requestStatus === "idle" && (
+            <button
+              onClick={handleRequest}
+              disabled={requesting}
+              className="text-xs px-3 py-1 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium disabled:opacity-50 flex items-center gap-1 whitespace-nowrap"
+              data-testid="request-button"
             >
-              More Info
-            </a>
+              {requesting ? (
+                <>
+                  <span className="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                  Requesting…
+                </>
+              ) : (
+                "Request"
+              )}
+            </button>
           )}
 
-          {/* More Info + Request/Requested kept together so they never split across lines */}
-          {showRequestButton && (
-            <div className="flex gap-2 flex-nowrap">
-              {moreInfoHref && (
-                <a
-                  href={moreInfoHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs px-3 py-1 rounded-lg bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors font-medium whitespace-nowrap"
-                  data-testid="more-info-button"
-                >
-                  More Info
-                </a>
-              )}
-
-              {requestStatus === "idle" && (
-                <button
-                  onClick={handleRequest}
-                  disabled={requesting}
-                  className="text-xs px-3 py-1 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium disabled:opacity-50 flex items-center gap-1 whitespace-nowrap"
-                  data-testid="request-button"
-                >
-                  {requesting ? (
-                    <>
-                      <span className="inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                      Requesting…
-                    </>
-                  ) : (
-                    "Request"
-                  )}
-                </button>
-              )}
-
-              {requestStatus === "success" && (
-                <span className="text-xs px-3 py-1 rounded-lg bg-green-500/20 text-green-400 border border-green-500/30 font-medium whitespace-nowrap" data-testid="request-success">
-                  Requested
-                </span>
-              )}
-
-              {requestStatus === "error" && (
-                <span className="text-xs text-destructive whitespace-nowrap">{errorMsg}</span>
-              )}
-            </div>
+          {showRequestButton && requestStatus === "success" && (
+            <span className="text-xs px-3 py-1 rounded-lg bg-green-500/20 text-green-400 border border-green-500/30 font-medium whitespace-nowrap" data-testid="request-success">
+              Requested
+            </span>
           )}
+
+          {showRequestButton && requestStatus === "error" && (
+            <span className="text-xs text-destructive whitespace-nowrap">{errorMsg}</span>
+          )}
+
+          {/* More Info — always shown; prefers IMDb → TMDB direct → TMDB search */}
+          <a
+            href={moreInfoHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs px-3 py-1 rounded-lg bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors font-medium whitespace-nowrap"
+            data-testid="more-info-button"
+          >
+            More Info
+          </a>
         </div>
       </div>
     </div>

--- a/src/lib/services/overseerr.ts
+++ b/src/lib/services/overseerr.ts
@@ -390,6 +390,8 @@ export interface OverseerrEpisode {
   airDate?: string;
   overview?: string;
   runtime?: number;
+  /** Full TMDB still image URL (https://image.tmdb.org/t/p/w300...) for the episode thumbnail. */
+  thumbPath?: string;
 }
 
 export async function getSeasonEpisodes(
@@ -398,13 +400,17 @@ export async function getSeasonEpisodes(
 ): Promise<{ seasonNumber: number; episodes: OverseerrEpisode[] }> {
   const data = await overseerrFetch(`/tv/${tvId}/season/${seasonNumber}`);
   const rawEpisodes = (data?.episodes as Record<string, unknown>[]) ?? [];
-  const episodes: OverseerrEpisode[] = rawEpisodes.map((ep) => ({
-    episodeNumber: ep.episodeNumber as number,
-    name: ep.name as string,
-    airDate: (ep.airDate as string | undefined) || undefined,
-    overview: (ep.overview as string | undefined)?.substring(0, 200) || undefined,
-    runtime: (ep.runtime as number | undefined) || undefined,
-  }));
+  const episodes: OverseerrEpisode[] = rawEpisodes.map((ep) => {
+    const stillPath = ep.stillPath as string | undefined;
+    return {
+      episodeNumber: ep.episodeNumber as number,
+      name: ep.name as string,
+      airDate: (ep.airDate as string | undefined) || undefined,
+      overview: (ep.overview as string | undefined)?.substring(0, 200) || undefined,
+      runtime: (ep.runtime as number | undefined) || undefined,
+      thumbPath: stillPath ? `https://image.tmdb.org/t/p/w300${stillPath}` : undefined,
+    };
+  });
   return { seasonNumber, episodes };
 }
 

--- a/src/lib/tools/display-titles-tool.ts
+++ b/src/lib/tools/display-titles-tool.ts
@@ -145,7 +145,10 @@ For overseerr_list_requests results: one card per request is correct (no season 
         plexUrl: baseUrl,
         plexMachineId: machineId,
         overseerrId: t.overseerrId ?? undefined,
-        overseerrMediaType: t.overseerrMediaType ?? undefined,
+        // Infer overseerrMediaType from mediaType when the LLM omits it but provides
+        // overseerrId — ensures Request button and More Info link always render.
+        overseerrMediaType: t.overseerrMediaType ??
+          (t.overseerrId != null ? (t.mediaType === "movie" ? "movie" : "tv") : undefined),
         imdbId: t.imdbId ?? undefined,
         mediaStatus: t.mediaStatus,
         cast: t.cast ?? undefined,

--- a/src/lib/tools/display-titles-tool.ts
+++ b/src/lib/tools/display-titles-tool.ts
@@ -52,6 +52,8 @@ export function registerDisplayTitlesTool() {
     name: "display_titles",
     description: `Display rich title cards for movies, TV shows, or episodes in the chat UI. Call after searching Plex or Overseerr — even when titles are not in Plex. All search tools return field names that map directly to this schema — pass them through without renaming.
 
+IMPORTANT: The exact function name is display_titles (snake_case, all lowercase). Always call it as display_titles({ titles: [...] }) — the argument must be an object with a "titles" array.
+
 TV shows from overseerr_search or overseerr_discover: use the returned seasonCount and seasons fields to create one card per season (title = 'Show Name — Season N', seasonNumber set, mediaStatus from the seasons compact string). Never create a single card for an entire multi-season show — the Request button requires seasonNumber.
 
 For overseerr_list_requests results: one card per request is correct (no season split needed).`,

--- a/src/lib/tools/overseerr-tools.ts
+++ b/src/lib/tools/overseerr-tools.ts
@@ -106,6 +106,7 @@ export function registerOverseerrTools() {
         runtime: r.runtime,
         episodeRuntime: r.episodeRuntime,
         seasonCount: r.seasonCount,
+        ...(r.thumbPath ? { thumbPath: r.thumbPath } : {}),
         ...(seasonsCompact ? { seasons: seasonsCompact } : {}),
       };
     },

--- a/src/lib/tools/overseerr-tools.ts
+++ b/src/lib/tools/overseerr-tools.ts
@@ -171,11 +171,12 @@ export function registerOverseerrTools() {
       const r = result as { seasonNumber: number; episodes: OverseerrEpisode[] };
       return {
         seasonNumber: r.seasonNumber,
-        episodes: r.episodes.map(({ episodeNumber, name, airDate, runtime }) => ({
+        episodes: r.episodes.map(({ episodeNumber, name, airDate, runtime, thumbPath }) => ({
           episodeNumber,
           name,
           ...(airDate ? { airDate } : {}),
           ...(runtime ? { runtime } : {}),
+          ...(thumbPath ? { thumbPath } : {}),
         })),
       };
     },

--- a/src/lib/tools/registry.ts
+++ b/src/lib/tools/registry.ts
@@ -69,7 +69,7 @@ export function getOpenAITools(): OpenAI.ChatCompletionTool[] {
  */
 function toSnakeCase(s: string): string {
   return s
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1_$2")
     .replace(/([a-z\d])([A-Z])/g, "$1_$2")
     .toLowerCase();
 }

--- a/src/lib/tools/registry.ts
+++ b/src/lib/tools/registry.ts
@@ -63,32 +63,103 @@ export function getOpenAITools(): OpenAI.ChatCompletionTool[] {
   });
 }
 
+/**
+ * Convert PascalCase or camelCase to snake_case.
+ * e.g. "DisplayTitlesTitles" → "display_titles_titles"
+ */
+function toSnakeCase(s: string): string {
+  return s
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z\d])([A-Z])/g, "$1_$2")
+    .toLowerCase();
+}
+
+/**
+ * Try to resolve a (possibly mangled) tool name to a registered tool.
+ *
+ * Gemini Flash sometimes emits PascalCase names or appends parameter names to
+ * the tool name (e.g. "DisplayTitlesTitles" instead of "display_titles").
+ * Strategy:
+ *   1. Direct lookup — fastest path.
+ *   2. Case-insensitive / underscore-stripped exact match — catches minor casing drift.
+ *   3. snake_case conversion — "DisplayTitles" → "display_titles".
+ *   4. Prefix match after snake_case conversion — "DisplayTitlesTitles" →
+ *      "display_titles_titles" starts with registered name "display_titles".
+ * Returns [resolvedName, tool] or undefined if no match.
+ */
+function resolveToolName(name: string): [string, ToolDefinition] | undefined {
+  // 1. Direct
+  const direct = tools.get(name);
+  if (direct) return [name, direct];
+
+  const registered = Array.from(tools.entries());
+
+  // 2. Case-insensitive / stripped
+  const stripped = name.replace(/_/g, "").toLowerCase();
+  for (const [k, v] of registered) {
+    if (k.replace(/_/g, "").toLowerCase() === stripped) return [k, v];
+  }
+
+  // 3. snake_case conversion exact match
+  const snake = toSnakeCase(name);
+  const snakeTool = tools.get(snake);
+  if (snakeTool) return [snake, snakeTool];
+
+  // 4. Prefix match: snake_case name starts with a registered tool name
+  // e.g. "display_titles_titles" starts with "display_titles"
+  // Sort by descending name length to prefer the longest (most specific) match
+  const byLength = [...registered].sort((a, b) => b[0].length - a[0].length);
+  for (const [k, v] of byLength) {
+    if (snake.startsWith(k + "_") || snake === k) return [k, v];
+  }
+
+  return undefined;
+}
+
 /** Execute a tool by name with the given arguments string (JSON). */
 export async function executeTool(
   name: string,
   argsString: string,
 ): Promise<string> {
-  const tool = tools.get(name);
-  if (!tool) {
+  const resolved = resolveToolName(name);
+  if (!resolved) {
     // Suggest the closest registered name so the LLM can self-correct on the next round.
     const registered = Array.from(tools.keys());
-    const suggestion = registered.find(
-      (k) => k.replace(/_/g, "").toLowerCase() === name.replace(/_/g, "").toLowerCase()
-        || levenshtein(k, name) <= 2,
-    );
+    const suggestion = registered.find((k) => levenshtein(k, name) <= 2);
     const hint = suggestion ? ` Did you mean "${suggestion}"?` : ` Available tools: ${registered.join(", ")}.`;
     logger.warn("Unknown tool called", { name, suggestion });
     return JSON.stringify({ error: `Unknown tool: "${name}".${hint}` });
   }
 
+  const [resolvedName, tool] = resolved;
+  if (resolvedName !== name) {
+    logger.warn("Tool name normalized", { original: name, resolved: resolvedName });
+  }
+
   try {
-    const args = JSON.parse(argsString);
+    let args = JSON.parse(argsString);
+
+    // Fix Gemini flat-argument hallucination for display_titles.
+    // Gemini sometimes calls display_titles with the contents of a single title
+    // object spread at the top level (e.g. { title: "...", seasonNumber: 1 })
+    // instead of the correct { titles: [{ title: "...", seasonNumber: 1 }] }.
+    if (
+      resolvedName === "display_titles" &&
+      !Array.isArray(args.titles) &&
+      typeof args.title === "string"
+    ) {
+      logger.warn("display_titles: flat args detected, wrapping into {titles: [...]}", {
+        original: name,
+      });
+      args = { titles: [args] };
+    }
+
     const parsed = tool.schema.parse(args);
     const result = await tool.handler(parsed);
     return JSON.stringify(result);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : "Tool execution failed";
-    logger.error("Tool execution error", { toolName: name, error: msg });
+    logger.error("Tool execution error", { toolName: resolvedName, error: msg });
     return JSON.stringify({ error: msg });
   }
 }

--- a/tests/e2e/helpers/mock-servers.ts
+++ b/tests/e2e/helpers/mock-servers.ts
@@ -33,6 +33,10 @@ export const TRIGGER_UNAVAILABLE = "e2e show unavailable movie";
 export const TRIGGER_MULTIPLE = "e2e show multiple movies";
 /** User message trigger → LLM returns display_titles with a pending TV show (has overseerrId + imdbId, no plexKey) */
 export const TRIGGER_PENDING = "e2e show pending tv";
+/** User message trigger → LLM returns display_titles with no imdbId/overseerrId (Plex-only item, tests More Info fallback) */
+export const TRIGGER_NO_EXTERNAL_IDS = "e2e show plex only movie";
+/** User message trigger → LLM returns display_titles with overseerrId but no overseerrMediaType (tests inference) */
+export const TRIGGER_MISSING_MEDIA_TYPE = "e2e show missing mediatype";
 
 // ---------------------------------------------------------------------------
 // Plex mock
@@ -337,6 +341,44 @@ function llmHandler(req: http.IncomingMessage, res: http.ServerResponse) {
                 mediaStatus: "not_requested",
                 overseerrId: 99901,
                 overseerrMediaType: "tv",
+              },
+            ],
+          });
+          sendToolCallResponse(res, args);
+          return;
+        }
+
+        if (lastUserContent.includes(TRIGGER_NO_EXTERNAL_IDS)) {
+          // Return a display_titles tool call: available Plex-only movie with no imdbId or overseerrId.
+          // Tests that More Info always renders (TMDB search fallback).
+          const args = JSON.stringify({
+            titles: [
+              {
+                mediaType: "movie",
+                title: "Local Favorite",
+                year: 2015,
+                mediaStatus: "available",
+                plexKey: "/library/metadata/500",
+                // no imdbId, no overseerrId
+              },
+            ],
+          });
+          sendToolCallResponse(res, args);
+          return;
+        }
+
+        if (lastUserContent.includes(TRIGGER_MISSING_MEDIA_TYPE)) {
+          // Return a display_titles tool call: not_requested with overseerrId but no overseerrMediaType.
+          // Tests that the handler infers overseerrMediaType so the Request button appears.
+          const args = JSON.stringify({
+            titles: [
+              {
+                mediaType: "tv",
+                title: "Unknown Type Show",
+                year: 2023,
+                mediaStatus: "not_requested",
+                overseerrId: 55555,
+                // no overseerrMediaType — tool handler should infer "tv"
               },
             ],
           });

--- a/tests/e2e/title-cards.spec.ts
+++ b/tests/e2e/title-cards.spec.ts
@@ -22,6 +22,8 @@ import {
   TRIGGER_UNAVAILABLE,
   TRIGGER_MULTIPLE,
   TRIGGER_PENDING,
+  TRIGGER_NO_EXTERNAL_IDS,
+  TRIGGER_MISSING_MEDIA_TYPE,
 } from "./helpers/mock-servers";
 
 // ---------------------------------------------------------------------------
@@ -213,5 +215,77 @@ test.describe("Title card — summary and rating", () => {
 
     // Rating visible (8.5 → "8.5")
     await expect(card).toContainText("8.5");
+  });
+});
+
+test.describe("Title card — More Info always visible", () => {
+  test("shows More Info even when no imdbId or overseerrId (falls back to TMDB search)", async ({ page }) => {
+    await page.goto("/chat");
+
+    await sendMessage(page, TRIGGER_NO_EXTERNAL_IDS);
+    await expect(page.getByTestId("message-assistant")).toBeVisible({ timeout: 20_000 });
+
+    const card = page.getByTestId("title-card").first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText("Local Favorite");
+
+    // More Info button is always visible regardless of external IDs
+    const moreInfo = card.getByTestId("more-info-button");
+    await expect(moreInfo).toBeVisible();
+
+    // Falls back to TMDB search URL
+    const href = await moreInfo.getAttribute("href");
+    expect(href).toContain("themoviedb.org/search");
+    expect(href).toContain("Local%20Favorite");
+  });
+
+  test("shows More Info with IMDB link when imdbId is present", async ({ page }) => {
+    await page.goto("/chat");
+
+    await sendMessage(page, TRIGGER_PENDING);
+    await expect(page.getByTestId("message-assistant")).toBeVisible({ timeout: 20_000 });
+
+    const card = page.getByTestId("title-card").first();
+    const moreInfo = card.getByTestId("more-info-button");
+    await expect(moreInfo).toBeVisible({ timeout: 10_000 });
+
+    const href = await moreInfo.getAttribute("href");
+    expect(href).toContain("imdb.com/title/tt32140872");
+  });
+
+  test("shows More Info with TMDB direct page when overseerrId is present (no imdbId)", async ({ page }) => {
+    await page.goto("/chat");
+
+    await sendMessage(page, TRIGGER_UNAVAILABLE);
+    await expect(page.getByTestId("message-assistant")).toBeVisible({ timeout: 20_000 });
+
+    const card = page.getByTestId("title-card").first();
+    const moreInfo = card.getByTestId("more-info-button");
+    await expect(moreInfo).toBeVisible({ timeout: 10_000 });
+
+    const href = await moreInfo.getAttribute("href");
+    expect(href).toContain("themoviedb.org/movie/27205");
+  });
+});
+
+test.describe("Title card — overseerrMediaType inference", () => {
+  test("shows Request button when overseerrId present but overseerrMediaType omitted", async ({ page }) => {
+    await page.goto("/chat");
+
+    await sendMessage(page, TRIGGER_MISSING_MEDIA_TYPE);
+    await expect(page.getByTestId("message-assistant")).toBeVisible({ timeout: 20_000 });
+
+    const card = page.getByTestId("title-card").first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText("Unknown Type Show");
+
+    // Request button must appear even though overseerrMediaType was not in the tool call
+    await expect(card.getByTestId("request-button")).toBeVisible();
+
+    // More Info should also be visible (TMDB link built from inferred overseerrMediaType)
+    const moreInfo = card.getByTestId("more-info-button");
+    await expect(moreInfo).toBeVisible();
+    const href = await moreInfo.getAttribute("href");
+    expect(href).toContain("themoviedb.org/tv/55555");
   });
 });


### PR DESCRIPTION
## Summary

- **#290**: `gemini-2.5-flash-lite` was calling `DisplayTitlesTitles` (PascalCase + parameter name suffix) instead of `display_titles`, and sending flat args instead of `{titles:[...]}`. Added `resolveToolName()` in `registry.ts` (PascalCase→snake_case, prefix-match) and flat-arg auto-wrapping in `executeTool()`.

- **#291**: `overseerr_get_season_episodes` was discarding `stillPath` from TMDB episode data, leaving episode cards with no thumbnail. `OverseerrEpisode` now includes `thumbPath` mapped from `stillPath`, and the tool's `llmSummary` passes it through.

- **Systemic thumbnail fix**: `overseerr_get_details` `llmSummary` was silently stripping `thumbPath` even though `getDetails()` returns it. Fixed. Added `llm-summary-thumbpath.test.ts` as an enforcement test (covers all 5 Overseerr tools) so this can't silently regress.

- **Guaranteed card buttons**: Every title card now always shows More Info (IMDb → TMDB direct → TMDB search fallback), and the `display_titles` handler infers `overseerrMediaType` from `mediaType` when the LLM omits it, unblocking both the Request button and the TMDB More Info link. Film/Tv icon replaces the "No Image" text placeholder.

- **display_titles description** updated to reinforce exact snake_case function name, reducing Gemini PascalCase hallucination frequency.

## Test plan

- [ ] Run `npx vitest run` — unit tests for tool name normalization (`registry.test.ts`), flat-arg wrapping, `overseerrMediaType` inference (`display-titles-tool.test.ts`), episode `thumbPath` (`overseerr.test.ts`), and llmSummary thumbPath enforcement (`llm-summary-thumbpath.test.ts`)
- [ ] Run E2E suite — new tests in `title-cards.spec.ts` cover More Info fallback, TMDB direct page, inferred `overseerrMediaType` → Request button visible
- [ ] Verify on beta with `gemini-2.5-flash-lite`: search for a TV show, confirm `display_titles` is called correctly (not `DisplayTitlesTitles`) and episode stills appear
- [ ] Confirm Request and More Info buttons appear on all card states (available, pending, not_requested)

https://claude.ai/code/session_01EHhUJ6mCYK1ZhHdiaKLaKi