### PR TITLE
fix: log richer LLM error details for diagnosis (issue #332)

### DIFF
--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -15,7 +15,7 @@ import type {
   ErrorEvent,
   DoneEvent,
 } from "@/types/chat";
-import type OpenAI from "openai";
+import OpenAI from "openai";
 
 export type OrchestratorEvent =
   | TextDeltaEvent
@@ -664,7 +664,22 @@ export async function* orchestrate(
         const errorCategory = /429|quota|rate.?limit/i.test(msg) ? "rate_limit"
           : /401|403|unauthorized|forbidden/i.test(msg) ? "auth_error"
           : "llm_error";
-        logger.error("LLM request failed", { conversationId, round, error: msg, errorCategory });
+        // Log richer details when the SDK gives us an APIError (status, code, body).
+        // "400 status code (no body)" errors from preview/experimental models often
+        // carry no body, so status+code alone help narrow down the failure.
+        const apiErr = e instanceof OpenAI.APIError ? e : null;
+        logger.error("LLM request failed", {
+          conversationId,
+          round,
+          error: msg,
+          errorCategory,
+          ...(apiErr && {
+            status: apiErr.status,
+            errorCode: apiErr.code,
+            errorType: apiErr.type,
+            errorBody: apiErr.error,
+          }),
+        });
         deleteMessages(toolRoundMessageIds);
         trace?.update({ output: `error: ${errorCategory}` });
         flushLangfuse();


### PR DESCRIPTION
## Summary

- Investigated issue #332 — same Malcolm in the Middle query, same model (`gemini-3.1-flash-lite-preview`), still failing after the #328 fix was deployed
- Confirmed via Langfuse (trace `f5b88a32`) that the `content:null` fix **is working** — the assistant message now correctly omits `content`. But the model still returns `400 status code (no body)` at round-1
- Root cause: `gemini-3.1-flash-lite-preview` generates short alphanumeric tool call IDs (`7bxhk8uf`) vs the `function-call-{number}` format used by `gemini-2.5-flash-lite`. The model's OpenAI compat layer appears to fail to match these IDs when they're sent back as `tool_call_id` in the tool result, returning 400 with no body — a bug in the preview model's compat implementation, not in the app
- Previously only `e.message` was logged on LLM errors; this adds `status`, `errorCode`, `errorType`, and `errorBody` when the SDK provides an `OpenAI.APIError`. Next occurrence will show the precise Gemini rejection reason

The model limitation (preview compat layer rejecting tool result continuation) cannot be fixed app-side without knowing what format the model actually expects. The richer logs will reveal that on the next hit.

## Test plan

- [ ] All 30 orchestrator tests pass
- [ ] Next `gemini-3.1-flash-lite-preview` failure will log `status: 400`, `errorCode`, `errorBody` in addition to the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)