### PR TITLE
fix: always send content:"" on assistant tool-call messages (issue #337)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -294,12 +294,14 @@ When `gemini-2.5-flash-lite` (and similar) returns 0 output tokens with no text 
 
 **Exception — empty after `display_titles`:** If the previous round's tool calls were exclusively `display_titles`, a zero-token follow-up response is correct and expected (the card is the answer). In this case the orchestrator skips the error path and yields `{ type: "done" }` instead, keeping all tool-round messages in the DB. Tracked via `previousRoundToolNames` in the outer loop.
 
-### Gemini Null Content in Assistant Tool-Call Messages (issue #328)
-Two related Gemini null-content bugs were fixed together:
+### Gemini Null/Absent Content in Assistant Tool-Call Messages (issues #328, #337)
+Three related bugs around assistant message content in tool-call sequences were fixed:
 
-**Round 1 (live path):** When the LLM emits a tool call with no accompanying text, `fullContent` is `""`. The orchestrator previously pushed `{ role: "assistant", content: null, tool_calls: [...] }` into `apiMessages` for the next round. Gemini's OpenAI-compatible API rejects `content: null` in assistant messages that contain `tool_calls`, returning an `llm_error` on round 1. The fix omits the `content` field entirely when `fullContent` is falsy, matching the behaviour of `loadHistory()`.
+**Round 1 (live path, issue #328):** When the LLM emits a tool call with no accompanying text, `fullContent` is `""`. The orchestrator previously pushed `{ role: "assistant", content: null, tool_calls: [...] }` into `apiMessages`. Gemini rejected `content: null`. The fix at the time omitted the field entirely. However, `gemini-3.1-flash-lite-preview` later returned HTTP 400 at round 1 when the `content` field was absent. The current fix always sets `content: fullContent || ""` — an explicit empty string that all known providers accept.
 
-**Round 0 (history path):** The display_titles empty-response special case saves `saveMessage(conversationId, "assistant", "")` — an assistant record with empty string content and no tool_calls. When `loadHistory()` loads it, `if (row.content)` is false for `""` so neither `content` nor `tool_calls` is set, producing `{ role: "assistant" }`. Gemini rejects this phantom message as `"400 Invalid value for 'content': expected a string, got null."` on the *next* conversation request (round 0). The fix skips assistant messages with neither content nor tool_calls in `loadHistory()`.
+**History path (issue #328):** `loadHistory()` now also sets `content: ""` on assistant messages that have `tool_calls` but no stored content, so reloaded history carries the same explicit empty string.
+
+**Phantom message (issue #328):** The display_titles empty-response special case saves `saveMessage(conversationId, "assistant", "")` — an assistant record with empty content and no tool_calls. `loadHistory()` skips these phantom records (`if (!msg.content && !msg.tool_calls?.length) continue`) so they never reach the LLM.
 
 ### Ghost User Turn Collapse
 When a request fails after saving its user message but before saving any assistant response, the user message remains in the DB. If the user retries, `saveMessage()` saves another user message, producing consecutive user turns in history (`[user#1, user#2]`). Gemini's strict alternating-turn format then returns 0 output tokens on every retry, permanently breaking the conversation.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -277,6 +277,8 @@ Opt-in tracing via `LANGFUSE_SECRET_KEY` + `LANGFUSE_PUBLIC_KEY` env vars, or vi
 ### Logging
 Winston singleton: Console (stdout, JSON) + DailyRotateFile (`/config/logs/`, 14-day retention, 20 MB max). Tool calls and API responses logged with truncation. Settings Logs tab provides file browser, 500-line viewer, and download.
 
+All `OpenAI` client instances (default and per-endpoint) use a `loggingFetch` wrapper (`src/lib/llm/client.ts`) that clones and logs the raw response body of any non-2xx HTTP response before the SDK reads it. The SDK often discards the body on parse failure (e.g. "400 status code (no body)"), so the wrapper ensures the raw body is always captured in logs regardless of model or provider.
+
 ### Chat Mode Toggle
 Three modes: text (default), voice (Whisper STT + TTS read-back), realtime (WebRTC full-duplex). Availability tied to endpoint capabilities. Mode resets to text on model switch if capability unavailable.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.6-beta.3",
+      "version": "1.1.6-beta.5",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "langfuse": "^3.38.20",
         "lucide-react": "^1.7.0",
-        "next": "16.2.2",
+        "next": "16.2.3",
         "openai": "^6.33.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.2.tgz",
-      "integrity": "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2069,9 +2069,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.2.tgz",
-      "integrity": "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
-      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -2101,9 +2101,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
-      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2117,9 +2117,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
-      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -2133,9 +2133,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
-      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -2149,9 +2149,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
-      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -2165,9 +2165,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
-      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz",
-      "integrity": "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -9000,12 +9000,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
-      "integrity": "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.2",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9019,14 +9019,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.2",
-        "@next/swc-darwin-x64": "16.2.2",
-        "@next/swc-linux-arm64-gnu": "16.2.2",
-        "@next/swc-linux-arm64-musl": "16.2.2",
-        "@next/swc-linux-x64-gnu": "16.2.2",
-        "@next/swc-linux-x64-musl": "16.2.2",
-        "@next/swc-win32-arm64-msvc": "16.2.2",
-        "@next/swc-win32-x64-msvc": "16.2.2",
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "drizzle-orm": "^0.45.2",
     "langfuse": "^3.38.20",
     "lucide-react": "^1.7.0",
-    "next": "16.2.2",
+    "next": "16.2.3",
     "openai": "^6.33.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -755,12 +755,13 @@ describe("orchestrator — tool-round assistant message format (issue #328)", ()
     expect(events.find((e) => e.type === "error")).toBeUndefined();
     expect(events.find((e) => e.type === "done")).toBeDefined();
 
-    // The assistant message from round 0 sent to round 1 must NOT have content:null.
-    // It should either be absent or be an empty string — never null.
+    // The assistant message from round 0 sent to round 1 must carry content: ""
+    // (explicit empty string). gemini-3.1-flash-lite-preview returns HTTP 400 at
+    // round 1 when the content field is absent entirely (issue #337).
     const assistantMsg = (capturedRound1Messages as { role: string; content?: unknown; tool_calls?: unknown[] }[])
       .find((m) => m.role === "assistant" && m.tool_calls != null);
     expect(assistantMsg).toBeDefined();
-    expect(assistantMsg!.content).not.toBe(null);
+    expect(assistantMsg!.content).toBe("");
   });
 });
 
@@ -845,6 +846,13 @@ describe("loadHistory — phantom empty assistant message suppression", () => {
     const phantomMsg = (capturedMsgs as { role: string; content?: unknown; tool_calls?: unknown[] }[])
       .find((m) => m.role === "assistant" && !m.content && !m.tool_calls?.length);
     expect(phantomMsg).toBeUndefined();
+
+    // The display_titles assistant message (with tool_calls) must carry content: ""
+    // — gemini-3.1-flash-lite-preview returns HTTP 400 when the field is absent (issue #337).
+    const toolCallMsg = (capturedMsgs as { role: string; content?: unknown; tool_calls?: unknown[] }[])
+      .find((m) => m.role === "assistant" && m.tool_calls?.length);
+    expect(toolCallMsg).toBeDefined();
+    expect(toolCallMsg!.content).toBe("");
   });
 });
 

