### PR TITLE
fix: resolve issue #324 — proactive title card + error after display_titles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -292,6 +292,8 @@ When `gemini-2.5-flash-lite` (and similar) returns 0 output tokens with no text 
 2. **Keeps the user message** in the DB intentionally — the user genuinely typed and sent it; the UI shows it as "message sent, no reply came back", which is consistent with Langfuse traces.
 3. Yields `{ type: "error" }` rather than a silent empty done event.
 
+**Exception — empty after `display_titles`:** If the previous round's tool calls were exclusively `display_titles`, a zero-token follow-up response is correct and expected (the card is the answer). In this case the orchestrator skips the error path and yields `{ type: "done" }` instead, keeping all tool-round messages in the DB. Tracked via `previousRoundToolNames` in the outer loop.
+
 ### Ghost User Turn Collapse
 When a request fails after saving its user message but before saving any assistant response, the user message remains in the DB. If the user retries, `saveMessage()` saves another user message, producing consecutive user turns in history (`[user#1, user#2]`). Gemini's strict alternating-turn format then returns 0 output tokens on every retry, permanently breaking the conversation.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -35,9 +35,9 @@ vi.mock("@/lib/tools/init", () => ({ initializeTools: vi.fn() }));
 vi.mock("@/lib/tools/registry", () => ({
   hasTools: () => false,
   getOpenAITools: () => [],
-  executeTool: vi.fn(),
+  executeTool: vi.fn().mockResolvedValue(JSON.stringify({ displayTitles: [] })),
   getToolLlmContent: (_name: string, result: string) => result,
-  getRegisteredToolNames: () => [],
+  getRegisteredToolNames: () => ["display_titles"],
 }));
 vi.mock("@/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -45,8 +45,13 @@ vi.mock("@/lib/logger", () => ({
 
 // ---------------------------------------------------------------------------
 // LLM client mock — captures messages sent to it
+// Supports a per-test response queue: push factory functions before calling
+// orchestrate() and the mock will consume them in order. Falls back to a
+// default text response when the queue is empty.
 // ---------------------------------------------------------------------------
 let capturedMessages: unknown[] = [];
+type AsyncGenFactory = () => AsyncGenerator<unknown, void, unknown>;
+let llmResponseQueue: AsyncGenFactory[] = [];
 
 vi.mock("@/lib/llm/client", () => ({
   getLlmClient: () => ({
@@ -54,7 +59,9 @@ vi.mock("@/lib/llm/client", () => ({
       completions: {
         create: vi.fn(async ({ messages }: { messages: unknown[] }) => {
           capturedMessages = messages;
-          // Return an async iterable that yields a single text chunk then usage
+          const factory = llmResponseQueue.shift();
+          if (factory) return factory();
+          // Default: return a plain text response
           return (async function* () {
             yield {
               choices: [{ delta: { content: "Here are the results." } }],
@@ -138,6 +145,7 @@ beforeEach(() => {
   testDb = drizzle(sqlite, { schema });
   migrate(testDb, { migrationsFolder: path.join(process.cwd(), "drizzle") });
   capturedMessages = [];
+  llmResponseQueue = [];
   vi.resetModules();
 });
 
@@ -583,7 +591,87 @@ describe("orchestrator — empty response retry", () => {
     expect(remaining.filter((m) => m.role === "assistant")).toHaveLength(0);
     expect(remaining.filter((m) => m.role === "tool")).toHaveLength(0);
   });
-});
+
+  it("yields done (not error) when LLM returns empty after an exclusive display_titles round (issue #324)", async () => {
+    // Round 0: LLM calls display_titles — the card is the response.
+    // Round 1 (and retries): LLM returns empty — this is correct; no text needed after a card.
+    // The orchestrator must treat this as a clean completion, not an error.
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async () => {
+              // Consume from the outer llmResponseQueue (set by the test below)
+              const factory = llmResponseQueue.shift();
+              if (factory) return factory();
+              // Fallback empty response for unexpected extra calls
+              return (async function* () {
+                yield { choices: [{ delta: {} }], usage: { prompt_tokens: 50, completion_tokens: 0, total_tokens: 50 } };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gemini-2.5-flash-lite",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+    vi.doMock("@/lib/tools/registry", () => ({
+      hasTools: () => true,
+      getOpenAITools: () => [{ type: "function", function: { name: "display_titles", description: "Show cards", parameters: {} } }],
+      executeTool: vi.fn(async () => JSON.stringify({ displayTitles: [{ title: "Song to Song", mediaStatus: "available" }] })),
+      getToolLlmContent: (_name: string, result: string) => result,
+      getRegisteredToolNames: () => ["display_titles"],
+    }));
+
+    // Round 0: display_titles tool call
+    llmResponseQueue.push(async function* () {
+      yield {
+        choices: [{
+          delta: {
+            tool_calls: [{ index: 0, id: "call_display_123", function: { name: "display_titles", arguments: '{"titles":[{"title":"Song to Song","mediaType":"movie","mediaStatus":"available"}]}' } }],
+          },
+        }],
+        usage: null,
+      };
+      yield { choices: [], usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 } };
+    });
+    // Round 1 (and retries): always empty — model has nothing to add after showing the card
+    const emptyResponse: AsyncGenFactory = async function* () {
+      yield { choices: [{ delta: {} }], usage: { prompt_tokens: 200, completion_tokens: 0, total_tokens: 200 } };
+    };
+    llmResponseQueue.push(emptyResponse, emptyResponse, emptyResponse); // cover all retries
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+    const { eq: drizzleEq } = await import("drizzle-orm");
+    const events: { type: string; message?: string }[] = [];
+    for await (const event of orchestrate({ conversationId, userMessage: "Render a title card?" })) {
+      events.push(event as { type: string; message?: string });
+    }
+
+    // Must complete without error
+    const errorEvents = events.filter((e) => e.type === "error");
+    expect(errorEvents).toHaveLength(0);
+
+    const doneEvent = events.find((e) => e.type === "done");
+    expect(doneEvent).toBeDefined();
+
+    // Tool-round messages (the display_titles call + result) must be kept in DB
+    const remaining = testDb
+      .select()
+      .from(schema.messages)
+      .where(drizzleEq(schema.messages.conversationId, conversationId))
+      .all();
+
+    const roles = remaining.map((m) => m.role);
+    // user + assistant(tool_calls) + tool(display_titles result) + assistant(empty follow-up)
+    expect(roles).toContain("user");
+    expect(remaining.filter((m) => m.role === "assistant")).toHaveLength(2);
+    expect(remaining.filter((m) => m.role === "tool")).toHaveLength(1);
+  });
+}); // end "orchestrator — empty response retry"
 
 // ---------------------------------------------------------------------------
 // Ghost-user collapse — loadHistory skips consecutive user messages from prior

--- a/src/lib/llm/default-prompt.ts
+++ b/src/lib/llm/default-prompt.ts
@@ -31,6 +31,7 @@ Guidelines:
 
 Displaying title cards:
 - After searching Plex or Overseerr (including overseerr_list_requests), ALWAYS call display_titles to show visual cards — even when a title is not in Plex (use Overseerr results alone).
+- This rule applies to any user message that names a specific title — even information-seeking questions ("What is X?", "Tell me about X?", "Can I watch X?") must result in a title card for the primary match. You may include descriptive text alongside the card, but never skip the card when a title was found.
 - When you have search results ready, call display_titles immediately in the next response — do NOT add a conversational message between receiving search results and calling display_titles. Every extra round adds visible delay before the user sees the cards.
 - For movies (not TV shows): after a plex_search_library or plex_check_availability result, call display_titles in the very next response without any intermediate text or tool calls.
 - When a user query involves multiple independent titles (e.g. "do I have X and Y?"), issue each search as a separate tool call in the same response so they run in parallel, then call display_titles once in the following response. Always issue each tool as a distinct call — never merge or concatenate tool names or arguments.

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -514,6 +514,11 @@ export async function* orchestrate(
   // response) so they are never resent to the LLM.
   const toolRoundMessageIds: string[] = [];
 
+  // Track the tool names executed in the previous round. When the model calls
+  // display_titles and then returns an empty response in the next round, that is
+  // correct behaviour (the card is the answer) — not an error to surface.
+  let previousRoundToolNames: string[] = [];
+
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     let fullContent = "";
     const toolCalls: { id: string; function: { name: string; arguments: string } }[] = [];
@@ -684,6 +689,23 @@ export async function* orchestrate(
       // error rather than silently yielding nothing (which leaves the user
       // staring at a blank message).
       if (fullContent === "" && (completionTokens ?? 0) === 0) {
+        // Special case: if the previous round exclusively called display_titles,
+        // an empty follow-up is correct — the card is the answer and the model
+        // has nothing more to say. Treat this as a clean completion.
+        if (
+          previousRoundToolNames.length > 0 &&
+          previousRoundToolNames.every((n) => n === "display_titles")
+        ) {
+          const messageId = saveMessage(conversationId, "assistant", "");
+          logger.info("Empty response after display_titles — treating as done", {
+            conversationId,
+            round,
+          });
+          trace?.update({ output: "" });
+          flushLangfuse();
+          yield { type: "done", messageId, llmDurationMs, promptTokens, completionTokens, totalTokens };
+          return;
+        }
         logger.error("LLM returned empty response after all retries", {
           conversationId,
           round,
@@ -848,6 +870,10 @@ export async function* orchestrate(
         error: isError,
       };
     }
+
+    // Record this round's tool names so the next round can detect the
+    // "empty after display_titles" case (see empty response handler above).
+    previousRoundToolNames = toolCalls.map((tc) => tc.function.name);
 
     // Loop continues — LLM will see tool results and either respond or call more tools
   }


### PR DESCRIPTION
## Summary

Diagnosed from Langfuse trace `b447adb6` (issue #324 — Song to Song).

- **Bug 1 — Proactive title card skipped**: On "What is song to song", `plex_check_availability` confirmed availability but the LLM responded with text only, violating the "ALWAYS call display_titles" rule. Root cause: the info-seeking phrasing ("What is X?") caused the model to treat it as a facts query. Fix: added an explicit system prompt instruction that even information-seeking questions about a specific title must produce a title card.

- **Bug 2 — Error after display_titles**: After `display_titles` returned successfully, the LLM produced 0 output tokens (correct — the card was the answer). The orchestrator retried twice, then surfaced "The AI service encountered an error" — a false positive. Fix: added `previousRoundToolNames` tracking in the orchestrator loop; when the previous round exclusively called `display_titles` and the follow-up is empty, yield `done` instead of `error`. Tool-round messages are also correctly preserved rather than deleted.

## Test plan

- [x] `npx vitest run` — all 520 tests pass, including new test `"yields done (not error) when LLM returns empty after an exclusive display_titles round (issue #324)"`
- [x] `npx tsc --noEmit` — no new type errors
- [ ] Verify in beta: ask "What is [movie title in library]?" — should show title card without explicitly asking for one
- [ ] Verify in beta: ask "Render a title card?" — should show card without an error message after

🤖 Generated with [Claude Code](https://claude.com/claude-code)