### PR TITLE
Fix #294: recover thumbPath and seasonNumber when Gemini drops them

### DIFF
--- a/src/__tests__/lib/display-titles-tool.test.ts
+++ b/src/__tests__/lib/display-titles-tool.test.ts
@@ -305,3 +305,97 @@ describe("display_titles — overseerrMediaType inference", () => {
     expect(displayTitles[0].overseerrMediaType).toBe("tv");
   });
 });
+
+describe("display_titles — issue #294: Overseerr thumbPath recovery when LLM omits it", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("fetches thumbPath from Overseerr when overseerrId present but thumbPath missing", async () => {
+    const POSTER = "https://image.tmdb.org/t/p/w300/bPsxOpHVpVCX3hFz2fxnF1Vz3Dj.jpg";
+    vi.doMock("@/lib/services/overseerr", () => ({
+      getDetails: vi.fn().mockResolvedValue({ thumbPath: POSTER }),
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, json: async () => ({ MediaContainer: { machineIdentifier: "server1" } }),
+    }));
+
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "tv", title: "Star Trek", year: 1966, mediaStatus: "not_requested", overseerrId: 253, overseerrMediaType: "tv" }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ thumbUrl?: string }> };
+    expect(displayTitles[0].thumbUrl).toContain("bPsxOpHVpVCX3hFz2fxnF1Vz3Dj.jpg");
+  });
+
+  it("deduplicates Overseerr lookups: multiple season cards with same overseerrId fire one request", async () => {
+    const POSTER = "https://image.tmdb.org/t/p/w300/poster.jpg";
+    const getDetailsMock = vi.fn().mockResolvedValue({ thumbPath: POSTER });
+    vi.doMock("@/lib/services/overseerr", () => ({ getDetails: getDetailsMock }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, json: async () => ({ MediaContainer: { machineIdentifier: "server1" } }),
+    }));
+
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [
+        { mediaType: "tv", title: "The Office — Season 1", year: 2005, mediaStatus: "not_requested", overseerrId: 2316, seasonNumber: 1 },
+        { mediaType: "tv", title: "The Office — Season 2", year: 2005, mediaStatus: "not_requested", overseerrId: 2316, seasonNumber: 2 },
+        { mediaType: "tv", title: "The Office — Season 3", year: 2005, mediaStatus: "not_requested", overseerrId: 2316, seasonNumber: 3 },
+      ],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ thumbUrl?: string }> };
+
+    // One network call for all three season cards sharing the same overseerrId
+    expect(getDetailsMock).toHaveBeenCalledTimes(1);
+    // All three cards get the poster
+    expect(displayTitles[0].thumbUrl).toContain("poster.jpg");
+    expect(displayTitles[1].thumbUrl).toContain("poster.jpg");
+    expect(displayTitles[2].thumbUrl).toContain("poster.jpg");
+  });
+
+  it("does not call Overseerr when thumbPath is already provided by the LLM", async () => {
+    const getDetailsMock = vi.fn();
+    vi.doMock("@/lib/services/overseerr", () => ({ getDetails: getDetailsMock }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, json: async () => ({ MediaContainer: { machineIdentifier: "server1" } }),
+    }));
+
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "movie", title: "Inception", year: 2010, mediaStatus: "not_requested",
+        overseerrId: 27205, overseerrMediaType: "movie",
+        thumbPath: "https://image.tmdb.org/t/p/w300/already.jpg" }],
+    }));
+    expect(getDetailsMock).not.toHaveBeenCalled();
+  });
+
+  it("is non-fatal when Overseerr lookup fails", async () => {
+    vi.doMock("@/lib/services/overseerr", () => ({
+      getDetails: vi.fn().mockRejectedValue(new Error("Overseerr unavailable")),
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, json: async () => ({ MediaContainer: { machineIdentifier: "server1" } }),
+    }));
+
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "movie", title: "Inception", year: 2010, mediaStatus: "not_requested", overseerrId: 27205 }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ thumbUrl?: string }> };
+    // thumbUrl is undefined but no error thrown
+    expect(displayTitles[0].thumbUrl).toBeUndefined();
+  });
+});

--- a/src/__tests__/lib/display-titles-tool.test.ts
+++ b/src/__tests__/lib/display-titles-tool.test.ts
@@ -399,3 +399,62 @@ describe("display_titles — issue #294: Overseerr thumbPath recovery when LLM o
     expect(displayTitles[0].thumbUrl).toBeUndefined();
   });
 });
