### PR TITLE
chore: bump version to 1.1.6-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bumps `package.json` from `1.1.6-beta.1` to `1.1.6-beta.2` so dev no longer matches beta, unblocking the dev → beta PR (#316).

## Why

Per the branch/merge strategy, a dev → beta PR must not be opened when both sides share the same version. Dev and beta are both at `1.1.6-beta.1` after PR #309 landed. This bump satisfies that requirement.

https://claude.ai/code/session_01X1fV8V6Aa7GxoHzUMHhCdP