### PR TITLE
fix: copy real Langfuse keys instead of masked placeholders (issue #325)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -201,6 +201,7 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
 | PATCH | `/api/settings` | Update config (admin only) |
 | GET | `/api/settings/logs` | List log files (admin) |
 | GET | `/api/settings/logs/[filename]` | Read/download log (`?download=true`) |
+| GET | `/api/settings/langfuse-keys` | Get unmasked Langfuse public + secret keys (admin) |
 | GET | `/api/settings/mcp-token` | Get global admin MCP token |
 | POST | `/api/settings/mcp-token` | Regenerate global admin MCP token |
 | GET | `/api/settings/mcp-token/user/[userId]` | Get per-user MCP token (admin; user can self-access) |

--- a/src/__tests__/api/settings-langfuse-keys.test.ts
+++ b/src/__tests__/api/settings-langfuse-keys.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for GET /api/settings/langfuse-keys
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockAdminSession = {
+  sessionId: "test-session",
+  user: { id: 1, plexId: "plex1", plexUsername: "admin", plexEmail: "a@b.com", plexAvatarUrl: null, isAdmin: true },
+};
+const mockUserSession = {
+  sessionId: "test-session-2",
+  user: { id: 2, plexId: "plex2", plexUsername: "user", plexEmail: "u@b.com", plexAvatarUrl: null, isAdmin: false },
+};
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth/session", () => ({ getSession: () => mockGetSession() }));
+
+const mockGetConfig = vi.fn();
+vi.mock("@/lib/config", () => ({ getConfig: (key: string) => mockGetConfig(key) }));
+
+async function getRoute() {
+  vi.resetModules();
+  const mod = await import("@/app/api/settings/langfuse-keys/route");
+  return mod.GET;
+}
+
+describe("GET /api/settings/langfuse-keys", () => {
+  beforeEach(() => {
+    mockGetSession.mockResolvedValue(mockAdminSession);
+    mockGetConfig.mockReturnValue("");
+  });
+
+  it("returns 403 when not authenticated", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const GET = await getRoute();
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    mockGetSession.mockResolvedValue(mockUserSession);
+    const GET = await getRoute();
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns the real (unmasked) public and secret keys for admins", async () => {
+    mockGetConfig.mockImplementation((key: string) => {
+      if (key === "langfuse.publicKey") return "pk-lf-real-public-key";
+      if (key === "langfuse.secretKey") return "sk-lf-real-secret-key";
+      return "";
+    });
+    const GET = await getRoute();
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.publicKey).toBe("pk-lf-real-public-key");
+    expect(body.data.secretKey).toBe("sk-lf-real-secret-key");
+  });
+
+  it("returns empty strings when no keys are configured", async () => {
+    mockGetConfig.mockReturnValue("");
+    const GET = await getRoute();
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.publicKey).toBe("");
+    expect(body.data.secretKey).toBe("");
+  });
+});

--- a/src/app/api/settings/langfuse-keys/route.ts
+++ b/src/app/api/settings/langfuse-keys/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getConfig } from "@/lib/config";
+import type { ApiResponse } from "@/types/api";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session || !session.user.isAdmin) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  return NextResponse.json<ApiResponse>({
+    success: true,
+    data: {
+      publicKey: getConfig("langfuse.publicKey") || "",
+      secretKey: getConfig("langfuse.secretKey") || "",
+    },
+  });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1647,7 +1647,13 @@ export default function SettingsPage() {
                     size="icon"
                     title="Copy as environment variables"
                     disabled={!langfuseConfig.publicKey && !langfuseConfig.secretKey}
-                    onClick={() => copyToClipboard(`LANGFUSE_PUBLIC_KEY=${langfuseConfig.publicKey}\nLANGFUSE_SECRET_KEY=${langfuseConfig.secretKey}`)}
+                    onClick={async () => {
+                      const res = await fetch("/api/settings/langfuse-keys");
+                      const data = await res.json();
+                      if (data.success) {
+                        copyToClipboard(`LANGFUSE_PUBLIC_KEY=${data.data.publicKey}\nLANGFUSE_SECRET_KEY=${data.data.secretKey}`);
+                      }
+                    }}
                   >
                     <Copy size={14} />
                   </Button>


### PR DESCRIPTION
## Summary

- The settings GET endpoint masks both Langfuse keys as `"••••••••"` for security, so the existing copy button was copying useless placeholder text
- Added `GET /api/settings/langfuse-keys` (admin-only) that returns the actual unmasked keys from the encrypted config store
- Updated the copy button to fetch from that endpoint before writing to clipboard, so the copied text is the real `LANGFUSE_PUBLIC_KEY=...` / `LANGFUSE_SECRET_KEY=...` values

Closes #325

## Test plan

- [ ] Configure Langfuse keys in Settings → Logs → Langfuse Observability
- [ ] Click the copy icon — paste into a terminal and verify real keys appear (not `••••••••`)
- [ ] Copy button remains disabled when no keys are configured
- [ ] Unit tests: `npx vitest run src/__tests__/api/settings-langfuse-keys.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)