### PR TITLE
fix(#396,#398): Dockerfile hardening + Gitleaks secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,19 +174,36 @@ jobs:
           path: ${{ runner.temp }}/codeql-results
           retention-days: 7
 
+  secrets:
+    name: Secret Scanning (Gitleaks)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Always runs — this is the single check required by branch protection rulesets.
-  # Passes if test/e2e/codeql succeeded or were skipped (docs-only PR).
-  # Fails if test, e2e, or codeql failed.
+  # Passes if test/e2e/codeql/secrets succeeded or were skipped (docs-only PR).
+  # Fails if any required job failed.
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
-    needs: [changes, test, e2e, codeql]
+    needs: [changes, test, e2e, codeql, secrets]
     if: always()
 
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" || "${{ needs.e2e.result }}" == "failure" || "${{ needs.codeql.result }}" == "failure" ]]; then
+          if [[ "${{ needs.test.result }}" == "failure" || "${{ needs.e2e.result }}" == "failure" || "${{ needs.codeql.result }}" == "failure" || "${{ needs.secrets.result }}" == "failure" ]]; then
             echo "One or more required jobs failed."
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-# Base image is pinned to a specific digest to prevent supply-chain attacks via
-# tag mutation. Dependabot will open PRs to keep this current automatically.
-# To refresh manually: docker pull node:22-alpine && docker inspect node:22-alpine --format '{{index .RepoDigests 0}}'
-# Stage 1: Install dependencies
+# Node base image — Dependabot keeps this tag current.
+# To pin to a digest instead: docker pull node:25-alpine && docker inspect node:25-alpine --format '{{index .RepoDigests 0}}'
+# Stage 1: Install dependencies (includes native build tools for better-sqlite3)
 FROM node:25-alpine AS deps
 WORKDIR /app
+RUN apk add --no-cache python3 make g++
 COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
-# Rebuild better-sqlite3 for Alpine
 RUN npm rebuild better-sqlite3
 
 # Stage 2: Build the application
@@ -28,7 +27,7 @@ ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 ENV TZ=UTC
 
-RUN apk upgrade --no-cache zlib openssl musl musl-utils && \
+RUN apk upgrade --no-cache && \
     apk add --no-cache shadow su-exec tzdata && \
     mkdir -p /config && \
     chown node:node /config


### PR DESCRIPTION
## Summary

**Dockerfile (#398)**
- Remove the false "pinned to digest" comment (the FROM lines used tags, not digests — the comment was actively misleading); replace with an accurate note and instruction for manual pinning
- Add `python3 make g++` to the deps stage so `npm rebuild better-sqlite3` has explicit native build tooling rather than relying on what the base image happens to include
- Switch runner stage from `apk upgrade --no-cache zlib openssl musl musl-utils` to `apk upgrade --no-cache` — ensures all Alpine packages are patched, not just the ones named explicitly; new CVEs in other libs are no longer silently missed

**CI (#396)**
- Add `secrets` job running `gitleaks/gitleaks-action@v2` with `fetch-depth: 0` (full history scan) in parallel with the existing jobs
- Wire `secrets` into the `CI Complete` gate so a detected secret blocks the PR

## Not done (with reasoning)
- `USER node` in Dockerfile — incompatible with the linuxserver.io entrypoint pattern; the entrypoint needs root to create dynamic PUID/PGID users then uses `su-exec` to drop privileges. Adding `USER node` would break `addgroup`/`adduser`.
- ZAP scan in CI — tracked as a separate PR; needs the exclude list finalised first (LLM, GitHub, Plex endpoints) and a scheduled workflow rather than per-PR to avoid 3–5 min overhead.

## Test plan
- [ ] Docker build succeeds with new deps stage (`docker build -t thinkarr:test .`)
- [ ] Trivy scan still passes (`apk upgrade` should reduce findings, not increase them)
- [ ] Gitleaks job appears in CI and passes on this PR
- [ ] `CI Complete` gate still green

Closes #396 (partial — ZAP in separate PR), Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)