### PR TITLE
chore: bump version to 1.1.7-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.6",
+  "version": "1.1.7-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps `package.json` from `1.1.6` → `1.1.7-beta.1` ahead of the next `dev → beta` release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)