### PR TITLE
Fix #301 (Gemini hang) and #302 (network error on slow responses)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -286,6 +286,12 @@ Manifest + service worker (network-first). Platform-aware install UI: Android na
 ### Conversation History Cap
 Last 20 messages sent to LLM. Prevents unbounded token growth on long conversations.
 
+### Gemini Empty Response Retry
+When `gemini-2.5-flash-lite` (and similar) returns 0 output tokens with no text and no tool calls after a tool result, the orchestrator retries the LLM call up to `MAX_EMPTY_RESPONSE_RETRIES` (2) times. If all retries are exhausted, the orchestrator yields `{ type: "error" }` rather than a silent empty done event (which left the user staring at a blank response). Each retry uses a distinct Langfuse generation span name (`llm-round-N-retry-M`) to preserve observability.
+
+### SSE Heartbeat Interval and Network Error Recovery
+The chat SSE heartbeat is sent every 5 seconds (down from 15 s) to reset reverse-proxy idle timeouts on long LLM responses. When the streaming connection drops mid-response (e.g. a 30+ second GPT-4.1 reply hitting a 30 s proxy timeout), the client `use-chat.ts` now suppresses the "Network error" toast and lets the post-stream reload recover the completed response silently. The error is only surfaced if the server-side reload also fails or returns no assistant content.
+
 ### Gemini Parallel Tool-Call Concatenation Repair
 Some Gemini variants (e.g. `gemini-2.5-flash-lite`) emit parallel tool calls as a single concatenated call: the tool name becomes two registered names joined (e.g. `sonarr_search_seriesplex_search_library`) and the arguments become two JSON objects concatenated (`{"term":"X"}{"query":"X"}`). `trySplitConcatenatedCall()` and `trySplitJsonArgs()` in `orchestrator.ts` detect this pattern and split it back into two valid calls before execution. The system prompt also includes an explicit instruction not to concatenate tool calls.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -406,6 +406,105 @@ describe("orchestrator — LLM error sanitization", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Empty response retry tests (issues #301/#302 — Gemini Flash hang)
+// ---------------------------------------------------------------------------
+
+describe("orchestrator — empty response retry", () => {
+  it("retries and recovers when the LLM returns 0 tokens on the first attempt", async () => {
+    let callCount = 0;
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async () => {
+              callCount++;
+              if (callCount === 1) {
+                // First call: simulate Gemini empty response (0 output tokens, no content)
+                return (async function* () {
+                  yield { choices: [{ delta: {} }], usage: null };
+                  yield {
+                    choices: [],
+                    usage: { prompt_tokens: 100, completion_tokens: 0, total_tokens: 100 },
+                  };
+                })();
+              }
+              // Second call: real response
+              return (async function* () {
+                yield { choices: [{ delta: { content: "The Testaments has not been requested yet." } }], usage: null };
+                yield {
+                  choices: [],
+                  usage: { prompt_tokens: 100, completion_tokens: 12, total_tokens: 112 },
+                };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gemini-2.5-flash-lite",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+    const events: { type: string; content?: string; message?: string }[] = [];
+    for await (const event of orchestrate({ conversationId, userMessage: "Is the testaments requested?" })) {
+      events.push(event as { type: string; content?: string; message?: string });
+    }
+
+    // Should have retried and yielded the real text response
+    expect(callCount).toBe(2);
+    const textEvent = events.find((e) => e.type === "text_delta");
+    expect(textEvent).toBeDefined();
+    expect(textEvent!.content).toMatch(/Testaments/);
+    const doneEvent = events.find((e) => e.type === "done");
+    expect(doneEvent).toBeDefined();
+    const errorEvents = events.filter((e) => e.type === "error");
+    expect(errorEvents).toHaveLength(0);
+  });
+
+  it("yields an error after all retries are exhausted with empty responses", async () => {
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async () => {
+              // Always return empty
+              return (async function* () {
+                yield { choices: [{ delta: {} }], usage: null };
+                yield {
+                  choices: [],
+                  usage: { prompt_tokens: 100, completion_tokens: 0, total_tokens: 100 },
+                };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gemini-2.5-flash-lite",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+    const events: { type: string; message?: string }[] = [];
+    for await (const event of orchestrate({ conversationId, userMessage: "Hello" })) {
+      events.push(event as { type: string; message?: string });
+    }
+
+    // Should yield an error, not a silent empty done
+    const errorEvent = events.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent!.message).toBe("The AI service encountered an error. Please try again.");
+    const doneEvent = events.find((e) => e.type === "done");
+    expect(doneEvent).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // trimToolHistory — pure unit tests (no DB or LLM mock needed)
 // ---------------------------------------------------------------------------
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -113,11 +113,13 @@ export async function POST(request: Request) {
         }
       };
 
-      // Send an SSE comment every 15 seconds so the client stays connected
+      // Send an SSE comment every 5 seconds so the client stays connected
       // while the backend is waiting for the LLM or tool execution to finish.
+      // 5s is short enough to keep alive most reverse-proxy idle timeouts
+      // (e.g. Synology DSM default is 30 s) even on slow 30+ second responses.
       const heartbeat = setInterval(() => {
         enqueue(encoder.encode(": heartbeat\n\n"));
-      }, 15000);
+      }, 5000);
 
       try {
         for await (const event of orchestrate({

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -91,6 +91,10 @@ export function useChat(conversationId: string | null, options?: UseChatOptions)
       abortRef.current = controller;
 
       let phase: "fetch" | "stream" = "fetch";
+      // If the streaming connection drops after the server has already saved
+      // the response (e.g. proxy timeout on a slow LLM), we suppress the
+      // error and let the finally-block reload recover the completed message.
+      let suppressedStreamError: string | null = null;
       try {
         const res = await fetch("/api/chat", {
           method: "POST",
@@ -187,14 +191,25 @@ export function useChat(conversationId: string | null, options?: UseChatOptions)
           online,
           conversationId: convId,
         });
-        const userMsg =
-          errMsg === "Failed to fetch" || errMsg === "NetworkError when attempting to fetch resource."
-            ? online === false
-              ? "Network error: you appear to be offline"
-              : "Network error: could not reach the server"
-            : errMsg;
-        setError(userMsg);
-        setMessages((prev) => prev.filter((m) => m.id !== assistantId || (m.content && m.content.length > 0)));
+        const isNetworkError =
+          errMsg === "Failed to fetch" || errMsg === "NetworkError when attempting to fetch resource.";
+        const userMsg = isNetworkError
+          ? online === false
+            ? "Network error: you appear to be offline"
+            : "Network error: could not reach the server"
+          : errMsg;
+        // If the connection dropped mid-stream (not during the initial fetch),
+        // the server may have completed and saved the response. Suppress the
+        // error for now — the finally-block reload will recover it. Only show
+        // the error if the reload itself also fails or returns no response.
+        if (phase === "stream" && isNetworkError) {
+          suppressedStreamError = userMsg;
+          // Remove the empty placeholder so the reload result fills the slot cleanly
+          setMessages((prev) => prev.filter((m) => m.id !== assistantId || (m.content && m.content.length > 0)));
+        } else {
+          setError(userMsg);
+          setMessages((prev) => prev.filter((m) => m.id !== assistantId || (m.content && m.content.length > 0)));
+        }
       } finally {
         streamingRef.current = false;
         setStreaming(false);
@@ -211,6 +226,17 @@ export function useChat(conversationId: string | null, options?: UseChatOptions)
             if (data.success && data.data.messages && conversationIdRef.current === convId) {
               setMessages(data.data.messages);
               setToolCalls(new Map());
+              // If the stream dropped but the server saved a real assistant
+              // response, the reload recovered it — no error needed.
+              // Only surface the error if the reload produced no response.
+              if (suppressedStreamError) {
+                const hasResponse = (data.data.messages as { role: string; content?: string }[]).some(
+                  (m) => m.role === "assistant" && m.content && m.content.length > 0,
+                );
+                if (!hasResponse) setError(suppressedStreamError);
+              }
+            } else if (suppressedStreamError) {
+              setError(suppressedStreamError);
             }
           } catch (e: unknown) {
             // Best-effort — messages stay as optimistic state if reload fails
@@ -220,7 +246,10 @@ export function useChat(conversationId: string | null, options?: UseChatOptions)
               online: typeof navigator !== "undefined" ? navigator.onLine : null,
               conversationId: convId,
             });
+            if (suppressedStreamError) setError(suppressedStreamError);
           }
+        } else if (suppressedStreamError) {
+          setError(suppressedStreamError);
         }
       }
     },

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -34,6 +34,7 @@ interface OrchestratorParams {
 type ChatMessage = OpenAI.ChatCompletionMessageParam;
 
 const MAX_TOOL_ROUNDS = 8;
+const MAX_EMPTY_RESPONSE_RETRIES = 2;
 
 /**
  * Retry an LLM API call on 429 rate-limit responses with exponential backoff.
@@ -478,130 +479,177 @@ export async function* orchestrate(
     let completionTokens: number | undefined;
     let totalTokens: number | undefined;
 
-    try {
-      const llmStart = Date.now();
-      const generation = trace?.generation({
-        name: `llm-round-${round}`,
-        model,
-        input: apiMessages,
-        startTime: new Date(llmStart),
-      }) ?? null;
-      const stream = await callWithRateLimitRetry(
-        () =>
-          client.chat.completions.create({
-            model,
-            messages: apiMessages,
-            stream: true,
-            stream_options: { include_usage: true },
-            ...(tools && tools.length > 0 ? { tools } : {}),
-          }),
-        conversationId,
-        round,
-      );
+    // Inner retry loop: some models (e.g. Gemini Flash) occasionally return
+    // 0 output tokens with no tool calls — an empty response that leaves the
+    // user staring at a spinner forever. Retry up to MAX_EMPTY_RESPONSE_RETRIES
+    // times before giving up and yielding an error.
+    for (let emptyRetry = 0; emptyRetry <= MAX_EMPTY_RESPONSE_RETRIES; emptyRetry++) {
+      if (emptyRetry > 0) {
+        // Reset accumulators for the retry attempt
+        fullContent = "";
+        toolCalls.length = 0;
+        llmDurationMs = undefined;
+        promptTokens = undefined;
+        completionTokens = undefined;
+        totalTokens = undefined;
+      }
 
-      // Accumulate streaming chunks
-      // Key by tool-call id rather than stream index. OpenAI uses distinct
-      // indices for parallel tool calls; Gemini sends all at index 0 with
-      // distinct ids. Keying by id handles both — indexToCurrentId maps an
-      // index to whichever id arrived most recently at that index, so
-      // continuation chunks (empty id) are associated correctly.
-      const toolCallDeltas: Map<string, { id: string; name: string; args: string }> = new Map();
-      const indexToCurrentId: Map<number, string> = new Map();
+      const roundLabel = emptyRetry === 0 ? `llm-round-${round}` : `llm-round-${round}-retry-${emptyRetry}`;
 
-      for await (const chunk of stream) {
-        // Token usage is sent in the final chunk
-        if (chunk.usage) {
-          promptTokens = chunk.usage.prompt_tokens;
-          completionTokens = chunk.usage.completion_tokens;
-          totalTokens = chunk.usage.total_tokens;
-        }
+      try {
+        const llmStart = Date.now();
+        const generation = trace?.generation({
+          name: roundLabel,
+          model,
+          input: apiMessages,
+          startTime: new Date(llmStart),
+        }) ?? null;
+        const stream = await callWithRateLimitRetry(
+          () =>
+            client.chat.completions.create({
+              model,
+              messages: apiMessages,
+              stream: true,
+              stream_options: { include_usage: true },
+              ...(tools && tools.length > 0 ? { tools } : {}),
+            }),
+          conversationId,
+          round,
+        );
 
-        const choice = chunk.choices[0];
-        if (!choice) continue;
+        // Accumulate streaming chunks
+        // Key by tool-call id rather than stream index. OpenAI uses distinct
+        // indices for parallel tool calls; Gemini sends all at index 0 with
+        // distinct ids. Keying by id handles both — indexToCurrentId maps an
+        // index to whichever id arrived most recently at that index, so
+        // continuation chunks (empty id) are associated correctly.
+        const toolCallDeltas: Map<string, { id: string; name: string; args: string }> = new Map();
+        const indexToCurrentId: Map<number, string> = new Map();
 
-        const delta = choice.delta;
+        for await (const chunk of stream) {
+          // Token usage is sent in the final chunk
+          if (chunk.usage) {
+            promptTokens = chunk.usage.prompt_tokens;
+            completionTokens = chunk.usage.completion_tokens;
+            totalTokens = chunk.usage.total_tokens;
+          }
 
-        // Text content — accumulate but do NOT yield yet.
-        // We defer yielding until after the full stream is consumed so we can
-        // tell whether the LLM also emitted tool calls in this same response.
-        // If it did, the text is a premature / speculative answer produced
-        // before the tools ran and should be suppressed entirely (the next LLM
-        // turn after seeing the tool results will produce the real answer).
-        if (delta?.content) {
-          fullContent += delta.content;
-        }
+          const choice = chunk.choices[0];
+          if (!choice) continue;
 
-        // Tool call deltas
-        if (delta?.tool_calls) {
-          for (const tc of delta.tool_calls) {
-            const idx = tc.index;
-            // A non-empty id signals the start of a new tool call at this index.
-            // Update the index→id mapping so subsequent continuation chunks
-            // (which arrive with an empty id) attach to the right entry.
-            if (tc.id) {
-              indexToCurrentId.set(idx, tc.id);
-              if (!toolCallDeltas.has(tc.id)) {
-                toolCallDeltas.set(tc.id, { id: tc.id, name: "", args: "" });
+          const delta = choice.delta;
+
+          // Text content — accumulate but do NOT yield yet.
+          // We defer yielding until after the full stream is consumed so we can
+          // tell whether the LLM also emitted tool calls in this same response.
+          // If it did, the text is a premature / speculative answer produced
+          // before the tools ran and should be suppressed entirely (the next LLM
+          // turn after seeing the tool results will produce the real answer).
+          if (delta?.content) {
+            fullContent += delta.content;
+          }
+
+          // Tool call deltas
+          if (delta?.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              const idx = tc.index;
+              // A non-empty id signals the start of a new tool call at this index.
+              // Update the index→id mapping so subsequent continuation chunks
+              // (which arrive with an empty id) attach to the right entry.
+              if (tc.id) {
+                indexToCurrentId.set(idx, tc.id);
+                if (!toolCallDeltas.has(tc.id)) {
+                  toolCallDeltas.set(tc.id, { id: tc.id, name: "", args: "" });
+                }
               }
+              const currentId = indexToCurrentId.get(idx);
+              if (!currentId) continue;
+              const entry = toolCallDeltas.get(currentId)!;
+              if (tc.function?.name) entry.name += tc.function.name;
+              if (tc.function?.arguments) entry.args += tc.function.arguments;
             }
-            const currentId = indexToCurrentId.get(idx);
-            if (!currentId) continue;
-            const entry = toolCallDeltas.get(currentId)!;
-            if (tc.function?.name) entry.name += tc.function.name;
-            if (tc.function?.arguments) entry.args += tc.function.arguments;
           }
         }
-      }
 
-      llmDurationMs = Date.now() - llmStart;
+        llmDurationMs = Date.now() - llmStart;
 
-      // Close the Langfuse generation span with output and token usage
-      generation?.end({
-        output: fullContent || null,
-        usage: {
-          input: promptTokens,
-          output: completionTokens,
-          total: totalTokens,
-          unit: "TOKENS",
-        },
-      });
+        // Close the Langfuse generation span with output and token usage
+        generation?.end({
+          output: fullContent || null,
+          usage: {
+            input: promptTokens,
+            output: completionTokens,
+            total: totalTokens,
+            unit: "TOKENS",
+          },
+        });
 
-      // Collect completed tool calls, repairing Gemini's concatenation bug
-      // where two parallel calls are emitted as one (e.g. name =
-      // "sonarr_search_seriesplex_search_library"). trySplitConcatenatedCall
-      // detects this pattern and returns the two correct calls instead.
-      const registeredNames = getRegisteredToolNames();
-      for (const [, tc] of toolCallDeltas) {
-        if (tc.id && tc.name) {
-          const raw: RawToolCall = { id: tc.id, function: { name: tc.name, arguments: tc.args } };
-          const split = trySplitConcatenatedCall(raw, registeredNames);
-          if (split) {
-            logger.warn("Gemini concatenated tool calls detected, splitting", {
-              conversationId,
-              concatenated: tc.name,
-              into: split.map((s) => s.function.name),
-            });
-            toolCalls.push(...split);
-          } else {
-            toolCalls.push(raw);
+        // Collect completed tool calls, repairing Gemini's concatenation bug
+        // where two parallel calls are emitted as one (e.g. name =
+        // "sonarr_search_seriesplex_search_library"). trySplitConcatenatedCall
+        // detects this pattern and returns the two correct calls instead.
+        const registeredNames = getRegisteredToolNames();
+        for (const [, tc] of toolCallDeltas) {
+          if (tc.id && tc.name) {
+            const raw: RawToolCall = { id: tc.id, function: { name: tc.name, arguments: tc.args } };
+            const split = trySplitConcatenatedCall(raw, registeredNames);
+            if (split) {
+              logger.warn("Gemini concatenated tool calls detected, splitting", {
+                conversationId,
+                concatenated: tc.name,
+                into: split.map((s) => s.function.name),
+              });
+              toolCalls.push(...split);
+            } else {
+              toolCalls.push(raw);
+            }
           }
         }
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : "LLM request failed";
+        const errorCategory = /429|quota|rate.?limit/i.test(msg) ? "rate_limit"
+          : /401|403|unauthorized|forbidden/i.test(msg) ? "auth_error"
+          : "llm_error";
+        logger.error("LLM request failed", { conversationId, round, error: msg, errorCategory });
+        trace?.update({ output: `error: ${errorCategory}` });
+        flushLangfuse();
+        yield { type: "error", message: sanitizeLlmError(msg) };
+        return;
       }
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "LLM request failed";
-      const errorCategory = /429|quota|rate.?limit/i.test(msg) ? "rate_limit"
-        : /401|403|unauthorized|forbidden/i.test(msg) ? "auth_error"
-        : "llm_error";
-      logger.error("LLM request failed", { conversationId, round, error: msg, errorCategory });
-      trace?.update({ output: `error: ${errorCategory}` });
-      flushLangfuse();
-      yield { type: "error", message: sanitizeLlmError(msg) };
-      return;
+
+      // Detect empty response: 0 output tokens, no text, no tool calls.
+      // Some models (notably Gemini Flash variants) silently return nothing
+      // after tool calls. Retry before treating it as a final empty response.
+      const isEmpty = fullContent === "" && toolCalls.length === 0 && (completionTokens ?? 0) === 0;
+      if (isEmpty && emptyRetry < MAX_EMPTY_RESPONSE_RETRIES) {
+        logger.warn("LLM returned empty response, retrying", {
+          conversationId,
+          round,
+          emptyRetry: emptyRetry + 1,
+          model,
+        });
+        continue;
+      }
+      break; // got a real response (or exhausted retries)
     }
 
     // If no tool calls, this is the final assistant response — yield the
     // accumulated text now that we know no tool calls came in this round.
     if (toolCalls.length === 0) {
+      // If retries were exhausted and the response is still empty, surface an
+      // error rather than silently yielding nothing (which leaves the user
+      // staring at a blank message).
+      if (fullContent === "" && (completionTokens ?? 0) === 0) {
+        logger.error("LLM returned empty response after all retries", {
+          conversationId,
+          round,
+          model,
+        });
+        trace?.update({ output: "error: empty_response" });
+        flushLangfuse();
+        yield { type: "error", message: "The AI service encountered an error. Please try again." };
+        return;
+      }
       if (fullContent) {
         yield { type: "text_delta", content: fullContent };
       }


### PR DESCRIPTION
## Summary

- **#301 — Gemini 2.5 Flash Lite hang**: `gemini-2.5-flash-lite` was silently returning 0 output tokens after tool calls, leaving the user staring at an infinite spinner. The orchestrator now retries the LLM call up to 2 times when `completionTokens === 0` with no text and no tool calls. After all retries are exhausted it yields an error event rather than a silent empty done. Diagnosed via Langfuse trace `f0c1f078` (score: `user-report: 0, comment: "Hang"`).

- **#302 — Network error on slow GPT-4.1 response**: A 7-turn session accumulated enough context that GPT-4.1 took 30.6 s total (15 s in llm-round-2 at 1.5 tok/s due to server-side load). The Synology reverse proxy dropped the connection at the ~30 s mark. Two fixes: (1) SSE heartbeat reduced from 15 s → 5 s to reset the proxy's idle timer more aggressively; (2) `use-chat.ts` now suppresses the "Network error" toast when the stream drops mid-response and lets the post-stream reload silently recover the completed reply — the error only surfaces if the reload itself fails or returns no assistant content. Diagnosed via Langfuse trace `2ce031be` (score: `user-report: 0, comment: "Network error"`).

## Test plan

- [ ] Unit tests: 2 new tests in `orchestrator.test.ts` — retry recovers on second attempt; error yielded when all retries return empty
- [ ] Manual: send a message with Gemini 2.5 Flash Lite and confirm no hang if the model returns an empty response
- [ ] Manual: confirm long responses (>15 s) no longer show a spurious "Network error" toast when the server successfully completes

https://claude.ai/code/session_01LJqpE3xQ7JuWqNZdqjVELP