### PR TITLE
Merge pull request #344 from chrisrothwell/claude/trivyignore-cve-2026-28390-b8d4e1

fix: suppress CVE-2026-28390 in .trivyignore until Alpine ships openssl 3.5.6-r0

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -23,6 +23,12 @@ CVE-2026-26960
 CVE-2026-29786
 CVE-2026-31802
 
+# openssl: NULL pointer DoS in CMS (CVE-2026-28390) — fix is 3.5.6-r0 but that package
+# has not yet landed in Alpine's repos for node:25-alpine. The Dockerfile already runs
+# `apk upgrade --no-cache openssl` which will apply the patch automatically once Alpine
+# ships it. Remove this entry once node:25-alpine includes openssl ≥ 3.5.6-r0.
+CVE-2026-28390
+
 # picomatch: ReDoS (CVE-2026-33671) — Trivy false positive in dev-only deps
 # Trivy reads node_modules/tinyglobby/package.json and extracts "4.0.3" from the
 # "^4.0.3" dep spec as the installed version. npm ci actually resolves and installs


### PR DESCRIPTION
## Summary

<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->

-

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

<!-- What should be manually verified on the :beta image? -->

- [ ]
