### PR TITLE
Merge pull request #342 from chrisrothwell/claude/fix-openssl-trivy-cve-2026-28390-a7b3c2

fix: upgrade openssl in Alpine runner to resolve CVE-2026-28390 (high)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 ENV TZ=UTC
 
-RUN apk upgrade --no-cache zlib && \
+RUN apk upgrade --no-cache zlib openssl && \
     apk add --no-cache shadow su-exec tzdata && \
     mkdir -p /config && \
     chown node:node /config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.6-beta.5",
+      "version": "1.1.6-beta.6",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->

-

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

<!-- What should be manually verified on the :beta image? -->

- [ ]
