### PR TITLE
Fix #305 #308: clean up dangling tool messages and collapse ghost use…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -287,11 +287,15 @@ Manifest + service worker (network-first). Platform-aware install UI: Android na
 Last 20 messages sent to LLM. Prevents unbounded token growth on long conversations.
 
 ### Gemini Empty Response Retry + Dangling Message Cleanup
-When `gemini-2.5-flash-lite` (and similar) returns 0 output tokens with no text and no tool calls after a tool result, the orchestrator retries the LLM call up to `MAX_EMPTY_RESPONSE_RETRIES` (2) times. If all retries are exhausted, the orchestrator:
-1. Deletes the `assistant(tool_calls)` and `tool(result)` messages saved in the current round from the DB — without this, each failure leaves a dangling unclosed tool sequence in history; on subsequent requests these accumulate and Gemini (stricter about conversation format than OpenAI) refuses to generate output entirely, breaking every follow-up request in the same conversation.
-2. Yields `{ type: "error" }` rather than a silent empty done event.
+When `gemini-2.5-flash-lite` (and similar) returns 0 output tokens with no text and no tool calls after a tool result, the orchestrator retries the LLM call up to `MAX_EMPTY_RESPONSE_RETRIES` (2) times. If all retries are exhausted (or any other error fires), the orchestrator:
+1. Deletes **all tool-round messages** (`assistant(tool_calls)` + `tool(result)` from every round) from the DB — tracked in `toolRoundMessageIds`. Without this, each failure leaves dangling unclosed tool sequences in history; Gemini (stricter about conversation format than OpenAI) refuses to generate output on every subsequent request.
+2. **Keeps the user message** in the DB intentionally — the user genuinely typed and sent it; the UI shows it as "message sent, no reply came back", which is consistent with Langfuse traces.
+3. Yields `{ type: "error" }` rather than a silent empty done event.
 
