### PR TITLE
fix(#395): redirect to /login when session is invalidated

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -78,13 +78,17 @@ function ChatPageContent() {
   // Load current user
   useEffect(() => {
     fetch("/api/auth/session")
-      .then((r) => r.json())
-      .then((data) => {
+      .then(async (r) => {
+        if (r.status === 401) {
+          router.replace("/login");
+          return;
+        }
+        const data = await r.json();
         if (data.success) setUser(data.data.user);
       })
       .catch(() => {})
       .finally(() => setUserLoading(false));
-  }, []);
+  }, [router]);
 
   // Load available models, restoring the last-used model from localStorage
   useEffect(() => {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -163,9 +163,15 @@ export default function SettingsPage() {
   useEffect(() => {
     // Always fetch session first to determine admin status
     fetch("/api/auth/session")
-      .then((r) => r.json())
+      .then(async (r) => {
+        if (r.status === 401) {
+          router.replace("/login");
+          return;
+        }
+        return r.json();
+      })
       .then(async (sessionData) => {
-        if (!sessionData.success) return;
+        if (!sessionData || !sessionData.success) return;
         const user = sessionData.data.user;
         setCurrentUser(user);
 

--- a/tests/e2e/routing.spec.ts
+++ b/tests/e2e/routing.spec.ts
@@ -8,6 +8,34 @@
 
 import { test, expect } from "@playwright/test";
 
+test.describe("stale session redirect", () => {
+  test("/chat redirects to /login when session cookie is invalid", async ({ page, context }) => {
+    await context.addCookies([
+      {
+        name: "thinkarr_session",
+        value: "00000000-0000-0000-0000-000000000000",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+    await page.goto("/chat");
+    await expect(page).toHaveURL(/\/login/, { timeout: 5000 });
+  });
+
+  test("/settings redirects to /login when session cookie is invalid", async ({ page, context }) => {
+    await context.addCookies([
+      {
+        name: "thinkarr_session",
+        value: "00000000-0000-0000-0000-000000000000",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+    await page.goto("/settings");
+    await expect(page).toHaveURL(/\/login/, { timeout: 5000 });
+  });
+});
+
 test.describe("root redirect — post-setup", () => {
   test("/ redirects unauthenticated visitors to /login", async ({ page }) => {
     // Root page redirects to /chat when users exist, but the auth middleware


### PR DESCRIPTION
## Summary

- When a session is revoked server-side the cookie still exists, so the middleware passes through but every API call returns 401 — leaving the user on a blank page with no logout/login option
- Fix: detect the 401 on the initial `/api/auth/session` fetch in `/chat` and `/settings` and call `router.replace('/login')` immediately
- Added two E2E tests in `routing.spec.ts` that inject a bogus session cookie and verify the redirect fires

## Test plan

- [ ] Run `npx vitest run` — all 553 unit tests pass
- [ ] E2E: `npx playwright test tests/e2e/routing.spec.ts` — stale session redirect tests pass
- [ ] Manual: log in, invalidate the session row in the DB (or delete from `sessions` table), refresh `/chat` — should redirect to `/login` instead of blank page

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)