### PR TITLE
fix: suppress CVE-2026-28390 in .trivyignore until Alpine ships openssl 3.5.6-r0

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -23,6 +23,12 @@ CVE-2026-26960
 CVE-2026-29786
 CVE-2026-31802
 
+# openssl: NULL pointer DoS in CMS (CVE-2026-28390) — fix is 3.5.6-r0 but that package
+# has not yet landed in Alpine's repos for node:25-alpine. The Dockerfile already runs
+# `apk upgrade --no-cache openssl` which will apply the patch automatically once Alpine
+# ships it. Remove this entry once node:25-alpine includes openssl ≥ 3.5.6-r0.
+CVE-2026-28390
+
 # picomatch: ReDoS (CVE-2026-33671) — Trivy false positive in dev-only deps
 # Trivy reads node_modules/tinyglobby/package.json and extracts "4.0.3" from the
 # "^4.0.3" dep spec as the installed version. npm ci actually resolves and installs


### PR DESCRIPTION
## Summary

- Adds CVE-2026-28390 to `.trivyignore` to unblock the beta Docker build

**Root cause:** `openssl 3.5.6-r0` (the fix for the OpenSSL NULL-pointer DoS) is listed in NVD so Trivy classifies it as "fixed" — bypassing `--ignore-unfixed`. However the package has **not** landed in Alpine's repos for `node:25-alpine`, so `apk upgrade --no-cache openssl` (added in PR #342) cannot actually install it. The build images still ship `3.5.5-r0`.

**Why not just skip it permanently:** The Dockerfile already runs `apk upgrade --no-cache openssl` which will apply the patch automatically once Alpine ships it. When that happens, remove the `.trivyignore` entry and the CVE will pass the Trivy gate on its own.

## Test plan

- [ ] Beta Docker build passes Trivy scan (CVE-2026-28390 suppressed)
- [ ] No other new HIGH/CRITICAL findings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)