### PR TITLE
fix(#469): suppress newly-disclosed CVEs in npm CLI's bundled deps

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,10 +1,11 @@
-# Vulnerabilities in npm CLI's own bundled dependencies (tar, minimatch, glob).
+# Vulnerabilities in npm CLI's own bundled dependencies (tar, minimatch, glob,
+# brace-expansion, undici — the latter pulled in via npm's bundled node-gyp).
 # These packages live in /usr/local/lib/node_modules/npm/ and are only used by
 # the npm CLI tool itself. Our production container never runs 'npm install' or
 # any npm commands — it runs 'node server.js' only. The attack surface for these
-# CVEs (malicious archive extraction, glob injection) does not exist at runtime.
+# CVEs (malicious archive extraction, glob injection, DoS) does not exist at runtime.
 #
-# Suppress until the node:22-alpine base image ships a patched npm version,
+# Suppress until the node:26-alpine base image ships a patched npm version,
 # at which point these entries should be removed.
 
 # glob: Command Injection via Malicious Filenames (npm-internal only)
@@ -15,13 +16,25 @@ CVE-2026-26996
 CVE-2026-27903
 CVE-2026-27904
 
-# node-tar: various path traversal / file overwrite (npm-internal only)
+# brace-expansion: DoS via exponential-time complexity (npm-internal only,
+# transitive via npm's bundled minimatch) — issue #469
+CVE-2026-13149
+CVE-2026-14257
+
+# node-tar: various path traversal / file overwrite / DoS (npm-internal only)
 CVE-2026-23745
 CVE-2026-23950
 CVE-2026-24842
 CVE-2026-26960
 CVE-2026-29786
 CVE-2026-31802
+# node-tar: DoS via crafted gzip bomb / malformed archive header — issue #469
+CVE-2026-59873
+CVE-2026-59874
+
+# undici: DoS via unbounded memory growth over WebSocket (npm-internal only,
+# transitive via npm's bundled node-gyp) — issue #469
+CVE-2026-12151
 
 # openssl: NULL pointer DoS in CMS (CVE-2026-28390) — fix is 3.5.6-r0 but that package
 # has not yet landed in Alpine's repos for node:25-alpine. The Dockerfile already runs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.8-beta.4",
+      "version": "1.1.8-beta.5",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Closes #469. The Trivy Docker image scan for `1.1.8-beta.4` failed on 5 findings in `brace-expansion`, `tar`, and `undici` — all in Trivy's "Node.js (node-pkg)" category, blocking CI.

Verified these are the same class of finding as the existing `.trivyignore` entries (glob/minimatch/node-tar), not something in our own dependency tree:

- `npm ls tar undici brace-expansion` shows neither `tar` nor `undici` anywhere in our app's dependency tree at all, and our own `brace-expansion` instances are already at safe versions (`1.1.16`, `5.0.8`).
- Located npm's own bundled copies at `/usr/local/lib/node_modules/npm/node_modules/{tar,undici}` — `undici` is pulled in transitively via npm's bundled `node-gyp`.
- Confirmed a newer local npm (11.18.0) already ships patched versions of both (`tar@7.5.19`, `undici@6.27.0`) — same situation as the existing `openssl` entry: this is waiting on the `node:26-alpine` base image to pick up a newer bundled npm, not something fixable in this repo's own `package.json`.

Our production container only ever runs `node server.js` — never `npm` or `node-gyp` — so there's no runtime attack surface for any of these.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 622/622 passing
- [x] `npm run security:audit` — exits 0
- [ ] Confirm the `docker-e2e` job's Trivy scan passes on this branch in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)