--- a/src/lib/llm/client.ts
+++ b/src/lib/llm/client.ts
@@ -3,17 +3,26 @@ import { getConfig } from "@/lib/config";
 import { logger } from "@/lib/logger";
 
 /**
- * Wraps globalThis.fetch to capture and log the raw response body on any
- * non-2xx response before the OpenAI SDK reads it. The SDK surfaces structured
- * APIErrors but discards the raw body when it cannot be parsed — producing
- * messages like "400 status code (no body)" with no further detail. This
- * wrapper preserves the body so failures are diagnosable regardless of model.
+ * Wraps globalThis.fetch to log full details of any LLM API failure before
+ * the OpenAI SDK processes the response. Covers two failure modes:
  *
- * Logging is fire-and-forget (no await) so it never delays the response or
- * interferes with the SDK's own body read.
+ * 1. Non-2xx HTTP responses — clones the response and logs the raw body
+ *    fire-and-forget. The SDK often discards the body on parse failure
+ *    (e.g. "400 status code (no body)"), so the clone captures it first.
+ *
+ * 2. Network-level errors (fetch throws) — DNS failures, connection refused,
+ *    timeouts, etc. Logged then re-thrown so the SDK error path is unchanged.
  */
 async function loggingFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-  const response = await globalThis.fetch(input, init);
