### PR TITLE
fix(#396,#397,#398): tighten security headers (ZAP findings)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,21 +17,33 @@ const securityHeaders = [
   { key: "Permissions-Policy", value: "camera=(), geolocation=()" },
   // Prevent search engines from indexing home-server instances
   { key: "X-Robots-Tag", value: "noindex, nofollow" },
+  // Prevent this page from being used as an opener by cross-origin popups.
+  // same-origin-allow-popups (not same-origin) is used because the Plex OAuth
+  // flow opens a popup via window.open() — same-origin would null the opener reference.
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin-allow-popups" },
+  // Prevent cross-origin no-cors requests from reading our responses (Spectre mitigation).
+  { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
   // Content Security Policy — restricts resource loading to same origin.
-  // unsafe-inline is required for Next.js App Router inline scripts/styles.
+  // unsafe-inline is required for Next.js App Router (inline hydration scripts/styles).
+  // connect-src https: is intentionally broad — LLM base URLs are user-configured at
+  // runtime so we cannot enumerate them statically.
+  // img-src is limited to self+data: because all Plex/TMDB images are proxied
+  // server-side (/api/plex/thumb, /api/tmdb/thumb, /api/plex/avatar/*).
   {
     key: "Content-Security-Policy",
     value: [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline'",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: https:",
+      "img-src 'self' data:",
       // blob: required for TTS audio (URL.createObjectURL) and voice input (MediaRecorder)
       // https: required for WebRTC SDP exchange (realtime mode, OpenAI endpoint)
       "connect-src 'self' blob: https:",
       // blob: required for TTS audio playback via new Audio(objectUrl)
       "media-src 'self' blob:",
       "font-src 'self'",
+      "object-src 'none'",
+      "form-action 'self'",
       "frame-ancestors 'none'",
     ].join("; "),
   },
@@ -39,6 +51,7 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  poweredByHeader: false,
   env: {
     NEXT_PUBLIC_APP_VERSION: pkg.version,
   },


### PR DESCRIPTION
## Summary

Addresses the medium and low ZAP findings that are fixable at the application layer (`next.config.ts` only — one file changed).

| Change | ZAP finding resolved |
|---|---|
| `poweredByHeader: false` | Low: X-Powered-By header leaks Next.js version |
| `img-src 'self' data:` (removed `https:`) | Medium: CSP wildcard directive — Plex/TMDB images are server-proxied so `https:` was never needed |
| `form-action 'self'` | Medium: CSP failure to define directive with no fallback |
| `object-src 'none'` | Defence-in-depth (plugin content) |
| `Cross-Origin-Opener-Policy: same-origin-allow-popups` | Low: COOP header missing — `allow-popups` variant chosen to preserve Plex OAuth popup flow |
| `Cross-Origin-Resource-Policy: same-origin` | Low: CORP header missing |

## Findings NOT fixed here (and why)

| Finding | Reason |
|---|---|
| `script-src unsafe-inline` | Next.js App Router requirement for hydration |
| `style-src unsafe-inline` | Tailwind CSS inline styles |
| `connect-src https:` | LLM base URLs are user-configured at runtime — cannot enumerate statically |
| HSTS | Must be set in the reverse proxy only — setting it in-app permanently breaks HTTP LAN deployments |
| COEP | `require-corp` would break `blob:` TTS audio and WebRTC |
| Proxy Disclosure (TRACE) | Nginx config on the Synology reverse proxy — not an app fix |
| Cookie Slack Detector | False positive — public routes correctly ignore the session cookie |

## Test plan
- [ ] `npx vitest run` — all tests pass
- [ ] Dev server: check response headers include COOP, CORP, updated CSP, no X-Powered-By
- [ ] Plex OAuth login still works (popup opens and completes)
- [ ] TTS audio playback still works (blob: URLs)
- [ ] Re-run ZAP scan and confirm medium/low count drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)