### PR TITLE
fix(zap): pass spider excludeList via -z to avoid argparse collision

### DIFF
--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -33,4 +33,4 @@ jobs:
           allow_issue_writing: false
           artifact_name: zap-baseline-${{ github.run_number }}
           cmd_options: >-
-            -config spider.excludeList=.*\/api\/chat.*,.*\/api\/realtime\/.*,.*\/api\/voice\/.*,.*\/api\/report-issue.*,.*\/api\/mcp.*,.*\/api\/plex\/.*,.*\/api\/tmdb\/.*,.*\/api\/services\/.*,.*\/api\/setup\/.*,.*\/api\/settings\/langfuse.*,.*\/api\/internal.*
+            -z "-config spider.excludeList=.*\/api\/chat.*,.*\/api\/realtime\/.*,.*\/api\/voice\/.*,.*\/api\/report-issue.*,.*\/api\/mcp.*,.*\/api\/plex\/.*,.*\/api\/tmdb\/.*,.*\/api\/services\/.*,.*\/api\/setup\/.*,.*\/api\/settings\/langfuse.*,.*\/api\/internal.*"


### PR DESCRIPTION
## Summary

- Fixes ZAP baseline scan failure: `FileNotFoundError: '/zap/wrk/onfig'`
- Root cause: Python's `getopt` in `zap-baseline.py` parses `-config` as short flag `-c` (config file) + value `onfig`, producing a bogus path
- Fix: use `-z "..."` — the ZAP baseline script's dedicated pass-through flag for raw ZAP CLI options — so the string is forwarded directly to ZAP's JVM without being consumed by the Python argument parser

## Test plan

- [ ] Trigger the ZAP workflow manually via Actions → ZAP Security Scan → Run workflow
- [ ] Confirm scan starts successfully (no `FileNotFoundError`)
- [ ] Confirm API paths in the exclude list are not spidered

🤖 Generated with [Claude Code](https://claude.com/claude-code)