### PR TITLE
fix(#417): prefer plex_search_by_tag for library genre queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/lib/overseerr.test.ts
+++ b/src/__tests__/lib/overseerr.test.ts
@@ -726,7 +726,7 @@ describe("discover — issue #207", () => {
     expect(hasMore).toBe(false);
   });
 
-  it("includes genreIds param when genre resolves to a known ID", async () => {
+  it("uses /discover/movies/genre/{id} path when genre resolves to a known ID", async () => {
     const fetchMock = vi.fn()
       // First call: genre list
       .mockResolvedValueOnce({
@@ -746,10 +746,11 @@ describe("discover — issue #207", () => {
     await discover("movie", "Action");
 
     const discoverUrl = fetchMock.mock.calls[1][0] as string;
-    expect(discoverUrl).toContain("genreIds=28");
+    expect(discoverUrl).toContain("/discover/movies/genre/28");
+    expect(discoverUrl).not.toContain("genreIds");
   });
 
-  it("skips genreIds when genre name not found in genre list", async () => {
+  it("falls back to /discover/movies when genre name not found in genre list", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -767,7 +768,8 @@ describe("discover — issue #207", () => {
     await discover("movie", "UnknownGenre");
 
     const discoverUrl = fetchMock.mock.calls[1][0] as string;
-    expect(discoverUrl).not.toContain("genreIds");
+    expect(discoverUrl).toContain("/discover/movies");
+    expect(discoverUrl).not.toContain("/genre/");
   });
 
   it("uses /discover/movies/upcoming for upcoming category", async () => {

--- a/src/lib/llm/default-prompt.ts
+++ b/src/lib/llm/default-prompt.ts
@@ -20,7 +20,8 @@ Guidelines:
 - Do not make assumptions about the availability of content. Always check the Media Library. To check availability, use the plex_check_availability tool.
 - If a title is not available, search Overseerr using the overseerr_search tool to check request status, then call display_titles so the user can request it themselves via the card button.
 - When users ask about new, recent, or upcoming movies/shows (e.g. "what's new", "recent releases", "what came out this year"), use overseerr_discover with category="upcoming" or category="trending". Do NOT pass a year as the overseerr_search query — overseerr_search only accepts titles.
-- When users ask about movies or TV by genre (e.g. "action movies", "comedy shows"), use overseerr_discover with the genre parameter instead of overseerr_search.
+- When users ask about movies or TV by genre from their library (e.g. "horror movies", "action movies", "find me some comedy"), use plex_search_by_tag with tagType="genre" — this searches the Plex library by genre tag and is the correct tool for genre browsing.
+- To discover new titles by genre that are not yet in the library (e.g. "what new horror movies can I request?"), use overseerr_discover with the genre parameter.
 - If the user asks what movies or series are leaving soon (or expiring, or leaving the library), search the relevant collection: use plex_search_collection('Movies leaving soon') for movies, plex_search_collection('Series leaving soon') for TV shows. If the question is ambiguous or covers both, search both collections.
 - Never request media on behalf of the user — always display a title card and let the user click the Request button.
 - If a title is requested but not available, you can offer to search for it in the queue using the radarr_search_queue tool or sonarr_search_queue tool to see if it is in the queue.

--- a/src/lib/llm/default-prompt.ts
+++ b/src/lib/llm/default-prompt.ts
@@ -20,10 +20,10 @@ Guidelines:
 - Do not make assumptions about the availability of content. Always check the Media Library. To check availability, use the plex_check_availability tool.
 - If a title is not available, search Overseerr using the overseerr_search tool to check request status, then call display_titles so the user can request it themselves via the card button.
 - When users ask about new, recent, or upcoming movies/shows (e.g. "what's new", "recent releases", "what came out this year"), use overseerr_discover with category="upcoming" or category="trending". Do NOT pass a year as the overseerr_search query — overseerr_search only accepts titles.
-- When users ask about movies or TV by genre (e.g. "horror movies", "action movies", "find me some comedy"):
-  - Use plex_search_by_tag with tagType="genre" to show what they already have in the library.
-  - Also call overseerr_discover with the genre parameter to show new titles they could request.
-  - Call both in the same response (in parallel), then display_titles with all results combined.
+- When users ask about movies or TV by genre (e.g. "horror movies", "action movies", "find me some comedy"), infer intent from the phrasing:
+  - Library browse ("what [genre] do I have?", "find me some [genre]") → use plex_search_by_tag with tagType="genre".
+  - Discovery ("what new [genre] can I request?", "recommend me some [genre]") → use overseerr_discover with the genre parameter.
+  - When ambiguous, default to plex_search_by_tag. If results are thin or the user asks for more, offer to show new requestable titles via overseerr_discover.
 - If the user asks what movies or series are leaving soon (or expiring, or leaving the library), search the relevant collection: use plex_search_collection('Movies leaving soon') for movies, plex_search_collection('Series leaving soon') for TV shows. If the question is ambiguous or covers both, search both collections.
 - Never request media on behalf of the user — always display a title card and let the user click the Request button.
 - If a title is requested but not available, you can offer to search for it in the queue using the radarr_search_queue tool or sonarr_search_queue tool to see if it is in the queue.

--- a/src/lib/llm/default-prompt.ts
+++ b/src/lib/llm/default-prompt.ts
@@ -20,8 +20,10 @@ Guidelines:
 - Do not make assumptions about the availability of content. Always check the Media Library. To check availability, use the plex_check_availability tool.
 - If a title is not available, search Overseerr using the overseerr_search tool to check request status, then call display_titles so the user can request it themselves via the card button.
 - When users ask about new, recent, or upcoming movies/shows (e.g. "what's new", "recent releases", "what came out this year"), use overseerr_discover with category="upcoming" or category="trending". Do NOT pass a year as the overseerr_search query — overseerr_search only accepts titles.
-- When users ask about movies or TV by genre from their library (e.g. "horror movies", "action movies", "find me some comedy"), use plex_search_by_tag with tagType="genre" — this searches the Plex library by genre tag and is the correct tool for genre browsing.
-- To discover new titles by genre that are not yet in the library (e.g. "what new horror movies can I request?"), use overseerr_discover with the genre parameter.
+- When users ask about movies or TV by genre (e.g. "horror movies", "action movies", "find me some comedy"):
+  - Use plex_search_by_tag with tagType="genre" to show what they already have in the library.
+  - Also call overseerr_discover with the genre parameter to show new titles they could request.
+  - Call both in the same response (in parallel), then display_titles with all results combined.
 - If the user asks what movies or series are leaving soon (or expiring, or leaving the library), search the relevant collection: use plex_search_collection('Movies leaving soon') for movies, plex_search_collection('Series leaving soon') for TV shows. If the question is ambiguous or covers both, search both collections.
 - Never request media on behalf of the user — always display a title card and let the user click the Request button.
 - If a title is requested but not available, you can offer to search for it in the queue using the radarr_search_queue tool or sonarr_search_queue tool to see if it is in the queue.

--- a/src/lib/services/overseerr.ts
+++ b/src/lib/services/overseerr.ts
@@ -393,14 +393,16 @@ export async function discover(
     genreId = match?.id;
   }
 
+  // Seerr uses a path-based genre endpoint: /discover/movies/genre/{genreId}
+  // (not a query parameter). Genre and upcoming are mutually exclusive — the
+  // genre endpoint does not have an /upcoming variant.
   let path: string;
-  if (category === "upcoming") {
+  if (genreId != null) {
+    path = `/discover/${discoverSegment}/genre/${genreId}?page=${page}`;
+  } else if (category === "upcoming") {
     path = `/discover/${discoverSegment}/upcoming?page=${page}`;
   } else {
     path = `/discover/${discoverSegment}?page=${page}`;
-  }
-  if (genreId != null) {
-    path += `&genreIds=${genreId}`;
   }
 
   const data = await overseerrFetch(path);


### PR DESCRIPTION
## Summary

The Seerr API exposes genre-based discovery via a **path segment**, not a query parameter. The code was building \`/discover/movies?genreIds=27\` (HTTP 400); the correct endpoint per the Seerr API spec at \`192.168.1.20:5056/api-docs\` is \`/discover/movies/genre/27\`.

Changes:
- **\`overseerr.ts\`**: Build the genre discover path as \`/discover/{segment}/genre/{id}\` instead of appending \`&genreIds={id}\`. Genre and upcoming are mutually exclusive; genre takes precedence.
- **\`default-prompt.ts\`**: For genre queries, call either \`plex_search_by_tag\` (library content) or \`overseerr_discover\` (requestable new titles)
- **\`overseerr.test.ts\`**: Updated assertions from \`genreIds=28\` param to \`/discover/movies/genre/28\` path.

**Trace:** \`f2be27be-fcb1-435e-b7b4-7346786a4c78\` — user asked "Find me some horror movies", LLM hit \`overseerr_discover\` twice (400 both times), fell back to \`plex_search_by_tag\`.

Closes #417

## Test plan

- [ ] Ask "find me some horror movies" — LLM calls both \`plex_search_by_tag\` and \`overseerr_discover\` in parallel; cards show library titles (available) alongside requestable titles
- [ ] Ask "what new action movies can I request?" — \`overseerr_discover\` uses \`/discover/movies/genre/{id}\` path, returns results without 400
- [ ] All 578 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)