### PR TITLE
fix(docker): upgrade musl/musl-utils to patch CVE-2026-40200

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 ENV TZ=UTC
 
-RUN apk upgrade --no-cache zlib openssl && \
+RUN apk upgrade --no-cache zlib openssl musl musl-utils && \
     apk add --no-cache shadow su-exec tzdata && \
     mkdir -p /config && \
     chown node:node /config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.7",
+  "version": "1.1.6-beta.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Adds `musl musl-utils` to the `apk upgrade` command in the runner stage of the Dockerfile
- Pulls in `>=1.2.5-r23`, resolving the HIGH-severity CVE-2026-40200 (stack-based arbitrary code execution / DoS in musl libc)
- Bumps version to `1.1.6-beta.8`

## Test plan

- [ ] Trivy scan of the built image shows no HIGH/CRITICAL findings for `musl` or `musl-utils`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)