+
+describe("display_titles — seasonNumber recovery from title", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  const noOpFetch = vi.fn().mockResolvedValue({
+    ok: true, json: async () => ({ MediaContainer: { machineIdentifier: "server1" } }),
+  });
+
+  it("recovers seasonNumber from 'Show — Season N' title when LLM omits it", async () => {
+    vi.doMock("@/lib/services/overseerr", () => ({ getDetails: vi.fn().mockResolvedValue({ thumbPath: undefined }) }));
+    vi.stubGlobal("fetch", noOpFetch);
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "tv", title: "Breaking Bad — Season 3", mediaStatus: "not_requested", overseerrId: 1396 }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ seasonNumber?: number }> };
+    expect(displayTitles[0].seasonNumber).toBe(3);
+  });
+
+  it("handles em-dash, en-dash, and hyphen variants in title", async () => {
+    vi.doMock("@/lib/services/overseerr", () => ({ getDetails: vi.fn().mockResolvedValue({ thumbPath: undefined }) }));
+    vi.stubGlobal("fetch", noOpFetch);
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    for (const sep of ["—", "–", "-"]) {
+      vi.resetModules();
+      vi.doMock("@/lib/services/overseerr", () => ({ getDetails: vi.fn().mockResolvedValue({ thumbPath: undefined }) }));
+      const { registerDisplayTitlesTool: reg } = await import("@/lib/tools/display-titles-tool");
+      const { executeTool: exec } = await import("@/lib/tools/registry");
+      reg();
+      const raw = await exec("display_titles", JSON.stringify({
+        titles: [{ mediaType: "tv", title: `The Office ${sep} Season 2`, mediaStatus: "not_requested" }],
+      }));
+      const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ seasonNumber?: number }> };
+      expect(displayTitles[0].seasonNumber).toBe(2);
+    }
+  });
+
+  it("does not override an explicitly provided seasonNumber", async () => {
+    vi.doMock("@/lib/services/overseerr", () => ({ getDetails: vi.fn().mockResolvedValue({ thumbPath: undefined }) }));
+    vi.stubGlobal("fetch", noOpFetch);
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{ mediaType: "tv", title: "Severance — Season 1", mediaStatus: "not_requested", seasonNumber: 1 }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ seasonNumber?: number }> };
+    expect(displayTitles[0].seasonNumber).toBe(1);
+  });
+});

--- a/src/lib/tools/display-titles-tool.ts
+++ b/src/lib/tools/display-titles-tool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { defineTool } from "./registry";
 import { buildThumbUrl, getPlexMachineId, searchLibrary, findShowPlexKey } from "@/lib/services/plex";
+import * as overseerr from "@/lib/services/overseerr";
 import { getConfig } from "@/lib/config";
 import type { DisplayTitle } from "@/types/titles";
 
@@ -128,18 +129,57 @@ For overseerr_list_requests results: one card per request is correct (no season 
         }
       }
 
