### PR TITLE
fix: upgrade openssl in Alpine runner to resolve CVE-2026-28390 (high)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 ENV TZ=UTC
 
-RUN apk upgrade --no-cache zlib && \
+RUN apk upgrade --no-cache zlib openssl && \
     apk add --no-cache shadow su-exec tzdata && \
     mkdir -p /config && \
     chown node:node /config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.6-beta.5",
+      "version": "1.1.6-beta.6",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Adds `openssl` to the `apk upgrade` call in the production runner stage so `libcrypto3` and `libssl3` are patched to ≥3.5.6-r0
- CVE-2026-28390: OpenSSL NULL pointer dereference in CMS — DoS, HIGH severity, fix available
- Bumps version to `1.1.6-beta.6`

Trivy reported two HIGH findings against the `1.1.6-beta.5` image built from PR #341:
- `libcrypto3` — CVE-2026-28390 — fixed in 3.5.6-r0
- `libssl3` — CVE-2026-28390 — fixed in 3.5.6-r0

The runner stage already pins `zlib` via `apk upgrade --no-cache zlib`; this change extends that to include `openssl` so Alpine pulls in the patched package before the image is finalised.

## Test plan

- [ ] Build image locally: `docker build -t thinkarr:local-test .`
- [ ] Run Trivy scan — CVE-2026-28390 must no longer appear for libcrypto3 / libssl3
- [ ] Confirm app still boots and `/api/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)