### PR TITLE
chore: bump version to 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.7-beta.2",
+  "version": "1.1.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `1.1.7-beta.2` → `1.1.7` in preparation for a production release

## Pre-merge checklist
- [x] Type-check passes (no new errors)
- [x] Unit tests pass (578/578)

🤖 Generated with [Claude Code](https://claude.com/claude-code)