### PR TITLE
fix(ci): apply production-only audit gate to docker-publish + hygiene workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm ci
 
       - name: Dependency audit
-        run: npm audit --audit-level=high
+        run: npm run security:audit
 
       - name: SAST scan
         run: |

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -27,10 +27,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: npm audit (all severities)
+      - name: npm audit (production deps, all severities)
         id: audit
         run: |
-          npm audit --json > audit.json 2>&1 || true
+          # Production dependencies only — devDependencies (eslint, drizzle-kit,
+          # etc.) never reach the shipped Docker image, so their findings are
+          # noise for a production hygiene report. See scripts/check-npm-audit.mjs.
+          npm audit --omit=dev --json > audit.json 2>&1 || true
           CRITICAL=$(cat audit.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('metadata',{}).get('vulnerabilities',{}).get('critical',0))")
           HIGH=$(cat audit.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('metadata',{}).get('vulnerabilities',{}).get('high',0))")
           MODERATE=$(cat audit.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('metadata',{}).get('vulnerabilities',{}).get('moderate',0))")
@@ -40,7 +43,7 @@ jobs:
           echo "moderate=$MODERATE" >> $GITHUB_OUTPUT
           echo "low=$LOW" >> $GITHUB_OUTPUT
           {
-            echo "## npm audit"
+            echo "## npm audit (production dependencies)"
             echo "| Severity | Count |"
             echo "|----------|-------|"
             echo "| 🔴 Critical | $CRITICAL |"
@@ -48,6 +51,19 @@ jobs:
             echo "| 🟡 Moderate | $MODERATE |"
             echo "| 🔵 Low | $LOW |"
           } >> $GITHUB_STEP_SUMMARY
+
+      - name: npm audit gate
+        id: audit_gate
+        run: |
+          # The actual pass/fail gate — scripts/check-npm-audit.mjs fails on ANY
+          # severity in production deps, with .npmauditignore as the documented
+          # exception for a genuinely upstream-blocked case. This is the same
+          # gate used in ci.yml and docker-publish.yml.
+          if npm run security:audit; then
+            echo "blocking=0" >> $GITHUB_OUTPUT
+          else
+            echo "blocking=1" >> $GITHUB_OUTPUT
+          fi
 
       - name: ESLint (warnings + errors)
         id: lint
@@ -81,12 +97,11 @@ jobs:
 
       - name: Fail if regressions detected
         run: |
-          CRITICAL=${{ steps.audit.outputs.critical }}
-          HIGH=${{ steps.audit.outputs.high }}
+          AUDIT_BLOCKING=${{ steps.audit_gate.outputs.blocking }}
           ERRORS=${{ steps.lint.outputs.errors }}
           FINDINGS=${{ steps.semgrep.outputs.findings }}
-          if [[ "$CRITICAL" -gt 0 || "$HIGH" -gt 0 || "$ERRORS" -gt 0 || "$FINDINGS" -gt 0 ]]; then
+          if [[ "$AUDIT_BLOCKING" -eq 1 || "$ERRORS" -gt 0 || "$FINDINGS" -gt 0 ]]; then
             echo "❌ Regressions detected — see summary above."
             exit 1
           fi
-          echo "✅ No regressions. Moderate/low findings in summary are informational."
+          echo "✅ No regressions."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.3",
+  "version": "1.1.8-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.8-beta.3",
+      "version": "1.1.8-beta.4",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.3",
+  "version": "1.1.8-beta.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

PR #465 (dev→beta merge) failed the Docker build's own \`npm audit --audit-level=high\` step — that failure is from **`docker-publish.yml`**, a separate workflow from `ci.yml` that I didn't touch when fixing the audit gate in #462. It still had the old hardcoded command, so it still counts the devDependency-only `eslint`/`eslint-config-next` `brace-expansion` findings as blocking HIGH severity.

Found and fixed a second instance of the same staleness: **`hygiene.yml`** (the weekly scheduled job — this is the exact job issue #448 said had been failing since 2026-05-18) had its own independent, hand-rolled HIGH/CRITICAL-only check against combined prod+dev dependencies.

## Changes

- `docker-publish.yml`: `npm audit --audit-level=high` → `npm run security:audit` (uses `scripts/check-npm-audit.mjs` from #462 — production deps only, any severity, `.npmauditignore` for documented upstream-blocked exceptions).
- `hygiene.yml`: scoped the reporting table to `--omit=dev` (so it reflects the same production-only view), and replaced the pass/fail gate with `npm run security:audit` so there's one canonical definition of "audit passes" across all three workflows instead of three independent implementations.
- Version bump: `dev` matched `beta` (`1.1.8-beta.3`), bumped to `1.1.8-beta.4` per the standard workflow rule.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 622/622 passing
- [x] `npm run security:audit` — exits 0 (0 blocking production-dependency vulnerabilities)
- [x] Validated both workflow YAML files parse correctly
- [ ] Confirm on CI that `docker-publish.yml`'s audit step now passes on a push to `beta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)