### PR TITLE
Merge pull request #347 from chrisrothwell/claude/fix-gemini-thought-signature-c3f9a1

fix: propagate Gemini thought_signature through tool-call rounds (issue #346)

### DIFF
--- a/src/__tests__/lib/orchestrator.test.ts
+++ b/src/__tests__/lib/orchestrator.test.ts
@@ -766,6 +766,105 @@ describe("orchestrator — tool-round assistant message format (issue #328)", ()
 });
 
 // ---------------------------------------------------------------------------
+// thought_signature propagation (Gemini thinking models — issue #346)
+// ---------------------------------------------------------------------------
+
+describe("orchestrator — thought_signature propagation (issue #346)", () => {
+  it("extracts thought_signature from extra_content.google and replays it in round-1 assistant message", async () => {
+    // gemini-3.1-flash-lite-preview and other Gemini thinking models include a
+    // thought_signature nested under extra_content.google.thought_signature on each
+    // function-call delta (the OpenAI SDK wraps vendor-specific fields in extra_content).
+    // Gemini returns HTTP 400 INVALID_ARGUMENT in round 1 if that signature is not
+    // replayed verbatim under the same nested path in the assistant message's tool_calls.
+    const FAKE_SIG = "CqkBCqYBGiQxMjM=";
+    let capturedRound1Messages: unknown[] = [];
+    let callCount = 0;
+
+    vi.doMock("@/lib/db", () => ({ getDb: () => testDb, schema }));
+    vi.doMock("@/lib/config", () => ({
+      getConfig: vi.fn(() => null),
+      getRateLimit: vi.fn(() => ({ messages: 100, period: "day" })),
+    }));
+    vi.doMock("@/lib/llm/langfuse", () => ({
+      startTrace: () => null,
+      flushLangfuse: () => {},
+      isLangfuseEnabled: () => false,
+    }));
+    vi.doMock("@/lib/llm/client", () => ({
+      getLlmClient: () => ({
+        chat: {
+          completions: {
+            create: vi.fn(async (params: { messages: unknown[] }) => {
+              callCount++;
+              if (callCount === 2) capturedRound1Messages = params.messages;
+              if (callCount === 1) {
+                // Round 0: tool call delta with thought_signature under extra_content.google
+                // (mirrors exact shape the OpenAI SDK produces for Gemini responses)
+                return (async function* () {
+                  yield {
+                    choices: [{
+                      delta: {
+                        tool_calls: [{
+                          index: 0,
+                          id: "call_sig_test",
+                          type: "function",
+                          function: { name: "plex_search_library", arguments: '{"query":"Malcolm"}' },
+                          extra_content: { google: { thought_signature: FAKE_SIG } },
+                        }],
+                      },
+                    }],
+                    usage: null,
+                  };
+                  yield { choices: [], usage: { prompt_tokens: 100, completion_tokens: 21, total_tokens: 121 } };
+                })();
+              }
+              // Round 1: plain text
+              return (async function* () {
+                yield { choices: [{ delta: { content: "It is available." } }], usage: null };
+                yield { choices: [], usage: { prompt_tokens: 200, completion_tokens: 5, total_tokens: 205 } };
+              })();
+            }),
+          },
+        },
+      }),
+      getLlmModel: () => "gemini-3.1-flash-lite-preview",
+      getLlmClientForEndpoint: vi.fn(),
+    }));
+    vi.doMock("@/lib/tools/registry", () => ({
+      hasTools: () => true,
+      getOpenAITools: () => [{ type: "function", function: { name: "plex_search_library", description: "Search Plex", parameters: {} } }],
+      executeTool: vi.fn(async () => JSON.stringify({ results: [], hasMore: false })),
+      getToolLlmContent: (_name: string, result: string) => result,
+      getRegisteredToolNames: () => ["plex_search_library"],
+    }));
+    vi.doMock("@/lib/tools/init", () => ({ initializeTools: vi.fn() }));
+    vi.doMock("@/lib/llm/system-prompt", () => ({ buildSystemPrompt: () => "You are helpful." }));
+
+    const userId = seedUser(testDb);
+    const conversationId = seedConversation(testDb, userId);
+
+    const { orchestrate } = await import("@/lib/llm/orchestrator");
+    const events: { type: string }[] = [];
+    for await (const event of orchestrate({ conversationId, userMessage: "Is Malcolm available?" })) {
+      events.push(event as { type: string });
+    }
+
+    expect(events.find((e) => e.type === "error")).toBeUndefined();
+    expect(events.find((e) => e.type === "done")).toBeDefined();
+
+    // The assistant message sent to round 1 must carry thought_signature nested
+    // under extra_content.google — the exact path Gemini's API expects on replay.
+    type ToolCall = { id: string; extra_content?: { google?: { thought_signature?: string } } };
+    type AssistantMsg = { role: string; tool_calls?: ToolCall[] };
+    const assistantMsg = (capturedRound1Messages as AssistantMsg[])
+      .find((m) => m.role === "assistant" && m.tool_calls != null);
+    expect(assistantMsg).toBeDefined();
+    const tc = assistantMsg!.tool_calls![0];
+    expect(tc.extra_content?.google?.thought_signature).toBe(FAKE_SIG);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // loadHistory — skips phantom empty assistant messages (issue #328 follow-on)
 // ---------------------------------------------------------------------------
 

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -104,12 +104,18 @@ function loadHistory(conversationId: string): ChatMessage[] {
       if (row.content) msg.content = row.content;
       if (row.toolCalls) {
         try {
-          const toolCalls = JSON.parse(row.toolCalls) as OpenAI.ChatCompletionMessageToolCall[];
+          // Cast as extended type: thought_signature is a Gemini extension field
+          // stored flat alongside standard tool call fields in the DB JSON.
+          // On the wire it lives under extra_content.google.thought_signature —
+          // the SDK wraps vendor-specific fields there — so we reconstruct that
+          // nested shape when building the messages array for the next request.
+          const toolCalls = JSON.parse(row.toolCalls) as (OpenAI.ChatCompletionMessageToolCall & { thought_signature?: string })[];
           // Compact display_titles call arguments: strip summary, thumbPath, and cast
           // from each title entry. These are the bulky repeated fields (a 20-season show
           // repeats a 300-char summary 20 times). The tool result (via llmSummary) already
           // confirms which cards were shown, so the full args are not needed in history.
           msg.tool_calls = toolCalls.map((tc) => {
+            let result: typeof tc = tc;
             if (
               tc.type === "function" &&
               tc.function.name === "display_titles" &&
@@ -130,15 +136,24 @@ function loadHistory(conversationId: string): ChatMessage[] {
                     ({ summary: _s, cast: _c, ...rest }) => rest,
                   ),
                 };
-                return {
+                result = {
                   ...tc,
                   function: { ...tc.function, arguments: JSON.stringify(compacted) },
                 };
               } catch {
-                return tc;
+                // fall through with original tc
               }
             }
-            return tc;
+            // Restore thought_signature to the nested extra_content.google path
+            // that Gemini's OpenAI-compatible endpoint expects on replay.
+            if (tc.thought_signature) {
+              const { thought_signature, ...rest } = result;
+              return {
+                ...rest,
+                extra_content: { google: { thought_signature } },
+              };
+            }
+            return result;
           });
         } catch {
           // Skip malformed tool calls
@@ -400,7 +415,7 @@ function deleteMessages(messageIds: string[]): void {
     .run();
 }
 
-type RawToolCall = { id: string; function: { name: string; arguments: string } };
+type RawToolCall = { id: string; function: { name: string; arguments: string }; thought_signature?: string; };
 
 /**
  * Find the boundary between two back-to-back JSON objects in a string.
@@ -529,7 +544,7 @@ export async function* orchestrate(
 
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     let fullContent = "";
-    const toolCalls: { id: string; function: { name: string; arguments: string } }[] = [];
+    const toolCalls: RawToolCall[] = [];
     let llmDurationMs: number | undefined;
     let promptTokens: number | undefined;
     let completionTokens: number | undefined;
@@ -579,7 +594,7 @@ export async function* orchestrate(
         // distinct ids. Keying by id handles both — indexToCurrentId maps an
         // index to whichever id arrived most recently at that index, so
         // continuation chunks (empty id) are associated correctly.
-        const toolCallDeltas: Map<string, { id: string; name: string; args: string }> = new Map();
+        const toolCallDeltas: Map<string, { id: string; name: string; args: string; thought_signature?: string }> = new Map();
         const indexToCurrentId: Map<number, string> = new Map();
 
         for await (const chunk of stream) {
@@ -623,6 +638,14 @@ export async function* orchestrate(
               const entry = toolCallDeltas.get(currentId)!;
               if (tc.function?.name) entry.name += tc.function.name;
               if (tc.function?.arguments) entry.args += tc.function.arguments;
+              // Gemini thinking models include a thought_signature on the function
+              // call delta, nested under extra_content.google.thought_signature
+              // (the OpenAI SDK wraps unknown vendor fields in extra_content).
+              // It must be replayed verbatim in the next round's assistant message
+              // or Gemini returns HTTP 400 INVALID_ARGUMENT.
+              const sig = (tc as unknown as { extra_content?: { google?: { thought_signature?: string } } })
+                .extra_content?.google?.thought_signature;
+              if (typeof sig === "string" && sig) entry.thought_signature = sig;
             }
           }
         }
@@ -647,7 +670,7 @@ export async function* orchestrate(
         const registeredNames = getRegisteredToolNames();
         for (const [, tc] of toolCallDeltas) {
           if (tc.id && tc.name) {
-            const raw: RawToolCall = { id: tc.id, function: { name: tc.name, arguments: tc.args } };
+            const raw: RawToolCall = { id: tc.id, function: { name: tc.name, arguments: tc.args }, ...(tc.thought_signature && { thought_signature: tc.thought_signature }) };
             const split = trySplitConcatenatedCall(raw, registeredNames);
             if (split) {
               logger.warn("Gemini concatenated tool calls detected, splitting", {
@@ -785,6 +808,7 @@ export async function* orchestrate(
         id: tc.id,
         type: "function",
         function: tc.function,
+        ...(tc.thought_signature && { thought_signature: tc.thought_signature }),
       })),
     );
     const assistantMsgId = saveMessage(conversationId, "assistant", fullContent || null, {
@@ -800,11 +824,17 @@ export async function* orchestrate(
     const assistantApiMsg: OpenAI.ChatCompletionAssistantMessageParam = {
       role: "assistant",
       content: fullContent || "",
+      // Cast required: extra_content is a Gemini/OpenAI-SDK extension field not
+      // in the OpenAI type, but JSON.stringify includes it and Gemini requires
+      // thought_signature to be replayed here in round N+1 (thinking models).
       tool_calls: toolCalls.map((tc) => ({
         id: tc.id,
         type: "function" as const,
         function: tc.function,
-      })),
+        ...(tc.thought_signature && {
+          extra_content: { google: { thought_signature: tc.thought_signature } },
+        }),
+      })) as OpenAI.ChatCompletionMessageToolCall[],
     };
     apiMessages.push(assistantApiMsg);
 


### PR DESCRIPTION
## Summary

<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->

-

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

<!-- What should be manually verified on the :beta image? -->

- [ ]
