### PR TITLE
Merge pull request #306 from chrisrothwell/claude/fix-gemini-dangling-messages-305-Kp9mX

Fix #305: delete dangling tool messages when Gemini empty-response error fires

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -286,8 +286,12 @@ Manifest + service worker (network-first). Platform-aware install UI: Android na
 ### Conversation History Cap
 Last 20 messages sent to LLM. Prevents unbounded token growth on long conversations.
 
-### Gemini Empty Response Retry
-When `gemini-2.5-flash-lite` (and similar) returns 0 output tokens with no text and no tool calls after a tool result, the orchestrator retries the LLM call up to `MAX_EMPTY_RESPONSE_RETRIES` (2) times. If all retries are exhausted, the orchestrator yields `{ type: "error" }` rather than a silent empty done event (which left the user staring at a blank response). Each retry uses a distinct Langfuse generation span name (`llm-round-N-retry-M`) to preserve observability.
+### Gemini Empty Response Retry + Dangling Message Cleanup
+When `gemini-2.5-flash-lite` (and similar) returns 0 output tokens with no text and no tool calls after a tool result, the orchestrator retries the LLM call up to `MAX_EMPTY_RESPONSE_RETRIES` (2) times. If all retries are exhausted, the orchestrator:
+1. Deletes the `assistant(tool_calls)` and `tool(result)` messages saved in the current round from the DB — without this, each failure leaves a dangling unclosed tool sequence in history; on subsequent requests these accumulate and Gemini (stricter about conversation format than OpenAI) refuses to generate output entirely, breaking every follow-up request in the same conversation.
+2. Yields `{ type: "error" }` rather than a silent empty done event.
+
+Each retry uses a distinct Langfuse generation span name (`llm-round-N-retry-M`) to preserve observability.
 
 ### SSE Heartbeat Interval and Network Error Recovery
 The chat SSE heartbeat is sent every 5 seconds (down from 15 s) to reset reverse-proxy idle timeouts on long LLM responses. When the streaming connection drops mid-response (e.g. a 30+ second GPT-4.1 reply hitting a 30 s proxy timeout), the client `use-chat.ts` now suppresses the "Network error" toast and lets the post-stream reload recover the completed response silently. The error is only surfaced if the server-side reload also fails or returns no assistant content.

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -502,6 +502,85 @@ describe("orchestrator — empty response retry", () => {
     const doneEvent = events.find((e) => e.type === "done");
     expect(doneEvent).toBeUndefined();
   });
