### PR TITLE
Add OpenClaw text-channel adapter and channel identity registration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,7 +23,9 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
 ├── entrypoint.sh                    # PUID/PGID user creation + server start
 ├── docker-compose.yml               # Development/example compose
 ├── drizzle/
-│   └── 0000_short_gressill.sql      # Initial migration (5 tables)
+│   ├── 0000_short_gressill.sql      # Initial migration (5 tables)
+│   ├── 0001_add_message_duration.sql
+│   └── 0002_mcp_channel_integration.sql  # mcp_channel_identities, mcp_registration_tokens, mcp_pending_baskets
 ├── public/
 │   ├── manifest.json                # PWA web app manifest
 │   └── sw.js                        # Service worker (network-first)
@@ -42,7 +44,9 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
     │   │   │       ├── route.ts             # GET with messages / DELETE
     │   │   │       ├── messages/route.ts    # POST save realtime turn
     │   │   │       └── title/route.ts       # PATCH rename
-    │   │   ├── mcp/route.ts                 # GET list tools / POST execute (bearer auth)
+    │   │   ├── mcp/
+    │   │   │   ├── route.ts                 # GET list tools / POST execute (bearer auth; ?mode=text for channel adapter)
+    │   │   │   └── link/route.ts            # GET validate registration token / POST complete Plex OAuth → store channel identity
     │   │   ├── models/route.ts              # GET available models for current user
     │   │   ├── plex/
     │   │   │   └── avatar/[userId]/route.ts # GET server-side Plex avatar proxy
@@ -70,6 +74,8 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
     │   │       └── tts/route.ts             # POST text → OpenAI TTS
     │   ├── chat/page.tsx            # Chat page (sidebar, model picker, messages, input)
     │   ├── login/page.tsx           # Plex OAuth login
+    │   ├── mcp/
+    │   │   └── link/page.tsx        # Channel identity registration (Plex OAuth for external channels)
     │   ├── settings/page.tsx        # 5-tab settings (General, LLM, Plex & Arrs, MCP, Users, Logs)
     │   ├── setup/page.tsx           # Welcome splash (first-time setup)
     │   ├── globals.css              # Dark theme CSS variables + Tailwind 4
@@ -106,7 +112,7 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
     │   ├── db/
     │   │   ├── index.ts             # DB singleton + auto-migration
     │   │   ├── migrate.ts           # runMigrations standalone utility
-    │   │   └── schema.ts            # 5 tables
+    │   │   └── schema.ts            # 8 tables
     │   ├── llm/
     │   │   ├── client.ts            # OpenAI client factory (per-endpoint)
     │   │   ├── default-prompt.ts    # DEFAULT_SYSTEM_PROMPT + DEFAULT_REALTIME_SYSTEM_PROMPT
@@ -125,8 +131,10 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
     │   │   └── test-connection.ts   # Connectivity testers + capability probing
     │   ├── tools/
     │   │   ├── display-titles-tool.ts  # display_titles (builds DisplayTitle[], resolves thumbUrl)
+    │   │   ├── display-titles-text.ts  # formatDisplayTitlesAsText() — markdown renderer for text channels
     │   │   ├── init.ts              # Auto-register tools based on configured services
     │   │   ├── overseerr-tools.ts
+    │   │   ├── pending-basket.ts    # createBasket / resolveBasket (one-time-use, 10-min TTL)
     │   │   ├── plex-tools.ts        # 8 tools
     │   │   ├── radarr-tools.ts      # 3 tools
     │   │   ├── registry.ts          # defineTool, getOpenAITools, executeTool + tool logging
@@ -152,6 +160,9 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
 | `sessions` | `id` (UUID PK), `userId` (FK), `expiresAt` |
 | `conversations` | `id` (UUID PK), `userId` (FK), `title`, `createdAt`, `updatedAt` |
 | `messages` | `id` (UUID PK), `conversationId` (FK), `role`, `content`, `toolCalls`, `toolCallId`, `toolName` |
+| `mcp_channel_identities` | `(channelType, channelUserId)` (composite PK), `userId` (FK) — maps external channel user (WhatsApp/Telegram/etc.) to a Thinkarr user |
+| `mcp_registration_tokens` | `token` (PK), `channelType`, `channelUserId`, `expiresAt` — short-lived (15 min) self-registration link tokens |
+| `mcp_pending_baskets` | `token` (PK), `itemsJson`, `userId`, `expiresAt` — one-time-use (10 min) confirm_request validation state |
 
 ---
 
@@ -193,8 +204,10 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
 | DELETE | `/api/conversations/[id]` | Delete conversation |
 | PATCH | `/api/conversations/[id]/title` | Rename (max 200 chars) |
 | POST | `/api/conversations/[id]/messages` | Save realtime turn |
-| GET | `/api/mcp` | List MCP tools (bearer auth, permission-filtered) |
-| POST | `/api/mcp` | Execute tool (bearer auth) |
+| GET | `/api/mcp` | List MCP tools (bearer auth, permission-filtered; `?mode=text` adds `confirm_request`) |
+| POST | `/api/mcp` | Execute tool (bearer auth; `?mode=text` enables text-channel adapter) |
+| GET | `/api/mcp/link` | Validate a channel registration token |
+| POST | `/api/mcp/link` | Complete channel registration: exchange Plex PIN + registration token → store identity |
 | GET | `/api/models` | Available models for current user |
 | GET | `/api/services/status` | Service health (LLM, Plex, Sonarr, Radarr, Overseerr) |
 | GET | `/api/settings` | Get config (secrets masked, admin only) |
@@ -229,8 +242,11 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
 | Radarr | `radarr_search_movie`, `radarr_get_movie_status`, `radarr_get_queue` |
 | Seerr | `overseerr_search`, `overseerr_get_details`, `overseerr_list_requests`, `overseerr_discover`, `overseerr_get_season_episodes`, `overseerr_similar`, `overseerr_report_issue` |
 | Built-in | `display_titles` — renders TitleCarousel in chat (always registered) |
+| Text-channel only | `confirm_request` — submits an Overseerr request after explicit user confirmation; only available in `?mode=text` |
 
 External MCP access via bearer token (`mcp.bearerToken`). Optional `X-User-Id` header scopes operations to a user's permission level. Per-user tokens stored as `user.{id}.mcpToken`.
+
+In `?mode=text` (OpenClaw / external channel adapter): channel identity is resolved from `X-Channel-Type` + `X-Channel-User-Id` headers via `mcp_channel_identities`; `display_titles` results are transformed to markdown; `confirm_request` replaces the direct request tools as the only path to submit Overseerr requests.
 
 ---
 
