### PR TITLE
chore: bump version to 1.1.5 for production release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.5-beta.7",
+  "version": "1.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps `package.json` from `1.1.5-beta.7` → `1.1.5` ahead of the `dev → beta → main` production release flow.

https://claude.ai/code/session_01EHhUJ6mCYK1ZhHdiaKLaKi