+
+  it("deletes dangling assistant+tool messages when round-1 exhausts retries (issue #305)", async () => {
+    // Round 0 returns a tool call; round 1 always returns empty.
+    // The assistant(tool_calls) + tool(result) messages saved in round 0 must be
+    // deleted from the DB so they don't accumulate and corrupt subsequent requests.
+    let callCount = 0;
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async () => {
+              callCount++;
+              if (callCount === 1) {
+                // Round 0: return a tool call
+                return (async function* () {
+                  yield {
+                    choices: [{
+                      delta: {
+                        tool_calls: [{ index: 0, id: "call_test_123", function: { name: "overseerr_search", arguments: '{"term":"The Testaments"}' } }],
+                      },
+                    }],
+                    usage: null,
+                  };
+                  yield {
+                    choices: [],
+                    usage: { prompt_tokens: 100, completion_tokens: 19, total_tokens: 119 },
+                  };
+                })();
+              }
+              // Round 1 (and all retries): always empty
+              return (async function* () {
+                yield { choices: [{ delta: {} }], usage: null };
+                yield {
+                  choices: [],
+                  usage: { prompt_tokens: 200, completion_tokens: 0, total_tokens: 200 },
+                };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gemini-2.5-flash-lite",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+    vi.doMock("@/lib/tools/registry", () => ({
+      hasTools: () => true,
+      getOpenAITools: () => [{ type: "function", function: { name: "overseerr_search", description: "Search", parameters: {} } }],
+      executeTool: vi.fn(async () => JSON.stringify({ results: [{ title: "The Testaments", mediaStatus: "not_requested" }] })),
+      getToolLlmContent: (_name: string, result: string) => result,
+      getRegisteredToolNames: () => ["overseerr_search"],
+    }));
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+    const { eq: drizzleEq } = await import("drizzle-orm");
+    const events: { type: string; message?: string }[] = [];
+    for await (const event of orchestrate({ conversationId, userMessage: "Is the testaments requested?" })) {
+      events.push(event as { type: string; message?: string });
+    }
+
+    // Should yield an error
+    const errorEvent = events.find((e) => e.type === "error");
+    expect(errorEvent).toBeDefined();
+
+    // Only the user message should remain in DB — the dangling assistant+tool messages
+    // from round 0 must have been deleted so they don't corrupt subsequent requests.
+    const remaining = testDb
+      .select()
+      .from(schema.messages)
+      .where(drizzleEq(schema.messages.conversationId, conversationId))
+      .all();
+
+    const roles = remaining.map((m) => m.role);
+    expect(roles).toEqual(["user"]);
+    expect(remaining.filter((m) => m.role === "assistant" && m.toolCalls)).toHaveLength(0);
+    expect(remaining.filter((m) => m.role === "tool")).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import { getLlmClient, getLlmModel, getLlmClientForEndpoint } from "./client";
 import { buildSystemPrompt } from "./system-prompt";
 import { getDb, schema } from "@/lib/db";
-import { eq, asc } from "drizzle-orm";
+import { eq, asc, inArray } from "drizzle-orm";
 import { initializeTools } from "@/lib/tools/init";
 import { getOpenAITools, executeTool, hasTools, getToolLlmContent, getRegisteredToolNames } from "@/lib/tools/registry";
 import { logger } from "@/lib/logger";
@@ -361,6 +361,15 @@ function saveMessage(
   return id;
 }
 
+/** Delete a set of messages by ID (used to clean up dangling tool-round messages on error). */
+function deleteMessages(messageIds: string[]): void {
+  if (messageIds.length === 0) return;
+  const db = getDb();
+  db.delete(schema.messages)
+    .where(inArray(schema.messages.id, messageIds))
+    .run();
+}
+
 type RawToolCall = { id: string; function: { name: string; arguments: string } };
 
 /**
@@ -471,6 +480,12 @@ export async function* orchestrate(
   });
 
   // 3. Tool call loop
+  // Tracks assistant + tool result message IDs saved in the previous round.
+  // If the next round exhausts all empty-response retries, these are deleted from
+  // the DB so the conversation history does not accumulate dangling
+  // assistant(tool_calls)+tool(result) sequences that confuse strict models (Gemini).
+  let lastRoundCleanupIds: string[] = [];
+
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     let fullContent = "";
     const toolCalls: { id: string; function: { name: string; arguments: string } }[] = [];
@@ -645,6 +660,20 @@ export async function* orchestrate(
           round,
           model,
         });
+        // Remove the assistant(tool_calls)+tool(result) messages saved in the
+        // previous round from the DB. Without this, each failed attempt leaves
+        // a dangling unclosed tool sequence in history. On subsequent requests
+        // those sequences accumulate and Gemini (which is stricter about
+        // conversation format than OpenAI) refuses to generate any output at all,
+        // breaking every follow-up request in the same conversation.
+        if (lastRoundCleanupIds.length > 0) {
+          deleteMessages(lastRoundCleanupIds);
+          logger.info("Cleaned up dangling tool-round messages after empty response", {
+            conversationId,
+            round,
+            deletedCount: lastRoundCleanupIds.length,
+          });
+        }
         trace?.update({ output: "error: empty_response" });
         flushLangfuse();
         yield { type: "error", message: "The AI service encountered an error. Please try again." };
@@ -685,9 +714,11 @@ export async function* orchestrate(
         function: tc.function,
       })),
     );
-    saveMessage(conversationId, "assistant", fullContent || null, {
+    const assistantMsgId = saveMessage(conversationId, "assistant", fullContent || null, {
       toolCalls: serializedToolCalls,
     });
+    // Begin tracking IDs for this round in case the next round exhausts retries
+    lastRoundCleanupIds = [assistantMsgId];
 
     // Add assistant message to conversation for next round
     apiMessages.push({
@@ -755,11 +786,12 @@ export async function* orchestrate(
     for (const { tc, result, isError, durationMs } of toolResults) {
       // Save tool result to DB (even on error — ensures the API message sequence stays valid)
       try {
-        saveMessage(conversationId, "tool", result, {
+        const toolMsgId = saveMessage(conversationId, "tool", result, {
           toolCallId: tc.id,
           toolName: tc.function.name,
           durationMs,
         });
+        lastRoundCleanupIds.push(toolMsgId);
         logger.info("Tool result saved", { conversationId, toolCallId: tc.id, toolName: tc.function.name, durationMs, isError });
       } catch (e: unknown) {
         logger.error("Failed to save tool result — conversation will be broken", {


### PR DESCRIPTION
## Summary

<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->

-

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

<!-- What should be manually verified on the :beta image? -->

- [ ]
