### PR TITLE
chore: bump version to 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6-beta.8",
+  "version": "1.1.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Strips `-beta.8` suffix from `1.1.6-beta.8` → `1.1.6` for production release

## Release flow

After this merges to `dev`, the next steps are:
- `dev → beta` PR (triggers `:beta` image)
- `beta → main` PR (triggers `:latest` + `v1.1.6` tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)