-      const displayTitles: DisplayTitle[] = args.titles.map((t, i) => ({
+      // Issue #294: Gemini Flash Lite reliably drops thumbPath when calling display_titles
+      // even though it was present in the search results. Recover it from Overseerr
+      // using the same side-query pattern as the plexKey lookup above.
+      // Deduplicate by overseerrId so season cards for the same show fire one request.
+      const thumbPathOverrides = new Map<number, string>(); // index → thumbPath
+      {
+        const needsThumb = args.titles
+          .map((t, i) => ({ t, i }))
+          .filter(({ t }) => !t.thumbPath && t.overseerrId != null);
+
+        if (needsThumb.length > 0) {
+          // Group by overseerrId — multiple season cards share the same poster.
+          const byId = new Map<number, { indices: number[]; mediaType: "movie" | "tv" }>();
+          for (const { t, i } of needsThumb) {
+            const id = t.overseerrId!;
+            const mt = (t.overseerrMediaType ?? (t.mediaType === "movie" ? "movie" : "tv")) as "movie" | "tv";
+            const existing = byId.get(id);
+            if (existing) {
+              existing.indices.push(i);
+            } else {
+              byId.set(id, { indices: [i], mediaType: mt });
+            }
+          }
+
+          await Promise.all(
+            Array.from(byId.entries()).map(async ([id, { indices, mediaType }]) => {
+              try {
+                const detail = await overseerr.getDetails(id, mediaType);
+                if (detail.thumbPath) {
+                  for (const i of indices) thumbPathOverrides.set(i, detail.thumbPath);
+                }
+              } catch { /* non-fatal */ }
+            }),
+          );
+        }
+      }
+
+      const displayTitles: DisplayTitle[] = args.titles.map((t, i) => {
+        const effectiveThumbPath = t.thumbPath ?? thumbPathOverrides.get(i);
+        return {
         mediaType: t.mediaType,
         title: t.title,
         year: t.year ?? undefined,
         summary: t.summary ?? undefined,
         rating: t.rating ?? undefined,
-        thumbUrl: t.thumbPath
-          ? (t.thumbPath.startsWith("http")
+        thumbUrl: effectiveThumbPath
+          ? (effectiveThumbPath.startsWith("http")
               // Proxy external TMDB/HTTP thumbnails through our server so they load
               // as same-origin resources (prevents ad-blocker / cross-origin blocking).
-              ? `/api/tmdb/thumb?url=${encodeURIComponent(t.thumbPath)}`
-              : buildThumbUrl(t.thumbPath))
+              ? `/api/tmdb/thumb?url=${encodeURIComponent(effectiveThumbPath)}`
+              : buildThumbUrl(effectiveThumbPath))
           : undefined,
         plexKey: t.plexKey ?? plexKeyOverrides.get(i) ?? undefined,
         plexUrl: baseUrl,
@@ -156,7 +196,8 @@ For overseerr_list_requests results: one card per request is correct (no season 
         showTitle: t.showTitle ?? undefined,
         seasonNumber: t.seasonNumber ?? undefined,
         episodeNumber: t.episodeNumber ?? undefined,
-      }));
+        };
+      });
 
       return { displayTitles };
     },

--- a/src/lib/tools/display-titles-tool.ts
+++ b/src/lib/tools/display-titles-tool.ts
@@ -194,7 +194,13 @@ For overseerr_list_requests results: one card per request is correct (no season 
         cast: t.cast ?? undefined,
         airDate: t.airDate ?? undefined,
         showTitle: t.showTitle ?? undefined,
-        seasonNumber: t.seasonNumber ?? undefined,
+        // If the LLM drops seasonNumber, recover it from the title string.
+        // The system prompt requires season cards to be titled "Show Name — Season N",
+        // so we can parse it back deterministically.
+        seasonNumber: t.seasonNumber ??
+          (/[—–-]\s*Season\s+(\d+)/i.exec(t.title)?.[1]
+            ? parseInt(/[—–-]\s*Season\s+(\d+)/i.exec(t.title)![1], 10)
+            : undefined),
         episodeNumber: t.episodeNumber ?? undefined,
         };
       });


### PR DESCRIPTION
## Summary

- **thumbPath recovery (#294):** When Gemini Flash Lite omits `thumbPath` from a `display_titles` call despite it being present in Overseerr results, the handler now fires a side-query to `overseerr.getDetails()` to recover the poster URL. Deduplicated by `overseerrId` — 10 season cards for the same show trigger 1 request, not 10. Confirmed in Langfuse trace `7ee0136a` — 10 Star Trek titles all had `thumbPath` in the tool result, all were dropped in the subsequent `display_titles` call.

- **seasonNumber recovery:** When Gemini drops `seasonNumber` from season cards, it's parsed back deterministically from the title string (`"Show Name — Season N"` → `N`). The title format is enforced by the system prompt, so this is lossless recovery. Missing `seasonNumber` was the cause of the "got stuck" symptom — without it the Request button couldn't route correctly.

Both follow the same server-side recovery pattern as the `plexKey` lookup (#117) and `overseerrMediaType` inference already on `dev`. Non-fatal — if Overseerr is unavailable cards render without thumbnails rather than erroring.

## Test plan

- [ ] `npx vitest run` — new tests for thumbPath recovery (deduplication, non-fatal failure, no-op when already provided) and seasonNumber recovery (em-dash/en-dash/hyphen variants, no override when present)
- [ ] On beta with `gemini-2.5-flash-lite`: search "Star Trek" — all title cards should show poster images and Request buttons should work

https://claude.ai/code/session_01EHhUJ6mCYK1ZhHdiaKLaKi