-Each retry uses a distinct Langfuse generation span name (`llm-round-N-retry-M`) to preserve observability.
+### Ghost User Turn Collapse
+When a request fails after saving its user message but before saving any assistant response, the user message remains in the DB. If the user retries, `saveMessage()` saves another user message, producing consecutive user turns in history (`[user#1, user#2]`). Gemini's strict alternating-turn format then returns 0 output tokens on every retry, permanently breaking the conversation.
+
+`loadHistory()` detects consecutive user messages and skips the earlier "ghost" messages from the LLM context. Ghost messages remain in the DB for UI display but are never resent to the LLM — only the most recent user message in any consecutive run is included in the API call.
 
 ### SSE Heartbeat Interval and Network Error Recovery
 The chat SSE heartbeat is sent every 5 seconds (down from 15 s) to reset reverse-proxy idle timeouts on long LLM responses. When the streaming connection drops mid-response (e.g. a 30+ second GPT-4.1 reply hitting a 30 s proxy timeout), the client `use-chat.ts` now suppresses the "Network error" toast and lets the post-stream reload recover the completed response silently. The error is only surfaced if the server-side reload also fails or returns no assistant content.

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -592,12 +592,12 @@ describe("orchestrator — empty response retry", () => {
 
 describe("ghost user message collapse in loadHistory", () => {
   let sqlite: import("better-sqlite3").Database;
-  let testDb: ReturnType<typeof drizzle>;
+  let testDb: ReturnType<typeof drizzle<typeof schema>>;
 
   beforeEach(async () => {
     const Database = (await import("better-sqlite3")).default;
     sqlite = new Database(":memory:");
-    testDb = drizzle(sqlite);
+    testDb = drizzle(sqlite, { schema });
     migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
     vi.resetModules();
   });

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -503,10 +503,12 @@ describe("orchestrator — empty response retry", () => {
     expect(doneEvent).toBeUndefined();
   });
 
-  it("deletes dangling assistant+tool messages when round-1 exhausts retries (issue #305)", async () => {
+  it("keeps user message but deletes tool-round messages when round-1 exhausts retries (issues #305, #308)", async () => {
     // Round 0 returns a tool call; round 1 always returns empty.
-    // The assistant(tool_calls) + tool(result) messages saved in round 0 must be
-    // deleted from the DB so they don't accumulate and corrupt subsequent requests.
+    // The tool-round messages (assistant(tool_calls) + tool results) must be deleted
+    // on error so they don't accumulate as dangling sequences. The user message is
+    // intentionally kept — it was a real request and the UI shows it as "sent, no reply".
+    // loadHistory collapses consecutive user messages so the ghost is never resent to LLM.
     let callCount = 0;
     vi.doMock("@/lib/llm/client", () => ({
       getLlmClient: () => ({
@@ -568,8 +570,8 @@ describe("orchestrator — empty response retry", () => {
     const errorEvent = events.find((e) => e.type === "error");
     expect(errorEvent).toBeDefined();
 
-    // Only the user message should remain in DB — the dangling assistant+tool messages
-    // from round 0 must have been deleted so they don't corrupt subsequent requests.
+    // User message must remain in DB (shown in UI as "sent, no reply").
+    // Tool-round messages (assistant + tool results) must be deleted.
     const remaining = testDb
       .select()
       .from(schema.messages)
@@ -578,8 +580,104 @@ describe("orchestrator — empty response retry", () => {
 
     const roles = remaining.map((m) => m.role);
     expect(roles).toEqual(["user"]);
-    expect(remaining.filter((m) => m.role === "assistant" && m.toolCalls)).toHaveLength(0);
+    expect(remaining.filter((m) => m.role === "assistant")).toHaveLength(0);
     expect(remaining.filter((m) => m.role === "tool")).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ghost-user collapse — loadHistory skips consecutive user messages from prior
+// failed requests so the LLM never sees invalid consecutive user turns (#308)
+// ---------------------------------------------------------------------------
+
+describe("ghost user message collapse in loadHistory", () => {
+  let sqlite: import("better-sqlite3").Database;
+  let testDb: ReturnType<typeof drizzle>;
+
+  beforeEach(async () => {
+    const Database = (await import("better-sqlite3")).default;
+    sqlite = new Database(":memory:");
+    testDb = drizzle(sqlite);
+    migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("skips ghost user message from failed prior request when next request is made", async () => {
+    // Simulate: first request failed (kept user#1 in DB, no assistant saved).
+    // Second request sends user#2. loadHistory must skip user#1 so LLM sees only [user#2].
+    vi.doMock("@/lib/db", () => ({ getDb: () => testDb, schema }));
+    vi.doMock("@/lib/config", () => ({
+      getConfig: vi.fn(() => null),
+      getRateLimit: vi.fn(() => ({ messages: 100, period: "day" })),
+    }));
+    vi.doMock("@/lib/llm/langfuse", () => ({
+      startTrace: () => null,
+      flushLangfuse: () => {},
+      isLangfuseEnabled: () => false,
+    }));
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async (params: { messages: { role: string }[] }) => {
+              // Capture messages so test can assert on them
+              capturedMessages = params.messages;
+              return (async function* () {
+                yield { choices: [{ delta: { content: "The Testaments is pending." } }], usage: null };
+                yield { choices: [], usage: { prompt_tokens: 50, completion_tokens: 10, total_tokens: 60 } };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gemini-2.5-flash-lite",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+    vi.doMock("@/lib/tools/registry", () => ({
+      hasTools: () => false,
+      getOpenAITools: () => [],
+      executeTool: vi.fn(),
+      getToolLlmContent: (_name: string, result: string) => result,
+      getRegisteredToolNames: () => [],
+    }));
+    vi.doMock("@/lib/tools/init", () => ({ initializeTools: vi.fn() }));
+    vi.doMock("@/lib/llm/system-prompt", () => ({ buildSystemPrompt: () => "You are helpful." }));
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+
+    // Plant user#1 (ghost from a failed prior request) directly in DB
+    const { getDb } = await import("@/lib/db");
+    const db = getDb();
+    db.insert(schema.messages).values({
+      id: "ghost-user-msg-1",
+      conversationId,
+      role: "user",
+      content: "Is the testaments requested?",
+      toolCalls: null,
+      toolCallId: null,
+      toolName: null,
+      durationMs: null,
+    }).run();
+
+    // Second request (retry)
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+    const events: { type: string }[] = [];
+    for await (const event of orchestrate({ conversationId, userMessage: "Is the testaments requested?" })) {
+      events.push(event as { type: string });
+    }
+
+    // Must succeed (not error)
+    expect(events.find((e) => e.type === "done")).toBeDefined();
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+
+    // LLM must not have received consecutive user messages — only system + user#2
+    const userMsgs = capturedMessages.filter((m) => m.role === "user");
+    expect(userMsgs).toHaveLength(1);
   });
 });
 

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -676,7 +676,7 @@ describe("ghost user message collapse in loadHistory", () => {
     expect(events.find((e) => e.type === "error")).toBeUndefined();
 
     // LLM must not have received consecutive user messages — only system + user#2
-    const userMsgs = capturedMessages.filter((m) => m.role === "user");
+    const userMsgs = (capturedMessages as { role: string }[]).filter((m) => m.role === "user");
     expect(userMsgs).toHaveLength(1);
   });
 });

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -591,21 +591,6 @@ describe("orchestrator — empty response retry", () => {
 // ---------------------------------------------------------------------------
 
 describe("ghost user message collapse in loadHistory", () => {
-  let sqlite: import("better-sqlite3").Database;
-  let testDb: ReturnType<typeof drizzle<typeof schema>>;
-
-  beforeEach(async () => {
-    const Database = (await import("better-sqlite3")).default;
-    sqlite = new Database(":memory:");
-    testDb = drizzle(sqlite, { schema });
-    migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
-    vi.resetModules();
-  });
-
-  afterEach(() => {
-    sqlite.close();
-  });
-
   it("skips ghost user message from failed prior request when next request is made", async () => {
     // Simulate: first request failed (kept user#1 in DB, no assistant saved).
     // Second request sends user#2. loadHistory must skip user#1 so LLM sees only [user#2].

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -202,7 +202,29 @@ function loadHistory(conversationId: string): ChatMessage[] {
     }
   }
 
-  return capConversationHistory(trimToolHistory(repaired, conversationId), conversationId);
+  // Collapse consecutive user messages: if a user message is immediately followed
+  // by another user message with no assistant response in between, the earlier one
+  // is a "ghost" from a prior failed request (the request failed after saving its
+  // user message but before saving any assistant response). Skip it from the LLM
+  // context so the model never sees invalid consecutive user turns.
+  //
+  // The ghost message is intentionally kept in the DB — it represents a real
+  // request the user made and is shown in the UI as "sent, no reply received".
+  // Only the most recent user message in any consecutive run is sent to the LLM.
+  const withoutGhosts: ChatMessage[] = [];
+  for (let i = 0; i < repaired.length; i++) {
+    const msg = repaired[i];
+    const next = repaired[i + 1];
+    if (msg.role === "user" && next?.role === "user") {
+      logger.warn("Skipping ghost user message from prior failed request", {
+        conversationId,
+      });
+      continue;
+    }
+    withoutGhosts.push(msg);
+  }
+
+  return capConversationHistory(trimToolHistory(withoutGhosts, conversationId), conversationId);
 }
 
 export const MAX_TOOL_ROUNDS_IN_HISTORY = 5;
@@ -480,11 +502,17 @@ export async function* orchestrate(
   });
 
   // 3. Tool call loop
-  // Tracks assistant + tool result message IDs saved in the previous round.
-  // If the next round exhausts all empty-response retries, these are deleted from
-  // the DB so the conversation history does not accumulate dangling
-  // assistant(tool_calls)+tool(result) sequences that confuse strict models (Gemini).
-  let lastRoundCleanupIds: string[] = [];
+  // Tracks tool-round message IDs saved during this request (every assistant +
+  // tool result message). On any error return path these are deleted from the DB
+  // so the conversation history does not accumulate dangling assistant(tool_calls)
+  // + tool(result) sequences that break strict models like Gemini.
+  //
+  // The user message (userMessageId) is intentionally NOT deleted on error: the
+  // user genuinely typed and sent it, and keeping it in the DB lets the UI show
+  // "message sent, no reply" honestly. loadHistory collapses consecutive user
+  // messages (which arise when a prior request fails before saving any assistant
+  // response) so they are never resent to the LLM.
+  const toolRoundMessageIds: string[] = [];
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     let fullContent = "";
@@ -626,6 +654,7 @@ export async function* orchestrate(
           : /401|403|unauthorized|forbidden/i.test(msg) ? "auth_error"
           : "llm_error";
         logger.error("LLM request failed", { conversationId, round, error: msg, errorCategory });
+        deleteMessages(toolRoundMessageIds);
         trace?.update({ output: `error: ${errorCategory}` });
         flushLangfuse();
         yield { type: "error", message: sanitizeLlmError(msg) };
@@ -660,20 +689,19 @@ export async function* orchestrate(
           round,
           model,
         });
-        // Remove the assistant(tool_calls)+tool(result) messages saved in the
-        // previous round from the DB. Without this, each failed attempt leaves
-        // a dangling unclosed tool sequence in history. On subsequent requests
-        // those sequences accumulate and Gemini (which is stricter about
-        // conversation format than OpenAI) refuses to generate any output at all,
-        // breaking every follow-up request in the same conversation.
-        if (lastRoundCleanupIds.length > 0) {
-          deleteMessages(lastRoundCleanupIds);
-          logger.info("Cleaned up dangling tool-round messages after empty response", {
-            conversationId,
-            round,
-            deletedCount: lastRoundCleanupIds.length,
-          });
-        }
+        // Roll back all messages saved during this request (user message + every
+        // tool round's assistant and tool result messages). Without this, each
+        // failed attempt leaves a dangling user message and unclosed tool sequences
+        // in history. On the next retry saveMessage saves another user message,
+        // producing consecutive user turns ([user1, user2]) that confuse strict
+        // models like Gemini (which requires strictly alternating user/assistant
+        // turns) causing every subsequent request in the conversation to fail.
+        deleteMessages(toolRoundMessageIds);
+        logger.info("Deleted dangling tool-round messages after empty response", {
+          conversationId,
+          round,
+          deletedCount: toolRoundMessageIds.length,
+        });
         trace?.update({ output: "error: empty_response" });
         flushLangfuse();
         yield { type: "error", message: "The AI service encountered an error. Please try again." };
@@ -717,8 +745,7 @@ export async function* orchestrate(
     const assistantMsgId = saveMessage(conversationId, "assistant", fullContent || null, {
       toolCalls: serializedToolCalls,
     });
-    // Begin tracking IDs for this round in case the next round exhausts retries
-    lastRoundCleanupIds = [assistantMsgId];
+    toolRoundMessageIds.push(assistantMsgId);
 
     // Add assistant message to conversation for next round
     apiMessages.push({
@@ -791,7 +818,7 @@ export async function* orchestrate(
           toolName: tc.function.name,
           durationMs,
         });
-        lastRoundCleanupIds.push(toolMsgId);
+        toolRoundMessageIds.push(toolMsgId);
         logger.info("Tool result saved", { conversationId, toolCallId: tc.id, toolName: tc.function.name, durationMs, isError });
       } catch (e: unknown) {
         logger.error("Failed to save tool result — conversation will be broken", {
@@ -826,6 +853,7 @@ export async function* orchestrate(
   }
 
   // Safety: if we exhausted max rounds, yield what we have
+  deleteMessages(toolRoundMessageIds);
   trace?.update({ output: "error: tool call limit reached" });
   flushLangfuse();
   yield { type: "error", message: "Tool call limit reached" };


### PR DESCRIPTION
…r turns

Two complementary fixes for Gemini empty-response cascades:

1. Tool-round message cleanup (fixes #305) Track all assistant(tool_calls) + tool(result) IDs in toolRoundMessageIds across every round. On any error path (empty response, LLM error, max rounds), delete them all. Without this, dangling unclosed tool sequences accumulate in history and Gemini returns 0 tokens on every subsequent request.

   The user message is intentionally kept in DB — the user sent a real request and the UI shows it as "message sent, no reply came back", consistent with Langfuse traces.

2. Ghost user turn collapse in loadHistory (fixes #308) Confirmed via trace ce66068d: after a failed request, user#1 stays in DB. On retry, saveMessage saves user#2 → DB: [user#1, user#2] → consecutive user turns → Gemini strict alternating-format violation → 0 tokens on every retry.

   loadHistory now skips "ghost" user messages (a user message immediately followed by another user message) from the LLM context. Ghosts remain in DB for UI display but are never resent to the LLM.

https://claude.ai/code/session_01LJqpE3xQ7JuWqNZdqjVELP