### PR TITLE
feat: add copy-as-env-vars button to Langfuse settings card

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1640,7 +1640,18 @@ export default function SettingsPage() {
             {/* Langfuse observability */}
             <Card>
               <CardHeader>
-                <CardTitle className="text-lg">Langfuse Observability</CardTitle>
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-lg">Langfuse Observability</CardTitle>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    title="Copy as environment variables"
+                    disabled={!langfuseConfig.publicKey && !langfuseConfig.secretKey}
+                    onClick={() => copyToClipboard(`LANGFUSE_PUBLIC_KEY=${langfuseConfig.publicKey}\nLANGFUSE_SECRET_KEY=${langfuseConfig.secretKey}`)}
+                  >
+                    <Copy size={14} />
+                  </Button>
+                </div>
                 <CardDescription>
                   Connect to{" "}
                   <a


### PR DESCRIPTION
## Summary

- Adds a copy icon button to the **Langfuse Observability** card header in the Logs tab
- Copies both keys to the clipboard in `.env` format: `LANGFUSE_PUBLIC_KEY=xxx\nLANGFUSE_SECRET_KEY=xxx`
- Button is disabled when both keys are empty

Closes #325

## Test plan

- [ ] Navigate to Settings → Logs → Langfuse Observability
- [ ] With keys configured, click the copy icon — paste into a text editor and confirm format is `LANGFUSE_PUBLIC_KEY=...\nLANGFUSE_SECRET_KEY=...`
- [ ] With both keys empty, confirm the button is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)