### PR TITLE
Merge pull request #370 from chrisrothwell/claude/fix-sonarr-pending-season-status-1776232600

fix(sonarr): use 'pending' not 'partial' for monitored seasons with 0 episodes

### DIFF
--- a/src/__tests__/lib/tool-enrichment.test.ts
+++ b/src/__tests__/lib/tool-enrichment.test.ts
@@ -503,7 +503,7 @@ describe("sonarr_search_series — pre-computed mediaStatus (#280)", () => {
     const seasons = results[0].seasons as Array<{ seasonNumber: number; mediaStatus: string }>;
     expect(seasons).toEqual([
       { seasonNumber: 1, mediaStatus: "available" },
-      { seasonNumber: 2, mediaStatus: "partial" },
+      { seasonNumber: 2, mediaStatus: "pending" },
     ]);
     expect(mockOverseerrSearch).not.toHaveBeenCalled();
   });

--- a/src/lib/tools/sonarr-tools.ts
+++ b/src/lib/tools/sonarr-tools.ts
@@ -13,7 +13,8 @@ import type { SonarrSeries, SonarrSeriesStatus } from "@/lib/services/sonarr";
  */
 /** Derive per-season mediaStatus from Sonarr's own episode counts — no extra API call needed.
  *  episodeCount > 0 means Sonarr has downloaded episodes → "available".
- *  episodeCount === 0 + monitored → tracked by Sonarr, not yet downloaded → "partial" (suppresses Request button).
+ *  episodeCount === 0 + monitored → Sonarr is tracking it, will download when it airs → "pending"
+ *    (suppresses Request button; does NOT imply any content is present, unlike "partial").
  *  episodeCount === 0 + not monitored → "not_requested". */
 function sonarrPerSeasonStatus(
   sonarrSeasons: SonarrSeries["sonarrSeasons"],
@@ -21,7 +22,7 @@ function sonarrPerSeasonStatus(
   if (!sonarrSeasons || sonarrSeasons.length < 2) return undefined;
   return sonarrSeasons.map(({ seasonNumber, episodeCount, monitored }) => ({
     seasonNumber,
-    mediaStatus: episodeCount > 0 ? "available" : monitored ? "partial" : "not_requested",
+    mediaStatus: episodeCount > 0 ? "available" : monitored ? "pending" : "not_requested",
   }));
 }
 


### PR DESCRIPTION
## Summary

<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->

-

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

<!-- What should be manually verified on the :beta image? -->

- [ ]
