### PR TITLE
fix: persist title card request status across conversation reload (issue #338)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,6 +271,8 @@ Realtime (WebRTC) is restricted to `api.openai.com` only. `probeRealtimeSupport(
 
 The `year` field is typed as `number` throughout (`OverseerrSearchResult`, `OverseerrDetails`, `OverseerrRequest`, `OverseerrDiscoverResult`). The `yearFromDate()` helper in `overseerr.ts` parses the ISO date string from TMDB at source. The `display_titles` schema uses `z.coerce.number()` as a defensive measure so string years from any future path are coerced rather than rejected.
 
+**Request status persistence:** After a user clicks Request on a title card and the Overseerr submission succeeds, the "Requested" badge state is written to `localStorage` keyed as `thinkarr:requested:{mediaType}:{overseerrId}` (with an optional `:s{seasonNumber}` suffix for season-specific requests). On mount, `TitleCard` reads this key and initialises `requestStatus` to `"success"` if present, so the badge survives conversation reload without any server round-trip.
+
 ### Langfuse Observability
 Opt-in tracing via `LANGFUSE_SECRET_KEY` + `LANGFUSE_PUBLIC_KEY` env vars, or via Settings UI (env vars take precedence). Each chat request creates a root trace keyed by the user message UUID, with per-round LLM generation spans and per-tool spans. When a user reports an issue, a `user-report` score is attached to the trace and the GitHub issue body includes a `curl` retrieval command instead of a verbose transcript.
 

--- a/src/components/chat/title-card.tsx
+++ b/src/components/chat/title-card.tsx
@@ -16,9 +16,22 @@ const STATUS_STYLES: Record<string, { label: string; className: string }> = {
   not_requested: { label: "Not Requested", className: "bg-muted text-muted-foreground border border-border" },
 };
 
+function requestedStorageKey(overseerrId: number, mediaType: string, seasonNumber?: number | null): string {
+  const base = `thinkarr:requested:${mediaType}:${overseerrId}`;
+  return seasonNumber != null ? `${base}:s${seasonNumber}` : base;
+}
+
 export function TitleCard({ title }: TitleCardProps) {
   const [requesting, setRequesting] = useState(false);
-  const [requestStatus, setRequestStatus] = useState<"idle" | "success" | "error">("idle");
+  const storageKey = title.overseerrId != null && title.overseerrMediaType
+    ? requestedStorageKey(title.overseerrId, title.overseerrMediaType, title.seasonNumber)
+    : null;
+  const [requestStatus, setRequestStatus] = useState<"idle" | "success" | "error">(() => {
+    if (storageKey && typeof localStorage !== "undefined") {
+      try { return localStorage.getItem(storageKey) === "1" ? "success" : "idle"; } catch { /* ignore */ }
+    }
+    return "idle";
+  });
   const [errorMsg, setErrorMsg] = useState("");
 
   const status = STATUS_STYLES[title.mediaStatus] ?? STATUS_STYLES.not_requested;
@@ -61,6 +74,9 @@ export function TitleCard({ title }: TitleCardProps) {
       });
       const data = await res.json();
       if (data.success) {
+        if (storageKey) {
+          try { localStorage.setItem(storageKey, "1"); } catch { /* ignore */ }
+        }
         setRequestStatus("success");
       } else {
         setErrorMsg(data.error ?? "Request failed");

--- a/tests/e2e/title-cards.spec.ts
+++ b/tests/e2e/title-cards.spec.ts
@@ -130,6 +130,26 @@ test.describe("Title card — not_requested movie", () => {
     await expect(card.getByTestId("request-success")).toBeVisible({ timeout: 10_000 });
     await expect(card.getByTestId("request-button")).not.toBeVisible();
   });
+
+  test("Requested badge survives conversation reload (issue #338)", async ({ page }) => {
+    await page.goto("/chat");
+
+    await sendMessage(page, TRIGGER_UNAVAILABLE);
+    await expect(page.getByTestId("message-assistant")).toBeVisible({ timeout: 20_000 });
+    await page.waitForLoadState("networkidle");
+
+    const card = page.getByTestId("title-card").first();
+    await card.getByTestId("request-button").click();
+    await expect(card.getByTestId("request-success")).toBeVisible({ timeout: 10_000 });
+
+    // Reload the page — the Requested badge must still be shown
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const reloadedCard = page.getByTestId("title-card").first();
+    await expect(reloadedCard.getByTestId("request-success")).toBeVisible({ timeout: 10_000 });
+    await expect(reloadedCard.getByTestId("request-button")).not.toBeVisible();
+  });
 });
 
 test.describe("Title card — multiple titles (carousel)", () => {


### PR DESCRIPTION
## Summary

- After clicking Request on a title card and Overseerr confirms success, the "Requested" badge state is now written to `localStorage` keyed as `thinkarr:requested:{mediaType}:{overseerrId}` (with `:s{seasonNumber}` suffix for season requests)
- `TitleCard` reads this key on mount and initialises to `"success"` if present, so the badge survives conversation reload without any server round-trip
- Added E2E test `"Requested badge survives conversation reload (issue #338)"` to `title-cards.spec.ts`

Closes #338

**Note:** Issue #325 (Langfuse copy button) was already fixed and merged in PR #327 — no changes needed there.

## Test plan

- [ ] Click Request on a not_requested title card → "Requested" badge appears
- [ ] Reload the page → badge is still shown, Request button is gone
- [ ] Season-specific requests also persist (`:s{n}` key suffix)
- [ ] E2E: `npx playwright test title-cards.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)