### PR TITLE
Merge pull request #412 from chrisrothwell/claude/fix-gpt5-max-tokens-409-Xw2pL

fix(#409): support GPT-5 models — fall back to max_completion_tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ LLM-powered chat assistant for managing your media stack. Connect your Plex, Son
 
 ## Quick Start
 
-It is recommended to run this as a Docker container, alongside your other Arrs tools.
-The docker-compose.yml is designed to be similar to these other Arrs for ease of set up.
-If you are already running Sonarr/Radarr/Overseerr as Docker containers, you can follow the same steps to run the Thinkarr container on your chosen platform.
+- It is recommended to run this as a Docker container, alongside your other Arrs tools.
+- The docker-compose.yml is designed to be similar to these other Arrs for ease of set up.
+- If you are already running Sonarr/Radarr/Overseerr as Docker containers, you can follow the same steps to run the Thinkarr container on your chosen platform.
 
 ```yaml
 # docker-compose.yml
@@ -81,36 +81,36 @@ Depending on your preference and willingness to pay, you can sign up for and con
 
 | Organisation | Model Availability | Platform Link | Model Documentation |
 |--------------|--------------------|---------------|---------------------|
-| OpenAI | GPT 4, GPT 5 | https://platform.openai.com | https://developers.openai.com/api/docs/models |
-| Google | Gemini 2.5, 3 | https://aistudio.google.com | https://ai.google.dev/gemini-api/docs/models |
-| OpenRouter | Many | https://openrouter.ai/ | https://openrouter.ai/models |
+| OpenAI | GPT 4, GPT 5 | [OpenAI Platform](https://platform.openai.com) | [Models](https://developers.openai.com/api/docs/models) |
+| Google | Gemini 2.5, 3 | [Google AI Studio](https://aistudio.google.com) | [Models](https://ai.google.dev/gemini-api/docs/models) |
+| OpenRouter | Many | [OpenRouter Homepage](https://openrouter.ai/) | [Models](https://openrouter.ai/models) |
 
-You may also wish to run your own LLMs e.g. OLlama, which is outside the scope of this document.
-Any OpenAI compatible endpoint should work, although models and providers have various quirks which may require a code fix before they work.
+- You may also wish to run your own LLMs e.g. OLlama, which is outside the scope of this document.
+- Any OpenAI compatible endpoint should work, although models and providers have various quirks which may require a code fix before they work.
 
 ## Choosing an LLM
 
 The system prompt, tools and LLM call flow has been tested in the following configurations:
 
-| Model | Hosted by | Capabilities | Quality | Cost per turn $USD |
+| Model | Base URL | Capabilities | Quality | Cost per turn $USD |
 |-------|-----------|--------------|---------|--------------------|
-| `OpenAI gpt-4.1` | OpenAI (https://api.openai.com/v1) | Text, STT (Whisper), TTS | Very Good | $0.04342 |
-| `OpenAI gpt-5-mini` | OpenAI (https://api.openai.com/v1) | Text, STT (Whisper), TTS | Under testing | $X.XX |
-| `gemini-2.5-flash-lite` | Google (generativelanguage.googleapis.com/v1beta/openai) | Text | Medium, hallucinates tool calls, struggles with JSON handling, quickly forgets context | $0.002 |
-| `gemini-3.1-flash-lite-preview` | Google (generativelanguage.googleapis.com/v1beta/openai) | Text | Very Good | $0.0068 |
-| `moonshotai/kimi-k2.5` | OpenRouter (https://openrouter.ai/api/v1) | Text | Very Good, when available | Free Tier |
+| `OpenAI gpt-4.1` | https://api.openai.com/v1 | Text, STT (Whisper), TTS | Very Good | $0.04342 |
+| `OpenAI gpt-5-mini` | https://api.openai.com/v1 | Text, STT (Whisper), TTS | Under testing | $X.XX |
+| `gemini-2.5-flash-lite` | https://generativelanguage.googleapis.com/v1beta/openai | Text | Medium, hallucinates tool calls, struggles with JSON handling, quickly forgets context | $0.002 |
+| `gemini-3.1-flash-lite-preview` | https://generativelanguage.googleapis.com/v1beta/openai | Text | Very Good | $0.0068 |
+| `moonshotai/kimi-k2.5` | https://openrouter.ai/api/v1 | Text | Very Good, when available | Free Tier |
 
-Cost per turn is the approximate token cost observed during testing for a question which results in one API tool call and displaying the title carousel.
-These were all tested using the Default prompt.  You may be able to achieve better results on cheaper models by tweaking the system prompt.
-When selecting a model, you may wish to consider that the input:output ratio is approximately 60:1 so you should prioritize models with cheaper input / cached input costs.
-Please let me know which combination of model & prompt works best for you!!
+- Cost per turn is the approximate token cost observed during testing for a question which results in one API tool call and displaying the title carousel.
+- These were all tested using the Default prompt.  You may be able to achieve better results on cheaper models by tweaking the system prompt.
+- When selecting a model, you may wish to consider that the input:output ratio is approximately 60:1 so you should prioritize models with cheaper input / cached input costs.
+- Please let me know which combination of model & prompt works best for you!!
 
 ## Development
 
-Contributions are welcome! Feel free to fork the repo and clone to your local device.
-Please make changes on a new branch with a meaningful name, and be sure to test before pushing upstream.
+- Contributions are welcome! Feel free to fork the repo and clone to your local device.
+- Please make changes on a new branch with a meaningful name, and be sure to test before pushing upstream.
 
-Building from source:
+### Building from source:
 
 ```bash
 # Install dependencies
@@ -128,6 +128,6 @@ npx drizzle-kit generate
 
 ## Support and Feedback
 
-You can ask questions in the Help category of our [GitHub Discussions](https://github.com/chrisrothwell/thinkarr/discussions).
-Bug reports and feature requests can be submitted via [GitHub Issues](https://github.com/chrisrothwell/thinkarr/issues).
-I would love to get your input!
+- You can ask questions in the Help category of our [GitHub Discussions](https://github.com/chrisrothwell/thinkarr/discussions).
+- Bug reports and feature requests can be submitted via [GitHub Issues](https://github.com/chrisrothwell/thinkarr/issues).
+- I would love to get your input!

--- a/src/__tests__/lib/services/test-connection.test.ts
+++ b/src/__tests__/lib/services/test-connection.test.ts
@@ -57,7 +57,8 @@ describe("testConnection LLM — max_tokens fallback", () => {
 
     expect(result.success).toBe(true);
     expect(createMock.mock.calls[0][0]).toMatchObject({ max_tokens: 1 });
-    expect(createMock.mock.calls[1][0]).toMatchObject({ max_completion_tokens: 1 });
+    expect(createMock.mock.calls[1][0]).not.toHaveProperty("max_tokens");
+    expect(createMock.mock.calls[1][0]).not.toHaveProperty("max_completion_tokens");
   });
 
   it("reports failure (not retries) when model returns a 401 auth error", async () => {

--- a/src/__tests__/lib/services/test-connection.test.ts
+++ b/src/__tests__/lib/services/test-connection.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { createMock, listModelsMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  listModelsMock: vi.fn(),
+}));
+
+vi.mock("openai", () => {
+  class APIError extends Error {
+    status: number;
+    error: unknown;
+    headers: Record<string, string>;
+    constructor(status: number, error: unknown, message: string, headers: Record<string, string>) {
+      super(message);
+      this.status = status;
+      this.error = error;
+      this.headers = headers;
+    }
+  }
+  function OpenAIMock() {
+    return {
+      chat: { completions: { create: createMock } },
+      models: { list: listModelsMock },
+    };
+  }
+  return { default: OpenAIMock, APIError };
+});
+
+vi.mock("@/lib/security/url-validation", () => ({
+  validateServiceUrl: vi.fn().mockReturnValue({ valid: true }),
+}));
+
+import { testConnection } from "@/lib/services/test-connection";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listModelsMock.mockResolvedValue({ [Symbol.asyncIterator]: async function* () {} });
+});
+
+describe("testConnection LLM — max_tokens fallback", () => {
+  it("succeeds on first attempt with max_tokens for GPT-4.x models", async () => {
+    createMock.mockResolvedValue({ choices: [] });
+
+    const result = await testConnection({ type: "llm", url: "https://api.openai.com/v1", apiKey: "sk-test", model: "gpt-4.1" });
+
+    expect(result.success).toBe(true);
+    expect(createMock.mock.calls[0][0]).toMatchObject({ max_tokens: 1 });
+  });
+
+  it("retries with max_completion_tokens when GPT-5 returns 400 param=max_tokens", async () => {
+    const { APIError } = await import("openai");
+    createMock
+      .mockRejectedValueOnce(new (APIError as unknown as new (...args: unknown[]) => Error)(400, { param: "max_tokens", code: "unsupported_parameter" }, "Unsupported parameter", {}))
+      .mockResolvedValue({ choices: [] });
+
+    const result = await testConnection({ type: "llm", url: "https://api.openai.com/v1", apiKey: "sk-test", model: "gpt-5-mini" });
+
+    expect(result.success).toBe(true);
+    expect(createMock.mock.calls[0][0]).toMatchObject({ max_tokens: 1 });
+    expect(createMock.mock.calls[1][0]).toMatchObject({ max_completion_tokens: 1 });
+  });
+
+  it("reports failure (not retries) when model returns a 401 auth error", async () => {
+    const { APIError } = await import("openai");
+    createMock.mockRejectedValue(new (APIError as unknown as new (...args: unknown[]) => Error)(401, { message: "Unauthorized" }, "Unauthorized", {}));
+
+    const result = await testConnection({ type: "llm", url: "https://api.openai.com/v1", apiKey: "sk-bad", model: "gpt-4.1" });
+
+    expect(result.success).toBe(false);
+    // Should not retry on non-max_tokens API errors
+    const maxTokensCalls = createMock.mock.calls.filter((c: unknown[]) =>
+      (c[0] as Record<string, unknown>).max_completion_tokens !== undefined
+    );
+    expect(maxTokensCalls).toHaveLength(0);
+  });
+
+  it("retries without token limit on non-HTTP (network) errors", async () => {
+    createMock
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValue({ choices: [] });
+
+    const result = await testConnection({ type: "llm", url: "https://api.openai.com/v1", apiKey: "sk-test", model: "gpt-4.1" });
+
+    expect(result.success).toBe(true);
+    expect(createMock.mock.calls[0][0]).toMatchObject({ max_tokens: 1 });
+    expect(createMock.mock.calls[1][0]).not.toHaveProperty("max_tokens");
+    expect(createMock.mock.calls[1][0]).not.toHaveProperty("max_completion_tokens");
+  });
+});

--- a/src/app/api/services/status/route.ts
+++ b/src/app/api/services/status/route.ts
@@ -21,8 +21,8 @@ async function checkSingleLlmEndpoint(
     const { default: OpenAI } = await import("openai");
     const client = new OpenAI({ baseURL: baseUrl, apiKey });
     if (model) {
-      // GPT-5+ rejects max_tokens (HTTP 400); retry with max_completion_tokens.
-      // If that also fails (non-OpenAI endpoint quirk), retry without either.
+      // GPT-5+ rejects max_tokens with HTTP 400 and enforces a minimum on
+      // max_completion_tokens, so retry without any token limit on failure.
       try {
         await client.chat.completions.create({
           model,
@@ -30,18 +30,10 @@ async function checkSingleLlmEndpoint(
           max_tokens: 1,
         });
       } catch {
-        try {
-          await client.chat.completions.create({
-            model,
-            messages: [{ role: "user", content: "Hi" }],
-            max_completion_tokens: 1,
-          });
-        } catch {
-          await client.chat.completions.create({
-            model,
-            messages: [{ role: "user", content: "Hi" }],
-          });
-        }
+        await client.chat.completions.create({
+          model,
+          messages: [{ role: "user", content: "Hi" }],
+        });
       }
       return { name, status: "green", message: `Connected (${model})` };
     }

--- a/src/app/api/services/status/route.ts
+++ b/src/app/api/services/status/route.ts
@@ -21,7 +21,8 @@ async function checkSingleLlmEndpoint(
     const { default: OpenAI } = await import("openai");
     const client = new OpenAI({ baseURL: baseUrl, apiKey });
     if (model) {
-      // Some non-OpenAI endpoints reject max_tokens — retry without it
+      // GPT-5+ rejects max_tokens (HTTP 400); retry with max_completion_tokens.
+      // If that also fails (non-OpenAI endpoint quirk), retry without either.
       try {
         await client.chat.completions.create({
           model,
@@ -29,10 +30,18 @@ async function checkSingleLlmEndpoint(
           max_tokens: 1,
         });
       } catch {
-        await client.chat.completions.create({
-          model,
-          messages: [{ role: "user", content: "Hi" }],
-        });
+        try {
+          await client.chat.completions.create({
+            model,
+            messages: [{ role: "user", content: "Hi" }],
+            max_completion_tokens: 1,
+          });
+        } catch {
+          await client.chat.completions.create({
+            model,
+            messages: [{ role: "user", content: "Hi" }],
+          });
+        }
       }
       return { name, status: "green", message: `Connected (${model})` };
     }

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -968,8 +968,8 @@ export async function generateTitle(
     try {
       response = await client.chat.completions.create({ model, messages, max_tokens: 20 });
     } catch {
-      // GPT-5+ rejects max_tokens — retry with max_completion_tokens
-      response = await client.chat.completions.create({ model, messages, max_completion_tokens: 20 });
+      // GPT-5+ rejects max_tokens — retry without token limit
+      response = await client.chat.completions.create({ model, messages });
     }
 
     const title = response.choices[0]?.message?.content?.trim();

--- a/src/lib/llm/orchestrator.ts
+++ b/src/lib/llm/orchestrator.ts
@@ -955,18 +955,22 @@ export async function generateTitle(
     const client = getLlmClient();
     const model = getLlmModel();
 
-    const response = await client.chat.completions.create({
-      model,
-      messages: [
-        {
-          role: "system",
-          content:
-            "Generate a very short summary (3-6 words, no quotes) summarizing this chat message. Most conversations will be about TV and Movies and/or their avaialability in a Media Library so assume this is the case.  If the chat was about a specific title, reply with ONLY the title and the year e.g. Ghostbusters (1984), nothing else.  If the chat as about multiple titles or something else, reply with ONLY the short summary, nothing else.",
-        },
-        { role: "user", content: firstUserMessage },
-      ],
-      max_tokens: 20,
-    });
+    const messages = [
+      {
+        role: "system" as const,
+        content:
+          "Generate a very short summary (3-6 words, no quotes) summarizing this chat message. Most conversations will be about TV and Movies and/or their avaialability in a Media Library so assume this is the case.  If the chat was about a specific title, reply with ONLY the title and the year e.g. Ghostbusters (1984), nothing else.  If the chat as about multiple titles or something else, reply with ONLY the short summary, nothing else.",
+      },
+      { role: "user" as const, content: firstUserMessage },
+    ];
+
+    let response;
+    try {
+      response = await client.chat.completions.create({ model, messages, max_tokens: 20 });
+    } catch {
+      // GPT-5+ rejects max_tokens — retry with max_completion_tokens
+      response = await client.chat.completions.create({ model, messages, max_completion_tokens: 20 });
+    }
 
     const title = response.choices[0]?.message?.content?.trim();
     if (title) {

--- a/src/lib/services/test-connection.ts
+++ b/src/lib/services/test-connection.ts
@@ -81,10 +81,9 @@ async function testLlm(url: string, apiKey: string, model?: string): Promise<Tes
     const { default: OpenAI, APIError } = await import("openai");
     const client = new OpenAI({ baseURL: url, apiKey });
     if (model) {
-      // Quick completion test with a 3-tier fallback for token-limit params:
-      // 1. max_tokens:1 (works for GPT-4.x, most non-OpenAI endpoints)
-      // 2. max_completion_tokens:1 (GPT-5+ rejects max_tokens with HTTP 400)
-      // 3. No token limit (catch-all for non-OpenAI endpoints that reject both)
+      // Quick completion test. GPT-5+ rejects max_tokens with HTTP 400 (unsupported_parameter)
+      // and also enforces a minimum on max_completion_tokens, so the safest retry is no token
+      // limit at all — the cost difference on a one-off connection test is negligible.
       try {
         await client.chat.completions.create({
           model,
@@ -93,13 +92,12 @@ async function testLlm(url: string, apiKey: string, model?: string): Promise<Tes
         });
       } catch (inner: unknown) {
         if (inner instanceof APIError && inner.status !== undefined) {
-          // GPT-5+ rejects max_tokens with a specific 400 — retry with max_completion_tokens.
+          // GPT-5+ rejects max_tokens with a specific 400 — retry without any token limit.
           const errParam = (inner.error as Record<string, unknown> | null)?.param;
           if (inner.status === 400 && errParam === "max_tokens") {
             await client.chat.completions.create({
               model,
               messages: [{ role: "user", content: "Hi" }],
-              max_completion_tokens: 1,
             });
           } else {
             throw inner;

--- a/src/lib/services/test-connection.ts
+++ b/src/lib/services/test-connection.ts
@@ -81,8 +81,10 @@ async function testLlm(url: string, apiKey: string, model?: string): Promise<Tes
     const { default: OpenAI, APIError } = await import("openai");
     const client = new OpenAI({ baseURL: url, apiKey });
     if (model) {
-      // Quick completion test — some non-OpenAI endpoints reject max_tokens,
-      // so fall back to a plain request without it if the first attempt fails.
+      // Quick completion test with a 3-tier fallback for token-limit params:
+      // 1. max_tokens:1 (works for GPT-4.x, most non-OpenAI endpoints)
+      // 2. max_completion_tokens:1 (GPT-5+ rejects max_tokens with HTTP 400)
+      // 3. No token limit (catch-all for non-OpenAI endpoints that reject both)
       try {
         await client.chat.completions.create({
           model,
@@ -90,14 +92,25 @@ async function testLlm(url: string, apiKey: string, model?: string): Promise<Tes
           max_tokens: 1,
         });
       } catch (inner: unknown) {
-        // If the first attempt failed with a non-HTTP-error (e.g. network, max_tokens
-        // rejection), try again without max_tokens. Re-throw HTTP errors immediately so
-        // the outer catch can format them with full diagnostic detail.
-        if (inner instanceof APIError && inner.status !== undefined) throw inner;
-        await client.chat.completions.create({
-          model,
-          messages: [{ role: "user", content: "Hi" }],
-        });
+        if (inner instanceof APIError && inner.status !== undefined) {
+          // GPT-5+ rejects max_tokens with a specific 400 — retry with max_completion_tokens.
+          const errParam = (inner.error as Record<string, unknown> | null)?.param;
+          if (inner.status === 400 && errParam === "max_tokens") {
+            await client.chat.completions.create({
+              model,
+              messages: [{ role: "user", content: "Hi" }],
+              max_completion_tokens: 1,
+            });
+          } else {
+            throw inner;
+          }
+        } else {
+          // Non-HTTP error (network etc.) — retry without any token limit.
+          await client.chat.completions.create({
+            model,
+            messages: [{ role: "user", content: "Hi" }],
+          });
+        }
       }
     } else {
       // Just list models to verify connectivity


### PR DESCRIPTION
## Summary

<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->

-

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

<!-- What should be manually verified on the :beta image? -->

- [ ]
