### PR TITLE
fix(deps): override tsconfck peer dep to stop dependabot lock file failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.6",
+  "version": "1.1.6-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.6-beta.6",
+      "version": "1.1.6-beta.7",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "clsx": "^2.1.1",
@@ -11360,22 +11360,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "vitest": "^4.1.0"
   },
   "overrides": {
-    "flatted": ">=3.4.2"
+    "flatted": ">=3.4.2",
+    "tsconfck": {
+      "typescript": "$typescript"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `"tsconfck": { "typescript": "\$typescript" }` to the `overrides` section in `package.json`
- This redirects `tsconfck`'s optional `typescript@^5.0.0` peer dep to use the root-level typescript (currently 6.x) instead of installing a nested `typescript@5.9.3`

## Why

Every dependabot PR was failing CI with:
```
npm error Missing: typescript@5.9.3 from lock file
```

`tsconfck@3.1.6` (a transitive dep via `vite-tsconfig-paths`) has an optional peer dep on `typescript@^5.0.0`. Since top-level typescript is 6.x, **npm 10.9.7** (CI) installs a nested `typescript@5.9.3` under `vite-tsconfig-paths/`. Dependabot's internal npm skips this nested install, so its lock files fail `npm ci` on our npm version.

The override eliminates the nested install entirely — `tsconfck` gets the root typescript instead. Since the peer dep is optional, this is safe (tsconfck works without typescript too).

## Effect

Future dependabot PRs will pass CI without needing manual lock file fixes.

## Test plan

- [ ] CI passes
- [ ] `node_modules/vite-tsconfig-paths/node_modules/typescript` no longer exists in the lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)