@@ -269,6 +285,16 @@ Realtime (WebRTC) is restricted to `api.openai.com` only. `probeRealtimeSupport(
 ### Rate Limiting (Multi-Layer)
 1. **Message-based**: Per-user configurable (`user.{id}.rateLimit`), calendar-aligned, checked before each `/api/chat` stream.
 2. **API-based**: Per-user in-memory (60 req/min sliding window) on `/api/conversations/*` and `/api/settings/*`; returns HTTP 429.
+
+### Text-Channel Adapter (`?mode=text`)
+
+Enables external channel gateways (e.g. OpenClaw) to drive Thinkarr via MCP without a web UI. Three behaviour changes activate when `?mode=text` is appended to MCP requests:
+
+1. **Channel identity resolution**: `X-Channel-Type` + `X-Channel-User-Id` headers resolve to a `users` row via `mcp_channel_identities`. Unregistered users receive `{ error: "unregistered", registrationUrl: "..." }` pointing to `/mcp/link?token=...`. The token is short-lived (15 min) and stored in `mcp_registration_tokens`.
+
+2. **`display_titles` interception**: The route post-processes the tool result before returning. `formatDisplayTitlesAsText()` converts `displayTitles[]` to a markdown numbered list. Requestable items (`mediaStatus: "not_requested"` with an `overseerrId`) are stored in `mcp_pending_baskets` (10-min TTL) and the basket token is returned as `pendingKey` alongside the text.
+
+3. **`confirm_request` tool**: Exposed only in text mode. Takes `{ pendingKey, selection }`, validates the basket (token, TTL, ownership), calls `overseerr.requestMovie` or `overseerr.requestTv`, and returns a user-facing confirmation string. The basket is deleted on resolution (one-time use). `overseerr_request_movie` and `overseerr_request_tv` are hard-blocked in text mode — `confirm_request` is the only path to submit a request.
 
 ### Title Card Display System
 `display_titles` tool accepts 1–10 titles with rich metadata. Server resolves `thumbUrl` (Plex proxy + token) and `plexMachineId` (Watch Now universal link). Renders as both a collapsible tool call panel and a full-width TitleCarousel below the message. LLM always calls `display_titles` after searches.

--- a/drizzle/0002_mcp_channel_integration.sql
+++ b/drizzle/0002_mcp_channel_integration.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `mcp_channel_identities` (
+	`channel_type` text NOT NULL,
+	`channel_user_id` text NOT NULL,
+	`user_id` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`channel_type`, `channel_user_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `mcp_registration_tokens` (
+	`token` text PRIMARY KEY NOT NULL,
+	`channel_type` text NOT NULL,
+	`channel_user_id` text NOT NULL,
+	`expires_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `mcp_pending_baskets` (
+	`token` text PRIMARY KEY NOT NULL,
+	`items_json` text NOT NULL,
+	`user_id` integer NOT NULL,
+	`expires_at` integer NOT NULL
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1742651582000,
       "tag": "0001_add_message_duration",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1748354400000,
+      "tag": "0002_mcp_channel_integration",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "thinkarr",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.7",
+      "version": "1.1.8-beta.2",
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "langfuse": "^3.38.20",
         "lucide-react": "^1.8.0",
-        "next": "16.2.4",
+        "next": "16.2.6",
         "openai": "^6.34.0",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2069,9 +2069,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -2101,9 +2101,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -2117,9 +2117,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -2133,9 +2133,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -2149,9 +2149,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -2165,9 +2165,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -9000,12 +9000,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9019,14 +9019,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -9507,6 +9507,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "drizzle-orm": "^0.45.2",
     "langfuse": "^3.38.20",
     "lucide-react": "^1.8.0",
-    "next": "16.2.4",
+    "next": "16.2.6",
     "openai": "^6.34.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.1",
+  "version": "1.1.8-beta.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/api/mcp-text-mode.test.ts
+++ b/src/__tests__/api/mcp-text-mode.test.ts
@@ -11,8 +11,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // --- shared mock state ---
 let channelIdentityRow: { userId: number } | undefined;
-let basketRow: { token: string; itemsJson: string; userId: number; expiresAt: number } | undefined;
-let insertedBasket: { token: string; itemsJson: string; userId: number; expiresAt: number } | null = null;
 let insertedRegToken: { token: string; channelType: string; channelUserId: string; expiresAt: number } | null = null;
 
 const mockDbSelect = vi.fn();
@@ -70,7 +68,6 @@ vi.mock("@/lib/services/overseerr", () => ({
 
 vi.mock("@/lib/tools/pending-basket", () => ({
   createBasket: vi.fn().mockImplementation((items: unknown[], userId: number) => {
-    insertedBasket = { token: "basket-token", itemsJson: JSON.stringify(items), userId, expiresAt: 9999999999 };
     return "basket-token";
   }),
   resolveBasket: vi.fn().mockImplementation((token: string, selection: number, userId: number) => {
@@ -98,7 +95,6 @@ function makeRequest(opts: {
 
 describe("/api/mcp?mode=text", () => {
   beforeEach(() => {
-    insertedBasket = null;
     insertedRegToken = null;
     vi.clearAllMocks();
 

--- a/src/__tests__/api/mcp-text-mode.test.ts
+++ b/src/__tests__/api/mcp-text-mode.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Integration tests for /api/mcp?mode=text covering:
+ * - Unregistered channel user → returns registration URL
+ * - display_titles interception → markdown text + pendingKey
+ * - confirm_request happy path → Overseerr request submitted
+ * - confirm_request blocked outside text mode
+ * - overseerr_request_movie/tv blocked in text mode
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --- shared mock state ---
+let channelIdentityRow: { userId: number } | undefined;
+let basketRow: { token: string; itemsJson: string; userId: number; expiresAt: number } | undefined;
+let insertedBasket: { token: string; itemsJson: string; userId: number; expiresAt: number } | null = null;
+let insertedRegToken: { token: string; channelType: string; channelUserId: string; expiresAt: number } | null = null;
+
+const mockDbSelect = vi.fn();
+const mockDbInsert = vi.fn();
+const mockDbDelete = vi.fn();
+const mockDbUpdate = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    select: mockDbSelect,
+    insert: mockDbInsert,
+    delete: mockDbDelete,
+    update: mockDbUpdate,
+  }),
+  schema: {
+    users: { id: "id", plexId: "plex_id" },
+    mcpChannelIdentities: { channelType: "channel_type", channelUserId: "channel_user_id", userId: "user_id" },
+    mcpRegistrationTokens: { token: "token", channelType: "channel_type", channelUserId: "channel_user_id", expiresAt: "expires_at" },
+    mcpPendingBaskets: { token: "token", itemsJson: "items_json", userId: "user_id", expiresAt: "expires_at" },
+  },
+}));
+
+vi.mock("@/lib/config", () => ({
+  getConfig: (key: string) => {
+    if (key === "mcp.bearerToken") return "test-bearer";
+    return null;
+  },
+  getUserIdByMcpToken: () => null,
+}));
+
+vi.mock("@/lib/tools/init", () => ({ initializeTools: vi.fn() }));
+vi.mock("@/lib/tools/registry", () => ({
+  hasTools: () => true,
+  getOpenAITools: () => [],
+  executeTool: vi.fn().mockImplementation(async (name: string) => {
+    if (name === "display_titles") {
+      return JSON.stringify({
+        displayTitles: [
+          { title: "Alien", year: 2024, mediaType: "movie", mediaStatus: "available" },
+          { title: "Prometheus", year: 2012, mediaType: "movie", mediaStatus: "not_requested", overseerrId: 42, overseerrMediaType: "movie" },
+        ],
+      });
+    }
+    return JSON.stringify({ ok: true });
+  }),
+}));
+
+vi.mock("@/lib/logger", () => ({ logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/auth/rate-limit", () => ({ getClientIp: () => "127.0.0.1" }));
+
+vi.mock("@/lib/services/overseerr", () => ({
+  requestMovie: vi.fn().mockResolvedValue({ success: true, message: "Movie request submitted successfully" }),
+  requestTv: vi.fn().mockResolvedValue({ success: true, message: "TV show request submitted successfully" }),
+}));
+
+vi.mock("@/lib/tools/pending-basket", () => ({
+  createBasket: vi.fn().mockImplementation((items: unknown[], userId: number) => {
+    insertedBasket = { token: "basket-token", itemsJson: JSON.stringify(items), userId, expiresAt: 9999999999 };
+    return "basket-token";
+  }),
+  resolveBasket: vi.fn().mockImplementation((token: string, selection: number, userId: number) => {
+    if (token !== "basket-token" || userId !== 7) return null;
+    return { overseerrId: 42, mediaType: "movie" as const, title: "Prometheus" };
+  }),
+}));
+
+function makeRequest(opts: {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}): Request {
+  return new Request(opts.url ?? "http://localhost/api/mcp?mode=text", {
+    method: opts.method ?? "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-bearer",
+      ...opts.headers,
+    },
+    body: opts.body != null ? JSON.stringify(opts.body) : undefined,
+  });
+}
+
+describe("/api/mcp?mode=text", () => {
+  beforeEach(() => {
+    insertedBasket = null;
+    insertedRegToken = null;
+    vi.clearAllMocks();
+
+    // Default DB mock: no identity, chain support
+    mockDbSelect.mockReturnValue({
+      from: () => ({
+        where: () => ({
+          get: () => channelIdentityRow,
+          orderBy: () => ({ get: () => insertedRegToken }),
+        }),
+      }),
+    });
+    mockDbInsert.mockReturnValue({
+      values: (v: typeof insertedRegToken) => {
+        insertedRegToken = v as typeof insertedRegToken;
+        return { run: vi.fn() };
+      },
+    });
+    mockDbDelete.mockReturnValue({ where: () => ({ run: vi.fn() }) });
+  });
+
+  it("returns registration URL when channel user is unregistered", async () => {
+    channelIdentityRow = undefined;
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({
+      headers: { "x-channel-type": "whatsapp", "x-channel-user-id": "+447700900000" },
+      body: { tool: "plex_get_on_deck", arguments: {} },
+    }));
+    const data = await res.json();
+    expect(data.error).toBe("unregistered");
+    expect(data.registrationUrl).toContain("/mcp/link?token=");
+  });
+
+  it("intercepts display_titles and returns markdown text with pendingKey", async () => {
+    channelIdentityRow = { userId: 7 };
+    mockDbSelect.mockReturnValue({
+      from: () => ({
+        where: () => ({ get: () => channelIdentityRow }),
+      }),
+    });
+    // Second call for user lookup
+    let callCount = 0;
+    mockDbSelect.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          get: () => {
+            callCount++;
+            if (callCount === 1) return channelIdentityRow;
+            return { id: 7, isAdmin: false, plexUsername: "testuser" };
+          },
+        }),
+      }),
+    }));
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({
+      body: { tool: "display_titles", arguments: { titles: [] } },
+    }));
+    const data = await res.json();
+    expect(data.tool).toBe("display_titles");
+    expect(data.result.text).toContain("✓ Available in Plex");
+    expect(data.result.text).toContain("[1] *Prometheus*");
+    expect(data.result.pendingKey).toBe("basket-token");
+  });
+
+  it("confirm_request submits an Overseerr request for the selected item", async () => {
+    channelIdentityRow = { userId: 7 };
+    let callCount = 0;
+    mockDbSelect.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          get: () => {
+            callCount++;
+            if (callCount === 1) return channelIdentityRow;
+            return { id: 7, isAdmin: false, plexUsername: "testuser" };
+          },
+        }),
+      }),
+    }));
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({
+      body: { tool: "confirm_request", arguments: { pendingKey: "basket-token", selection: 1 } },
+    }));
+    const data = await res.json();
+    expect(data.result.success).toBe(true);
+    expect(data.result.message).toContain("Prometheus");
+
+    const { requestMovie } = await import("@/lib/services/overseerr");
+    expect(requestMovie).toHaveBeenCalledWith(42);
+  });
+
+  it("confirm_request returns error for invalid/expired basket", async () => {
+    channelIdentityRow = { userId: 7 };
+    let callCount = 0;
+    mockDbSelect.mockImplementation(() => ({
+      from: () => ({
+        where: () => ({
+          get: () => {
+            callCount++;
+            if (callCount === 1) return channelIdentityRow;
+            return { id: 7, isAdmin: false, plexUsername: "testuser" };
+          },
+        }),
+      }),
+    }));
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({
+      body: { tool: "confirm_request", arguments: { pendingKey: "wrong-token", selection: 1 } },
+    }));
+    const data = await res.json();
+    expect(data.result.success).toBe(false);
+    expect(data.result.message).toContain("no longer valid");
+  });
+
+  it("blocks confirm_request outside text mode", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({
+      url: "http://localhost/api/mcp",
+      body: { tool: "confirm_request", arguments: { pendingKey: "x", selection: 1 } },
+    }));
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks overseerr_request_movie in text mode", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({
+      body: { tool: "overseerr_request_movie", arguments: { tmdbId: 1 } },
+    }));
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks overseerr_request_tv in text mode", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({
+      body: { tool: "overseerr_request_tv", arguments: { tvdbId: 1 } },
+    }));
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/__tests__/api/mcp-text-mode.test.ts
+++ b/src/__tests__/api/mcp-text-mode.test.ts
@@ -151,6 +151,7 @@ describe("/api/mcp?mode=text", () => {
 
     const { POST } = await import("@/app/api/mcp/route");
     const res = await POST(makeRequest({
+      headers: { "x-channel-type": "whatsapp", "x-channel-user-id": "+447700900000" },
       body: { tool: "display_titles", arguments: { titles: [] } },
     }));
     const data = await res.json();
@@ -177,6 +178,7 @@ describe("/api/mcp?mode=text", () => {
 
     const { POST } = await import("@/app/api/mcp/route");
     const res = await POST(makeRequest({
+      headers: { "x-channel-type": "whatsapp", "x-channel-user-id": "+447700900000" },
       body: { tool: "confirm_request", arguments: { pendingKey: "basket-token", selection: 1 } },
     }));
     const data = await res.json();
@@ -204,6 +206,7 @@ describe("/api/mcp?mode=text", () => {
 
     const { POST } = await import("@/app/api/mcp/route");
     const res = await POST(makeRequest({
+      headers: { "x-channel-type": "whatsapp", "x-channel-user-id": "+447700900000" },
       body: { tool: "confirm_request", arguments: { pendingKey: "wrong-token", selection: 1 } },
     }));
     const data = await res.json();

--- a/src/__tests__/lib/display-titles-text.test.ts
+++ b/src/__tests__/lib/display-titles-text.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { formatDisplayTitlesAsText } from "@/lib/tools/display-titles-text";
+import type { DisplayTitle } from "@/types/titles";
+
+function title(overrides: Partial<DisplayTitle> & { title: string; mediaStatus: DisplayTitle["mediaStatus"] }): DisplayTitle {
+  return { mediaType: "movie", year: 2024, ...overrides };
+}
+
+describe("formatDisplayTitlesAsText", () => {
+  it("marks available titles with a checkmark", () => {
+    const { text, requestableItems } = formatDisplayTitlesAsText([
+      title({ title: "Alien", mediaStatus: "available" }),
+    ]);
+    expect(text).toContain("✓ Available in Plex");
+    expect(requestableItems).toHaveLength(0);
+  });
+
+  it("marks partial titles correctly", () => {
+    const { text } = formatDisplayTitlesAsText([
+      title({ title: "The Sopranos", mediaType: "tv", mediaStatus: "partial" }),
+    ]);
+    expect(text).toContain("✓ Partially available in Plex");
+  });
+
+  it("marks pending titles with a clock", () => {
+    const { text } = formatDisplayTitlesAsText([
+      title({ title: "Off Campus", mediaStatus: "pending" }),
+    ]);
+    expect(text).toContain("⏳ Already requested, downloading");
+  });
+
+  it("numbers requestable titles and adds them to requestableItems", () => {
+    const { text, requestableItems } = formatDisplayTitlesAsText([
+      title({ title: "Alien: Covenant", mediaStatus: "not_requested", overseerrId: 101, overseerrMediaType: "movie" }),
+      title({ title: "Prometheus", mediaStatus: "not_requested", overseerrId: 102, overseerrMediaType: "movie" }),
+    ]);
+    expect(text).toContain("[1] *Alien: Covenant*");
+    expect(text).toContain("[2] *Prometheus*");
+    expect(text).toContain('reply with its number');
+    expect(requestableItems).toHaveLength(2);
+    expect(requestableItems[0]).toMatchObject({ overseerrId: 101, mediaType: "movie", title: "Alien: Covenant" });
+    expect(requestableItems[1]).toMatchObject({ overseerrId: 102, mediaType: "movie", title: "Prometheus" });
+  });
+
+  it("assigns correct seasonNumber to TV season cards", () => {
+    const { requestableItems } = formatDisplayTitlesAsText([
+      title({
+        title: "Off Campus — Season 1",
+        mediaType: "tv",
+        mediaStatus: "not_requested",
+        overseerrId: 200,
+        overseerrMediaType: "tv",
+        seasonNumber: 1,
+      }),
+    ]);
+    expect(requestableItems[0].seasonNumber).toBe(1);
+  });
+
+  it("omits requestable prompt when no requestable items exist", () => {
+    const { text, requestableItems } = formatDisplayTitlesAsText([
+      title({ title: "Alien", mediaStatus: "available" }),
+      title({ title: "The Office", mediaType: "tv", mediaStatus: "pending" }),
+    ]);
+    expect(text).not.toContain("reply with its number");
+    expect(requestableItems).toHaveLength(0);
+  });
+
+  it("skips not_requested titles without an overseerrId (no Request button possible)", () => {
+    const { text, requestableItems } = formatDisplayTitlesAsText([
+      title({ title: "Orphan Film", mediaStatus: "not_requested" }),
+    ]);
+    expect(text).not.toContain("[1]");
+    expect(requestableItems).toHaveLength(0);
+  });
+
+  it("includes year in label when present", () => {
+    const { text } = formatDisplayTitlesAsText([
+      title({ title: "Dune", year: 2021, mediaStatus: "available" }),
+    ]);
+    expect(text).toContain("*Dune* (2021)");
+  });
+
+  it("handles mixed statuses with correct numbering", () => {
+    const { text, requestableItems } = formatDisplayTitlesAsText([
+      title({ title: "A", mediaStatus: "available" }),
+      title({ title: "B", mediaStatus: "not_requested", overseerrId: 1, overseerrMediaType: "movie" }),
+      title({ title: "C", mediaStatus: "pending" }),
+      title({ title: "D", mediaStatus: "not_requested", overseerrId: 2, overseerrMediaType: "movie" }),
+    ]);
+    expect(text).toContain("[1] *B*");
+    expect(text).toContain("[2] *D*");
+    expect(requestableItems).toHaveLength(2);
+  });
+});

--- a/src/__tests__/lib/pending-basket.test.ts
+++ b/src/__tests__/lib/pending-basket.test.ts
@@ -41,6 +41,7 @@ describe("pending-basket", () => {
     insertedRow = null;
     mockGet.mockReset();
     mockRun.mockReset();
+    mockDelete.mockClear();
     vi.resetModules();
   });
 

--- a/src/__tests__/lib/pending-basket.test.ts
+++ b/src/__tests__/lib/pending-basket.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PendingItem } from "@/lib/tools/pending-basket";
+
+const ITEMS: PendingItem[] = [
+  { overseerrId: 1, mediaType: "movie", title: "Alien" },
+  { overseerrId: 2, mediaType: "tv", seasonNumber: 1, title: "Off Campus — Season 1" },
+];
+
+const mockRun = vi.fn();
+const mockGet = vi.fn();
+const mockDelete = vi.fn().mockReturnValue({ where: () => ({ run: mockRun }) });
+
+let insertedRow: { token: string; itemsJson: string; userId: number; expiresAt: number } | null = null;
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({
+    insert: () => ({
+      values: (v: typeof insertedRow) => {
+        insertedRow = v;
+        return { run: vi.fn() };
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({ get: mockGet }),
+      }),
+    }),
+    delete: mockDelete,
+  }),
+  schema: {
+    mcpPendingBaskets: { token: "token", userId: "user_id", expiresAt: "expires_at" },
+  },
+}));
+
+vi.mock("crypto", () => ({
+  randomBytes: () => ({ toString: () => "a".repeat(64) }),
+}));
+
+describe("pending-basket", () => {
+  beforeEach(() => {
+    insertedRow = null;
+    mockGet.mockReset();
+    mockRun.mockReset();
+    vi.resetModules();
+  });
+
+  it("createBasket stores items and returns a hex token", async () => {
+    const { createBasket } = await import("@/lib/tools/pending-basket");
+    const token = createBasket(ITEMS, 42);
+    expect(typeof token).toBe("string");
+    expect(token).toHaveLength(64);
+    expect(insertedRow).not.toBeNull();
+    expect(JSON.parse(insertedRow!.itemsJson)).toEqual(ITEMS);
+    expect(insertedRow!.userId).toBe(42);
+    expect(insertedRow!.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("resolveBasket returns the correct item and deletes the row", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockGet.mockReturnValue({
+      token: "abc",
+      itemsJson: JSON.stringify(ITEMS),
+      userId: 42,
+      expiresAt: now + 600,
+    });
+    const { resolveBasket } = await import("@/lib/tools/pending-basket");
+    const item = resolveBasket("abc", 2, 42);
+    expect(item).toEqual(ITEMS[1]);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("resolveBasket returns null for expired token", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockGet.mockReturnValue({
+      token: "abc",
+      itemsJson: JSON.stringify(ITEMS),
+      userId: 42,
+      expiresAt: now - 1,
+    });
+    const { resolveBasket } = await import("@/lib/tools/pending-basket");
+    expect(resolveBasket("abc", 1, 42)).toBeNull();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("resolveBasket returns null for wrong user", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockGet.mockReturnValue({
+      token: "abc",
+      itemsJson: JSON.stringify(ITEMS),
+      userId: 99,
+      expiresAt: now + 600,
+    });
+    const { resolveBasket } = await import("@/lib/tools/pending-basket");
+    expect(resolveBasket("abc", 1, 42)).toBeNull();
+  });
+
+  it("resolveBasket returns null for out-of-range selection", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockGet.mockReturnValue({
+      token: "abc",
+      itemsJson: JSON.stringify(ITEMS),
+      userId: 42,
+      expiresAt: now + 600,
+    });
+    const { resolveBasket } = await import("@/lib/tools/pending-basket");
+    expect(resolveBasket("abc", 99, 42)).toBeNull();
+  });
+
+  it("resolveBasket returns null when row not found", async () => {
+    mockGet.mockReturnValue(undefined);
+    const { resolveBasket } = await import("@/lib/tools/pending-basket");
+    expect(resolveBasket("missing", 1, 42)).toBeNull();
+  });
+});

--- a/src/app/api/mcp/link/route.ts
+++ b/src/app/api/mcp/link/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from "next/server";
+import { getDb, schema } from "@/lib/db";
+import { eq, and } from "drizzle-orm";
+import { checkPlexPin, getPlexUser, checkUserHasLibraryAccess } from "@/lib/services/plex-auth";
+import { getConfig } from "@/lib/config";
+import { logger } from "@/lib/logger";
+import type { ApiResponse } from "@/types/api";
+
+/** GET /api/mcp/link?token=xxx — validate a registration token, return channel info. */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get("token");
+  if (!token) {
+    return NextResponse.json<ApiResponse>({ success: false, error: "token is required" }, { status: 400 });
+  }
+
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const row = db
+    .select()
+    .from(schema.mcpRegistrationTokens)
+    .where(eq(schema.mcpRegistrationTokens.token, token))
+    .get();
+
+  if (!row || row.expiresAt < now) {
+    return NextResponse.json<ApiResponse>({ success: false, error: "Registration link has expired. Please ask again to get a new one." }, { status: 410 });
+  }
+
+  return NextResponse.json<ApiResponse>({
+    success: true,
+    data: { channelType: row.channelType, channelUserId: row.channelUserId },
+  });
+}
+
+/**
+ * POST /api/mcp/link — complete channel identity registration after Plex OAuth.
+ * Body: { pinId: number, registrationToken: string }
+ */
+export async function POST(request: Request) {
+  let body: { pinId?: number; registrationToken?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json<ApiResponse>({ success: false, error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { pinId, registrationToken } = body;
+  if (!pinId || !registrationToken) {
+    return NextResponse.json<ApiResponse>({ success: false, error: "pinId and registrationToken are required" }, { status: 400 });
+  }
+
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+
+  const regToken = db
+    .select()
+    .from(schema.mcpRegistrationTokens)
+    .where(eq(schema.mcpRegistrationTokens.token, registrationToken))
+    .get();
+
+  if (!regToken || regToken.expiresAt < now) {
+    return NextResponse.json<ApiResponse>({ success: false, error: "Registration link has expired." }, { status: 410 });
+  }
+
+  // Validate Plex PIN and get user
+  const authToken = await checkPlexPin(pinId).catch(() => null);
+  if (!authToken) {
+    return NextResponse.json<ApiResponse>({ success: false, error: "pending" });
+  }
+
+  const plexUser = await getPlexUser(authToken).catch((e: unknown) => {
+    throw new Error(e instanceof Error ? e.message : "Failed to get Plex user");
+  });
+
+  // Upsert Thinkarr user
+  const existing = db.select().from(schema.users).where(eq(schema.users.plexId, plexUser.id)).get();
+
+  if (!existing) {
+    const userCount = db.select().from(schema.users).all().length;
+    if (userCount > 0) {
+      const plexServerUrl = getConfig("plex.url");
+      const plexAdminToken = getConfig("plex.token");
+      if (plexServerUrl && plexAdminToken) {
+        const hasAccess = await checkUserHasLibraryAccess(plexServerUrl, plexAdminToken, plexUser.id);
+        if (!hasAccess) {
+          return NextResponse.json<ApiResponse>(
+            { success: false, error: "You do not have access to any media on this server." },
+            { status: 403 },
+          );
+        }
+      }
+    }
+    db.insert(schema.users).values({
+      plexId: plexUser.id,
+      plexUsername: plexUser.username,
+      plexEmail: plexUser.email,
+      plexAvatarUrl: plexUser.thumb,
+      plexToken: plexUser.authToken,
+      isAdmin: userCount === 0,
+    }).run();
+  } else {
+    db.update(schema.users)
+      .set({ plexUsername: plexUser.username, plexEmail: plexUser.email, plexAvatarUrl: plexUser.thumb, plexToken: plexUser.authToken })
+      .where(eq(schema.users.plexId, plexUser.id))
+      .run();
+  }
+
+  const user = db.select().from(schema.users).where(eq(schema.users.plexId, plexUser.id)).get()!;
+
+  // Store (or update) channel identity
+  const existingIdentity = db
+    .select()
+    .from(schema.mcpChannelIdentities)
+    .where(
+      and(
+        eq(schema.mcpChannelIdentities.channelType, regToken.channelType),
+        eq(schema.mcpChannelIdentities.channelUserId, regToken.channelUserId),
+      ),
+    )
+    .get();
+
+  if (existingIdentity) {
+    db.update(schema.mcpChannelIdentities)
+      .set({ userId: user.id })
+      .where(
+        and(
+          eq(schema.mcpChannelIdentities.channelType, regToken.channelType),
+          eq(schema.mcpChannelIdentities.channelUserId, regToken.channelUserId),
+        ),
+      )
+      .run();
+  } else {
+    db.insert(schema.mcpChannelIdentities).values({
+      channelType: regToken.channelType,
+      channelUserId: regToken.channelUserId,
+      userId: user.id,
+    }).run();
+  }
+
+  // Consume the registration token
+  db.delete(schema.mcpRegistrationTokens)
+    .where(eq(schema.mcpRegistrationTokens.token, registrationToken))
+    .run();
+
+  logger.info("MCP_CHANNEL_LINKED", {
+    channelType: regToken.channelType,
+    userId: user.id,
+    plexUsername: plexUser.username,
+  });
+
+  return NextResponse.json<ApiResponse>({
+    success: true,
+    data: { plexUsername: plexUser.username },
+  });
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -72,7 +72,6 @@ function authenticateMcp(request: Request): AuthResult | null {
  */
 function resolveChannelIdentity(
   request: Request,
-  baseUrl: string,
 ): AuthResult | "unregistered" | null {
   const channelType = request.headers.get("x-channel-type");
   const channelUserId = request.headers.get("x-channel-user-id");
@@ -176,10 +175,6 @@ function buildToolList(permission: McpPermission, textMode: boolean) {
   return filtered;
 }
 
-function getRegistrationUrl(request: Request): string {
-  const url = new URL(request.url);
-  return `${url.origin}/mcp/link`;
-}
 
 export async function GET(request: Request) {
   const auth = authenticateMcp(request);
@@ -222,14 +217,13 @@ export async function POST(request: Request) {
   // Resolve channel identity when in text mode
   let auth = baseAuth;
   if (textMode) {
-    const resolved = resolveChannelIdentity(request, getRegistrationUrl(request));
+    const resolved = resolveChannelIdentity(request);
     if (resolved === "unregistered") {
       const url = new URL(request.url);
       // Find the token we just inserted so we can return it
       const channelType = request.headers.get("x-channel-type")!;
       const channelUserId = request.headers.get("x-channel-user-id")!;
       const db = getDb();
-      const now = Math.floor(Date.now() / 1000);
       const row = db
         .select()
         .from(schema.mcpRegistrationTokens)

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,19 +1,29 @@
 import { NextResponse } from "next/server";
+import { randomBytes } from "crypto";
 import { getConfig, getUserIdByMcpToken } from "@/lib/config";
 import { initializeTools } from "@/lib/tools/init";
 import { getOpenAITools, executeTool, hasTools } from "@/lib/tools/registry";
 import { getDb, schema } from "@/lib/db";
 import { logger } from "@/lib/logger";
 import { getClientIp } from "@/lib/auth/rate-limit";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
+import { formatDisplayTitlesAsText } from "@/lib/tools/display-titles-text";
+import { createBasket, resolveBasket } from "@/lib/tools/pending-basket";
+import * as overseerr from "@/lib/services/overseerr";
+import type { DisplayTitle } from "@/types/titles";
 
 type McpPermission = "admin" | "user";
+
+interface AuthResult {
+  permission: McpPermission;
+  userId?: number;
+}
 
 /**
  * Authenticate an MCP request via Bearer token.
  * Returns the permission level, or null if unauthorized.
  */
-function authenticateMcp(request: Request): { permission: McpPermission; userId?: number } | null {
+function authenticateMcp(request: Request): AuthResult | null {
   const authHeader = request.headers.get("authorization");
   if (!authHeader?.startsWith("Bearer ")) return null;
 
@@ -56,13 +66,53 @@ function authenticateMcp(request: Request): { permission: McpPermission; userId?
 }
 
 /**
+ * Resolve channel identity headers to a Thinkarr user.
+ * Returns the resolved AuthResult on match, "unregistered" if headers present but no mapping,
+ * or null if no channel headers (caller should use the base auth result).
+ */
+function resolveChannelIdentity(
+  request: Request,
+  baseUrl: string,
+): AuthResult | "unregistered" | null {
+  const channelType = request.headers.get("x-channel-type");
+  const channelUserId = request.headers.get("x-channel-user-id");
+  if (!channelType || !channelUserId) return null;
+
+  const db = getDb();
+  const identity = db
+    .select()
+    .from(schema.mcpChannelIdentities)
+    .where(
+      and(
+        eq(schema.mcpChannelIdentities.channelType, channelType),
+        eq(schema.mcpChannelIdentities.channelUserId, channelUserId),
+      ),
+    )
+    .get();
+
+  if (!identity) {
+    // Issue a short-lived registration token and return the link
+    const token = randomBytes(16).toString("hex");
+    const expiresAt = Math.floor(Date.now() / 1000) + 900; // 15 min
+    db.insert(schema.mcpRegistrationTokens)
+      .values({ token, channelType, channelUserId, expiresAt })
+      .run();
+    logger.info("MCP_CHANNEL_UNREGISTERED", { channelType, registrationToken: token });
+    return "unregistered";
+  }
+
+  const user = db.select().from(schema.users).where(eq(schema.users.id, identity.userId)).get();
+  if (!user) return "unregistered";
+  return { permission: user.isAdmin ? "admin" : "user", userId: user.id };
+}
+
+/**
  * Check if a user has permission to execute a tool.
  * Admin: all tools. User: query-only tools (no delete, no acting on behalf of others).
  */
 function canExecuteTool(toolName: string, permission: McpPermission): boolean {
   if (permission === "admin") return true;
 
-  // Users can use all query/read tools
   const readOnlyTools = [
     "plex_search_library",
     "plex_get_watch_history",
@@ -79,7 +129,6 @@ function canExecuteTool(toolName: string, permission: McpPermission): boolean {
     "overseerr_list_requests",
   ];
 
-  // Users can also request content on their own behalf
   const userActionTools = [
     "overseerr_request_movie",
     "overseerr_request_tv",
@@ -90,13 +139,48 @@ function canExecuteTool(toolName: string, permission: McpPermission): boolean {
   return readOnlyTools.includes(toolName) || userActionTools.includes(toolName);
 }
 
-/**
- * MCP endpoint — supports both tool listing and tool execution.
- *
- * GET  /api/mcp          → List available tools (OpenAI function format)
- * POST /api/mcp          → Execute a tool (JSON-RPC style)
- * POST /api/mcp (list)   → List tools via POST
- */
+/** Extra tool definition exposed only in text mode. */
+const CONFIRM_REQUEST_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "confirm_request",
+    description:
+      "Submit a media download request that the user has explicitly confirmed. ONLY call this after the user sends a clear positive confirmation (e.g. 'yes', 'request it', 'request #2'). Never call this speculatively.",
+    parameters: {
+      type: "object",
+      properties: {
+        pendingKey: {
+          type: "string",
+          description: "The pendingKey returned by display_titles in this conversation turn.",
+        },
+        selection: {
+          type: "number",
+          description: "The 1-based number the user selected from the displayed list.",
+        },
+      },
+      required: ["pendingKey", "selection"],
+    },
+  },
+};
+
+function buildToolList(permission: McpPermission, textMode: boolean) {
+  const allTools = getOpenAITools();
+  const filtered =
+    permission === "admin"
+      ? allTools
+      : allTools.filter((t) => t.type === "function" && canExecuteTool(t.function.name, permission));
+
+  if (textMode) {
+    return [...filtered, CONFIRM_REQUEST_TOOL];
+  }
+  return filtered;
+}
+
+function getRegistrationUrl(request: Request): string {
+  const url = new URL(request.url);
+  return `${url.origin}/mcp/link`;
+}
+
 export async function GET(request: Request) {
   const auth = authenticateMcp(request);
   if (!auth) {
@@ -113,19 +197,16 @@ export async function GET(request: Request) {
     return NextResponse.json({ tools: [] });
   }
 
-  const allTools = getOpenAITools();
-
-  // Filter based on permission
-  const tools = auth.permission === "admin"
-    ? allTools
-    : allTools.filter((t) => t.type === "function" && canExecuteTool(t.function.name, auth.permission));
+  const { searchParams } = new URL(request.url);
+  const textMode = searchParams.get("mode") === "text";
+  const tools = buildToolList(auth.permission, textMode);
 
   return NextResponse.json({ tools });
 }
 
 export async function POST(request: Request) {
-  const auth = authenticateMcp(request);
-  if (!auth) {
+  const baseAuth = authenticateMcp(request);
+  if (!baseAuth) {
     logger.warn("MCP_AUTH_FAILURE", { ip: getClientIp(request), path: "POST /api/mcp" });
     return NextResponse.json(
       { error: "Unauthorized. Provide a valid Bearer token." },
@@ -134,6 +215,42 @@ export async function POST(request: Request) {
   }
 
   initializeTools();
+
+  const { searchParams } = new URL(request.url);
+  const textMode = searchParams.get("mode") === "text";
+
+  // Resolve channel identity when in text mode
+  let auth = baseAuth;
+  if (textMode) {
+    const resolved = resolveChannelIdentity(request, getRegistrationUrl(request));
+    if (resolved === "unregistered") {
+      const url = new URL(request.url);
+      // Find the token we just inserted so we can return it
+      const channelType = request.headers.get("x-channel-type")!;
+      const channelUserId = request.headers.get("x-channel-user-id")!;
+      const db = getDb();
+      const now = Math.floor(Date.now() / 1000);
+      const row = db
+        .select()
+        .from(schema.mcpRegistrationTokens)
+        .where(
+          and(
+            eq(schema.mcpRegistrationTokens.channelType, channelType),
+            eq(schema.mcpRegistrationTokens.channelUserId, channelUserId),
+          ),
+        )
+        .orderBy(schema.mcpRegistrationTokens.expiresAt)
+        .get();
+      const token = row?.token ?? "";
+      return NextResponse.json({
+        error: "unregistered",
+        registrationUrl: `${url.origin}/mcp/link?token=${token}`,
+      });
+    }
+    if (resolved !== null) {
+      auth = resolved;
+    }
+  }
 
   let body: {
     method?: string;
@@ -144,18 +261,12 @@ export async function POST(request: Request) {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
   // Handle "list" method
   if (body.method === "list" || body.method === "tools/list") {
-    const allTools = getOpenAITools();
-    const tools = auth.permission === "admin"
-      ? allTools
-      : allTools.filter((t) => t.type === "function" && canExecuteTool(t.function.name, auth.permission));
+    const tools = buildToolList(auth.permission, textMode);
     return NextResponse.json({ tools });
   }
 
@@ -163,13 +274,67 @@ export async function POST(request: Request) {
   if (body.method === "execute" || body.method === "tools/call" || body.tool) {
     const toolName = body.tool || "";
     if (!toolName) {
+      return NextResponse.json({ error: "tool name is required" }, { status: 400 });
+    }
+
+    // confirm_request: text mode only, handled inline
+    if (toolName === "confirm_request") {
+      if (!textMode) {
+        return NextResponse.json(
+          { error: "confirm_request is only available in text mode" },
+          { status: 403 },
+        );
+      }
+      if (!auth.userId) {
+        return NextResponse.json(
+          { error: "User identity required for confirm_request" },
+          { status: 403 },
+        );
+      }
+
+      const args =
+        typeof body.arguments === "string"
+          ? (JSON.parse(body.arguments) as { pendingKey?: string; selection?: number })
+          : (body.arguments as { pendingKey?: string; selection?: number } | undefined) ?? {};
+
+      const { pendingKey, selection } = args;
+      if (!pendingKey || typeof selection !== "number") {
+        return NextResponse.json({ error: "pendingKey and selection are required" }, { status: 400 });
+      }
+
+      const item = resolveBasket(pendingKey, selection, auth.userId);
+      if (!item) {
+        return NextResponse.json({
+          tool: "confirm_request",
+          result: { success: false, message: "That selection is no longer valid. Please search again." },
+        });
+      }
+
+      logger.info("MCP_CONFIRM_REQUEST", { userId: auth.userId, title: item.title, mediaType: item.mediaType });
+
+      const result =
+        item.mediaType === "movie"
+          ? await overseerr.requestMovie(item.overseerrId)
+          : await overseerr.requestTv(
+              item.overseerrId,
+              item.seasonNumber != null ? [item.seasonNumber] : undefined,
+            );
+
+      const message = result.success
+        ? `✅ *${item.title}* has been requested.`
+        : `❌ Could not request *${item.title}*: ${result.message}`;
+
+      return NextResponse.json({ tool: "confirm_request", result: { ...result, message } });
+    }
+
+    // Block direct request tools in text mode — only confirm_request may submit requests
+    if (textMode && (toolName === "overseerr_request_movie" || toolName === "overseerr_request_tv")) {
       return NextResponse.json(
-        { error: "tool name is required" },
-        { status: 400 },
+        { error: "Use confirm_request in text mode — direct request tools are disabled." },
+        { status: 403 },
       );
     }
 
-    // Permission check
     if (!canExecuteTool(toolName, auth.permission)) {
       logger.warn("MCP_PERMISSION_DENIED", { tool: toolName, permission: auth.permission, userId: auth.userId });
       return NextResponse.json(
@@ -178,24 +343,37 @@ export async function POST(request: Request) {
       );
     }
 
-    const args = typeof body.arguments === "string"
-      ? body.arguments
-      : JSON.stringify(body.arguments || {});
+    const args =
+      typeof body.arguments === "string"
+        ? body.arguments
+        : JSON.stringify(body.arguments || {});
 
     logger.info("MCP_TOOL_EXEC", { tool: toolName, permission: auth.permission, userId: auth.userId });
 
     try {
-      const result = await executeTool(toolName, args);
-      return NextResponse.json({
-        tool: toolName,
-        result: JSON.parse(result),
-      });
+      const resultStr = await executeTool(toolName, args);
+      const result = JSON.parse(resultStr);
+
+      // In text mode, intercept display_titles and convert to markdown + pending basket
+      if (textMode && toolName === "display_titles") {
+        const displayTitles: DisplayTitle[] = result?.displayTitles ?? [];
+        const { text, requestableItems } = formatDisplayTitlesAsText(displayTitles);
+
+        let pendingKey: string | undefined;
+        if (requestableItems.length > 0 && auth.userId != null) {
+          pendingKey = createBasket(requestableItems, auth.userId);
+        }
+
+        return NextResponse.json({
+          tool: toolName,
+          result: { text, ...(pendingKey ? { pendingKey } : {}) },
+        });
+      }
+
+      return NextResponse.json({ tool: toolName, result });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "Tool execution failed";
-      return NextResponse.json(
-        { error: msg },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: msg }, { status: 500 });
     }
   }
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -126,6 +126,7 @@ function canExecuteTool(toolName: string, permission: McpPermission): boolean {
     "radarr_get_queue",
     "overseerr_search",
     "overseerr_list_requests",
+    "display_titles",
   ];
 
   const userActionTools = [

--- a/src/app/mcp/link/page.tsx
+++ b/src/app/mcp/link/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { Suspense, useState, useCallback, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -8,7 +8,7 @@ import { Spinner } from "@/components/ui/spinner";
 
 type PageState = "loading" | "ready" | "waiting" | "success" | "error" | "expired";
 
-export default function McpLinkPage() {
+function McpLinkContent() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
 
@@ -83,48 +83,56 @@ export default function McpLinkPage() {
     : "messaging";
 
   return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Connect your Plex account</CardTitle>
+        <CardDescription>
+          Link your Plex account to use Thinkarr from {channelLabel}.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {state === "loading" && <Spinner className="mx-auto" />}
+
+        {state === "expired" && (
+          <p className="text-destructive text-sm">
+            This link has expired or is invalid. Send another message to get a new one.
+          </p>
+        )}
+
+        {state === "ready" && (
+          <Button onClick={startPlexAuth}>Connect with Plex</Button>
+        )}
+
+        {state === "waiting" && (
+          <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground">
+            <Spinner />
+            <p>Waiting for Plex authorisation…</p>
+          </div>
+        )}
+
+        {state === "success" && (
+          <p className="text-sm text-green-500">
+            ✓ Account linked. You can close this tab and return to {channelLabel}.
+          </p>
+        )}
+
+        {state === "error" && (
+          <>
+            <p className="text-destructive text-sm">{error}</p>
+            <Button variant="outline" onClick={() => setState("ready")}>Try again</Button>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function McpLinkPage() {
+  return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle>Connect your Plex account</CardTitle>
-          <CardDescription>
-            Link your Plex account to use Thinkarr from {channelLabel}.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          {state === "loading" && <Spinner className="mx-auto" />}
-
-          {state === "expired" && (
-            <p className="text-destructive text-sm">
-              This link has expired or is invalid. Send another message to get a new one.
-            </p>
-          )}
-
-          {state === "ready" && (
-            <Button onClick={startPlexAuth}>Connect with Plex</Button>
-          )}
-
-          {state === "waiting" && (
-            <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground">
-              <Spinner />
-              <p>Waiting for Plex authorisation…</p>
-            </div>
-          )}
-
-          {state === "success" && (
-            <p className="text-sm text-green-500">
-              ✓ Account linked. You can close this tab and return to {channelLabel}.
-            </p>
-          )}
-
-          {state === "error" && (
-            <>
-              <p className="text-destructive text-sm">{error}</p>
-              <Button variant="outline" onClick={() => setState("ready")}>Try again</Button>
-            </>
-          )}
-        </CardContent>
-      </Card>
+      <Suspense fallback={<Spinner className="mx-auto" />}>
+        <McpLinkContent />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/mcp/link/page.tsx
+++ b/src/app/mcp/link/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+
+type PageState = "loading" | "ready" | "waiting" | "success" | "error" | "expired";
+
+export default function McpLinkPage() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [state, setState] = useState<PageState>("loading");
+  const [channelType, setChannelType] = useState("");
+  const [error, setError] = useState("");
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const popupRef = useRef<Window | null>(null);
+  const pinIdRef = useRef<number | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    if (popupRef.current && !popupRef.current.closed) popupRef.current.close();
+  }, []);
+
+  useEffect(() => { return cleanup; }, [cleanup]);
+
+  useEffect(() => {
+    if (!token) { setState("expired"); return; }
+    fetch(`/api/mcp/link?token=${encodeURIComponent(token)}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.success) {
+          setChannelType(d.data.channelType);
+          setState("ready");
+        } else {
+          setState("expired");
+        }
+      })
+      .catch(() => setState("expired"));
+  }, [token]);
+
+  async function startPlexAuth() {
+    setState("waiting");
+    setError("");
+    cleanup();
+    try {
+      const res = await fetch("/api/auth/plex", { method: "POST" });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || "Failed to start Plex auth");
+      const { id: pinId, authUrl } = data.data;
+      pinIdRef.current = pinId;
+      const popup = window.open(authUrl, "plex-auth", "width=800,height=600,menubar=no,toolbar=no");
+      popupRef.current = popup;
+
+      pollRef.current = setInterval(async () => {
+        try {
+          const cbRes = await fetch("/api/mcp/link", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ pinId, registrationToken: token }),
+          });
+          const cbData = await cbRes.json();
+          if (cbData.success) {
+            cleanup();
+            setState("success");
+          } else if (cbData.error !== "pending") {
+            cleanup();
+            setState("error");
+            setError(cbData.error || "Authentication failed");
+          }
+        } catch { /* keep polling */ }
+      }, 2000);
+    } catch (e) {
+      setState("error");
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    }
+  }
+
+  const channelLabel = channelType
+    ? channelType.charAt(0).toUpperCase() + channelType.slice(1)
+    : "messaging";
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Connect your Plex account</CardTitle>
+          <CardDescription>
+            Link your Plex account to use Thinkarr from {channelLabel}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {state === "loading" && <Spinner className="mx-auto" />}
+
+          {state === "expired" && (
+            <p className="text-destructive text-sm">
+              This link has expired or is invalid. Send another message to get a new one.
+            </p>
+          )}
+
+          {state === "ready" && (
+            <Button onClick={startPlexAuth}>Connect with Plex</Button>
+          )}
+
+          {state === "waiting" && (
+            <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground">
+              <Spinner />
+              <p>Waiting for Plex authorisation…</p>
+            </div>
+          )}
+
+          {state === "success" && (
+            <p className="text-sm text-green-500">
+              ✓ Account linked. You can close this tab and return to {channelLabel}.
+            </p>
+          )}
+
+          {state === "error" && (
+            <>
+              <p className="text-destructive text-sm">{error}</p>
+              <Button variant="outline" onClick={() => setState("ready")}>Try again</Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, primaryKey } from "drizzle-orm/sqlite-core";
 
 export const appConfig = sqliteTable("app_config", {
   key: text("key").primaryKey(),
@@ -45,6 +45,31 @@ export const conversations = sqliteTable("conversations", {
   updatedAt: integer("updated_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),
+});
+
+export const mcpChannelIdentities = sqliteTable("mcp_channel_identities", {
+  channelType: text("channel_type").notNull(),
+  channelUserId: text("channel_user_id").notNull(),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (t) => [primaryKey({ columns: [t.channelType, t.channelUserId] })]);
+
+export const mcpRegistrationTokens = sqliteTable("mcp_registration_tokens", {
+  token: text("token").primaryKey(),
+  channelType: text("channel_type").notNull(),
+  channelUserId: text("channel_user_id").notNull(),
+  expiresAt: integer("expires_at").notNull(),
+});
+
+export const mcpPendingBaskets = sqliteTable("mcp_pending_baskets", {
+  token: text("token").primaryKey(),
+  itemsJson: text("items_json").notNull(),
+  userId: integer("user_id").notNull(),
+  expiresAt: integer("expires_at").notNull(),
 });
 
 export const messages = sqliteTable("messages", {

--- a/src/lib/tools/display-titles-text.ts
+++ b/src/lib/tools/display-titles-text.ts
@@ -1,0 +1,51 @@
+import type { DisplayTitle } from "@/types/titles";
+import type { PendingItem } from "./pending-basket";
+
+export interface TextChannelDisplay {
+  text: string;
+  requestableItems: PendingItem[];
+}
+
+/**
+ * Convert a display_titles result to a plain-text representation for chat channels.
+ * Requestable items (mediaStatus "not_requested") are numbered for confirm_request.
+ */
+export function formatDisplayTitlesAsText(titles: DisplayTitle[]): TextChannelDisplay {
+  const requestableItems: PendingItem[] = [];
+  const lines: string[] = [];
+  let requestIndex = 0;
+
+  for (const t of titles) {
+    const yearStr = t.year ? ` (${t.year})` : "";
+    const label = `*${t.title}*${yearStr}`;
+
+    if (t.mediaStatus === "available") {
+      lines.push(`${label} ✓ Available in Plex`);
+    } else if (t.mediaStatus === "partial") {
+      lines.push(`${label} ✓ Partially available in Plex`);
+    } else if (t.mediaStatus === "pending") {
+      lines.push(`${label} ⏳ Already requested, downloading`);
+    } else {
+      // not_requested — include in numbered list only if we have an overseerrId to request with
+      if (t.overseerrId != null) {
+        requestIndex++;
+        lines.push(`[${requestIndex}] ${label} — Not in library`);
+        requestableItems.push({
+          overseerrId: t.overseerrId,
+          mediaType: t.overseerrMediaType ?? (t.mediaType === "movie" ? "movie" : "tv"),
+          ...(t.seasonNumber != null ? { seasonNumber: t.seasonNumber } : {}),
+          title: t.title,
+        });
+      } else {
+        lines.push(`${label} — Not in library`);
+      }
+    }
+  }
+
+  let text = lines.join("\n");
+  if (requestableItems.length > 0) {
+    text += '\n\nTo request a title, reply with its number (e.g. "request 1").';
+  }
+
+  return { text, requestableItems };
+}

--- a/src/lib/tools/pending-basket.ts
+++ b/src/lib/tools/pending-basket.ts
@@ -43,7 +43,7 @@ export function resolveBasket(
     )
     .get();
 
-  if (!row || row.expiresAt < now) return null;
+  if (!row || row.expiresAt < now || row.userId !== userId) return null;
 
   const items: PendingItem[] = JSON.parse(row.itemsJson);
   const item = items[selection - 1];

--- a/src/lib/tools/pending-basket.ts
+++ b/src/lib/tools/pending-basket.ts
@@ -1,0 +1,65 @@
+import { randomBytes } from "crypto";
+import { getDb, schema } from "@/lib/db";
+import { eq, lt, and } from "drizzle-orm";
+
+export interface PendingItem {
+  overseerrId: number;
+  mediaType: "movie" | "tv";
+  seasonNumber?: number;
+  title: string;
+}
+
+/** Store a list of requestable items for a user, returning a one-time token. TTL: 10 min. */
+export function createBasket(items: PendingItem[], userId: number): string {
+  const token = randomBytes(32).toString("hex");
+  const expiresAt = Math.floor(Date.now() / 1000) + 600;
+  const db = getDb();
+  db.insert(schema.mcpPendingBaskets)
+    .values({ token, itemsJson: JSON.stringify(items), userId, expiresAt })
+    .run();
+  return token;
+}
+
+/**
+ * Resolve a basket token + 1-based selection to a PendingItem.
+ * Returns null if the token is invalid, expired, wrong user, or the selection is out of range.
+ * Deletes the basket on a successful resolution (one-time use).
+ */
+export function resolveBasket(
+  token: string,
+  selection: number,
+  userId: number,
+): PendingItem | null {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const row = db
+    .select()
+    .from(schema.mcpPendingBaskets)
+    .where(
+      and(
+        eq(schema.mcpPendingBaskets.token, token),
+        eq(schema.mcpPendingBaskets.userId, userId),
+      ),
+    )
+    .get();
+
+  if (!row || row.expiresAt < now) return null;
+
+  const items: PendingItem[] = JSON.parse(row.itemsJson);
+  const item = items[selection - 1];
+  if (!item) return null;
+
+  db.delete(schema.mcpPendingBaskets)
+    .where(eq(schema.mcpPendingBaskets.token, token))
+    .run();
+
+  return item;
+}
+
+export function cleanExpiredBaskets(): void {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  db.delete(schema.mcpPendingBaskets)
+    .where(lt(schema.mcpPendingBaskets.expiresAt, now))
+    .run();
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `?mode=text` to `/api/mcp` enabling external channel gateways (OpenClaw, WhatsApp, Telegram, Discord, etc.) to drive Thinkarr without a web UI
- `display_titles` results are intercepted and converted to a markdown numbered list; requestable items are stored in a server-side pending basket so the LLM cannot fabricate request tokens
- New `confirm_request` tool (text mode only) validates the basket token, checks TTL + ownership, then submits the Overseerr request — direct `overseerr_request_*` tools are hard-blocked in text mode
- Channel identity resolution from `X-Channel-Type` + `X-Channel-User-Id` headers via new `mcp_channel_identities` table; unregistered users receive a self-service registration URL
- Self-service registration flow: user clicks link in chat → `/mcp/link` page → Plex OAuth → identity stored, all future calls resolve to the correct Plex-linked user
- DB migration `0002` adds three tables: `mcp_channel_identities`, `mcp_registration_tokens` (15-min TTL), `mcp_pending_baskets` (10-min one-time-use)
- 21 unit tests covering basket TTL/ownership/one-time-use, markdown formatting, and the full text-mode MCP flow end-to-end
- Bumps version to `1.1.8-beta.2`

Closes #5

## Test plan

- [ ] `node_modules` not installed in this environment — all tests run in CI
- [ ] MCP GET `?mode=text` returns tool list including `confirm_request`
- [ ] MCP POST `?mode=text` with unknown channel headers returns `{ error: "unregistered", registrationUrl: "..." }`
- [ ] `/mcp/link?token=xxx` page loads, validates token, runs Plex OAuth, stores identity on success
- [ ] After registration, MCP calls with channel headers resolve to correct Thinkarr user
- [ ] `display_titles` in text mode returns markdown text with numbered requestable items and a `pendingKey`
- [ ] `confirm_request` with valid `pendingKey` + selection submits Overseerr request and consumes the basket (second call with same key fails)
- [ ] `confirm_request` with expired/wrong-user basket returns "no longer valid" message
- [ ] `overseerr_request_movie` and `overseerr_request_tv` return 403 in text mode
- [ ] `confirm_request` returns 403 outside text mode
- [ ] Normal (non-text-mode) MCP calls are unaffected

https://claude.ai/code/session_015ncyAk2WuNSFzuGDV3EdAo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ncyAk2WuNSFzuGDV3EdAo)_