+  let response: Response;
+  try {
+    response = await globalThis.fetch(input, init);
+  } catch (err) {
+    logger.error("LLM API network error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
   if (!response.ok) {
     response
       .clone()

--- a/src/lib/llm/client.ts
+++ b/src/lib/llm/client.ts
@@ -1,5 +1,33 @@
 import OpenAI from "openai";
 import { getConfig } from "@/lib/config";
+import { logger } from "@/lib/logger";
+
+/**
+ * Wraps globalThis.fetch to capture and log the raw response body on any
+ * non-2xx response before the OpenAI SDK reads it. The SDK surfaces structured
+ * APIErrors but discards the raw body when it cannot be parsed — producing
+ * messages like "400 status code (no body)" with no further detail. This
+ * wrapper preserves the body so failures are diagnosable regardless of model.
+ *
+ * Logging is fire-and-forget (no await) so it never delays the response or
+ * interferes with the SDK's own body read.
+ */
+async function loggingFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const response = await globalThis.fetch(input, init);
+  if (!response.ok) {
+    response
+      .clone()
+      .text()
+      .then((body) => {
+        logger.error("LLM API raw error response", {
+          status: response.status,
+          rawBody: body || "(no body)",
+        });
+      })
+      .catch(() => {}); // suppress — logging failure must never affect the request
+  }
+  return response;
+}
 
 let _client: OpenAI | null = null;
 let _cachedKey: string | null = null;
@@ -17,7 +45,7 @@ export function getLlmClient(): OpenAI {
     return _client;
   }
 
-  _client = new OpenAI({ baseURL, apiKey });
+  _client = new OpenAI({ baseURL, apiKey, fetch: loggingFetch });
   _cachedKey = apiKey;
   return _client;
 }
@@ -92,7 +120,7 @@ export function getLlmClientForEndpoint(modelId: string): { client: OpenAI; mode
         if (cached && cached.key === ep.apiKey) {
           return { client: cached.client, model: modelName || ep.model, systemPrompt: ep.systemPrompt || undefined };
         }
-        const client = new OpenAI({ baseURL: ep.baseUrl, apiKey: ep.apiKey });
+        const client = new OpenAI({ baseURL: ep.baseUrl, apiKey: ep.apiKey, fetch: loggingFetch });
         endpointClients.set(ep.id, { client, key: ep.apiKey });
         return { client, model: modelName || ep.model, systemPrompt: ep.systemPrompt || undefined };
       }

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -146,10 +146,12 @@ function loadHistory(conversationId: string): ChatMessage[] {
       }
       // Skip assistant messages with neither content nor tool_calls — they are
       // phantom records (e.g. the empty message saved after the display_titles
-      // empty-response special case). Sending { role: "assistant" } with no
-      // content and no tool_calls causes Gemini to return
-      // "400 Invalid value for 'content': expected a string, got null."
+      // empty-response special case).
       if (!msg.content && !msg.tool_calls?.length) continue;
+      // Ensure assistant messages with tool_calls always carry an explicit content
+      // field (empty string when no text). gemini-3.1-flash-lite-preview returns
+      // HTTP 400 at round 1 when the field is absent entirely.
+      if (!msg.content && msg.tool_calls?.length) msg.content = "";
       messages.push(msg);
     } else if (row.role === "tool") {
       if (row.toolCallId && row.content) {
@@ -791,19 +793,19 @@ export async function* orchestrate(
     toolRoundMessageIds.push(assistantMsgId);
 
     // Add assistant message to conversation for next round.
-    // Omit content when empty — some providers (e.g. Gemini) reject content:null
-    // in assistant messages that contain tool_calls, even though the OpenAI spec
-    // allows it. This matches the behaviour of loadHistory which only sets content
-    // when the value is truthy.
+    // Always include content (empty string when no text) — some providers
+    // (e.g. gemini-3.1-flash-lite-preview) return HTTP 400 at round 1 when the
+    // assistant message that introduced the tool call omits the content field
+    // entirely. An explicit empty string is accepted by all known providers.
     const assistantApiMsg: OpenAI.ChatCompletionAssistantMessageParam = {
       role: "assistant",
+      content: fullContent || "",
       tool_calls: toolCalls.map((tc) => ({
         id: tc.id,
         type: "function" as const,
         function: tc.function,
       })),
     };
-    if (fullContent) assistantApiMsg.content = fullContent;
     apiMessages.push(assistantApiMsg);
 
     // 4. Execute tool calls in parallel — multiple tool calls in a single round


### PR DESCRIPTION
## Summary

- `gemini-3.1-flash-lite-preview` returns HTTP 400 with no body at round 1 when the assistant message from round 0 (a tool call) omits the `content` field entirely
- Fixed by always setting `content: fullContent || ""` — an explicit empty string rather than omitting the field
- Same fix applied to `loadHistory()` so replayed tool-call history from DB carries the same explicit empty string
- Previous fix (issue #328) had omitted `content` entirely to avoid `content: null` — correct for older Gemini models but breaks `gemini-3.1-flash-lite-preview`
- **Also adds `loggingFetch` wrapper** to all `OpenAI` client instances: captures the raw HTTP response body on any non-2xx before the SDK reads and discards it — so future "no body" errors across all models are diagnosable

**Root cause confirmed via Langfuse trace** `a03e126e-e691-43d6-b7b8-a879365783ea` (session `eb928ed4`): round 0 succeeds (18 tokens out, tool call made), round 1 fails HTTP 400 with the assistant message carrying no `content` field.

## Test plan

- [x] Updated existing test assertion: `content` on round-1 assistant message must now be `""` not just non-null
- [x] Added assertion to the `loadHistory` phantom-message test: assistant messages with `tool_calls` loaded from DB also carry `content: ""`
- [x] All 522 unit tests pass
- [ ] Verify on beta that "Is Malcolm in the Middle available?" (or any query that triggers a tool call) completes without error on `gemini-3.1-flash-lite-preview`

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)