### PR TITLE
fix(display-titles): fix thumbnail double-proxy and recover thumbPath for pending season cards

### DIFF
--- a/src/__tests__/lib/display-titles-tool.test.ts
+++ b/src/__tests__/lib/display-titles-tool.test.ts
@@ -728,4 +728,55 @@ describe("display_titles — issue #351: imdbId side-query from Plex Guid", () =
     // imdbId also recovered in the same fetch
     expect(displayTitles[0].imdbId).toBe("tt1234567");
   });
+
+  it("recovers thumbPath for a 'pending' season card when LLM drops plexKey and thumbPath", async () => {
+    // Sonarr per-season 'pending' cards (monitored, nothing downloaded) were not included
+    // in plexKeyOverrides lookup, so thumbPath recovery never fired for them.
+    // Fix: include 'pending' in the needsLookup filter so the show's plexKey is resolved
+    // and thumbPath can be recovered via Plex metadata.
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if ((url as string).includes("/hubs/search")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            MediaContainer: {
+              Hub: [{
+                type: "show",
+                Metadata: [{ type: "show", title: "Starfleet Academy", year: 2026, key: "/library/metadata/7116", thumb: "/library/metadata/7116/thumb/abc", addedAt: 1700000000 }],
+              }],
+            },
+          }),
+        });
+      }
+      if ((url as string).includes("/library/metadata/7116")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            MediaContainer: {
+              Metadata: [{ type: "show", title: "Starfleet Academy", thumb: "/library/metadata/7116/thumb/abc", Guid: [{ id: "imdb://tt7587890" }] }],
+            },
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ MediaContainer: { machineIdentifier: "abc123" } }) });
+    }));
+
+    const { registerDisplayTitlesTool } = await import("@/lib/tools/display-titles-tool");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerDisplayTitlesTool();
+
+    const raw = await executeTool("display_titles", JSON.stringify({
+      titles: [{
+        mediaType: "tv",
+        title: "Starfleet Academy — Season 2",
+        year: 2026,
+        seasonNumber: 2,
+        mediaStatus: "pending",
+        // LLM dropped both plexKey and thumbPath
+      }],
+    }));
+    const { displayTitles } = JSON.parse(raw) as { displayTitles: Array<{ thumbUrl?: string }> };
+    expect(displayTitles[0].thumbUrl).toContain("/api/plex/thumb");
+    expect(displayTitles[0].thumbUrl).toContain("abc");
+  });
 });

--- a/src/lib/tools/display-titles-tool.ts
+++ b/src/lib/tools/display-titles-tool.ts
@@ -74,7 +74,7 @@ For overseerr_list_requests results: one card per request is correct (no season 
         const needsLookup = args.titles
           .map((t, i) => ({ t, i }))
           .filter(({ t }) =>
-            (t.mediaStatus === "available" || t.mediaStatus === "partial") &&
+            (t.mediaStatus === "available" || t.mediaStatus === "partial" || t.mediaStatus === "pending") &&
             !t.plexKey &&
             t.title,
           );

--- a/src/lib/tools/radarr-tools.ts
+++ b/src/lib/tools/radarr-tools.ts
@@ -27,7 +27,7 @@ async function enrichRadarrMovie(m: RadarrMovie): Promise<RadarrMovie> {
     if (match) {
       return {
         ...m,
-        thumbPath: match.thumbPath ? plex.buildThumbUrl(match.thumbPath) : undefined,
+        thumbPath: match.thumbPath,
         plexKey: match.plexKey,
         cast: match.cast,
       };

--- a/src/lib/tools/sonarr-tools.ts
+++ b/src/lib/tools/sonarr-tools.ts
@@ -46,7 +46,7 @@ async function enrichSonarrSeries(s: SonarrSeries): Promise<SonarrSeries> {
       const isPartial = match.seasons != null && s.seasonCount != null && match.seasons < s.seasonCount;
       return {
         ...rest,
-        thumbPath: match.thumbPath ? plex.buildThumbUrl(match.thumbPath) : undefined,
+        thumbPath: match.thumbPath,
         plexKey: match.plexKey,
         cast: match.cast,
         mediaStatus: isPartial ? "partial" : "available",


### PR DESCRIPTION
## Summary

- **Double-proxy bug**: `sonarr-tools` and `radarr-tools` were calling `plex.buildThumbUrl()` before returning `thumbPath` to the LLM. `display-titles-tool.ts` then called `buildThumbUrl()` again on the already-proxied path, producing `/api/plex/thumb?path=%2Fapi%2Fplex%2Fthumb%3Fpath%3D...` — the route's `/library/...` path validation rejected this with 400, so thumbnails never loaded
- **Pending season cards**: `plexKeyOverrides` lookup only ran for `available`/`partial` statuses — Sonarr per-season `pending` cards got no `plexKey` and therefore no thumbPath recovery from Plex metadata. Fix: include `pending` in the lookup filter

`display-titles-tool.ts` is now the single place that calls `buildThumbUrl()`. All enrichment tools return the raw `/library/...` Plex path.

## Test plan

- [ ] Radarr search: movie thumbnails display correctly
- [ ] Sonarr partial show: all season cards (including `pending` seasons) show thumbnails
- [ ] Starfleet Academy: S1 (`available`) and S2 (`pending`) both show poster

🤖 Generated with [Claude Code](https://claude.com/claude-code)