### PR TITLE
fix(db): don't cache getDb() handle until schema integrity check passes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -272,6 +272,9 @@ plex.tv's `/api/v2/resources` can return a server resource with an empty `connec
 ### SQLite + Drizzle (no external DB)
 Stored at `/config/thinkarr.db`, auto-migrated on first connection. Zero external dependencies — no separate DB container. Uses better-sqlite3 (synchronous) configured as an external in `next.config.ts` for standalone builds.
 
+### Schema Integrity Check Is Only Cached On Success
+`ensureSchemaIntegrity()` (`src/lib/db/index.ts`) compares every table in `schema.ts` against the live SQLite file after `migrate()` runs, and throws if a NOT NULL column (or, degenerate case, a whole missing table) can't be safely auto-repaired — this is meant to fail loudly rather than let the app silently serve broken queries. `getDb()`'s module-level `_db` handle is only assigned *after* this check succeeds; a failed check is retried (and re-thrown) on every subsequent call within the same process instead of being cached. This matters because a live beta instance hit exactly this: `mcp_channel_identities`/`mcp_registration_tokens`/`mcp_pending_baskets` never got created despite `__drizzle_migrations` recording the migration as applied, and with the old caching order the failure logged once at boot and then went silent forever — the text-channel adapter kept 500ing on every request with no further signal. Fixed by an operator running the migration SQL directly against the live DB and restarting; regression coverage in `src/__tests__/db/get-db-cache.test.ts` and the "entire table missing" case in `src/__tests__/db/migrations.test.ts`.
+
 ### In-Process MCP Tool Registry
 Tools defined with Zod schemas, converted to JSON Schema → OpenAI function format at runtime. Single source of truth: same registry serves both the in-process chat engine and the external `/api/mcp` endpoint. Auto-initialized based on which services are configured.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.8-beta.5",
+      "version": "1.1.8-beta.6",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/db/get-db-cache.test.ts
+++ b/src/__tests__/db/get-db-cache.test.ts
@@ -1,0 +1,88 @@
+/**
+ * getDb() — schema-integrity failures must not be cached
+ *
+ * Regression test for a production incident (beta, 2026-07-27): a live
+ * database was missing the mcp_channel_identities/mcp_registration_tokens/
+ * mcp_pending_baskets tables even though __drizzle_migrations recorded them as
+ * applied. ensureSchemaIntegrity() correctly threw — but getDb() assigned the
+ * module-level `_db` cache *before* running the integrity check, so the throw
+ * only surfaced on the very first call after a process start. Every
+ * subsequent getDb() call in that same process silently returned the cached
+ * (broken) handle instead of re-checking, so the failure produced one log
+ * line at boot and then went completely quiet — even though the underlying
+ * tables were still missing and any query against them would fail.
+ *
+ * getDb() must instead keep retrying (and re-throwing) on every call until
+ * the underlying schema is actually fixed.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+import path from "path";
+import fs from "fs";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/lib/db/schema";
+
+const MIGRATIONS_DIR = path.join(process.cwd(), "drizzle");
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "thinkarr-getdb-cache-test-"));
+  dbPath = path.join(tmpDir, "thinkarr.db");
+  process.env.CONFIG_DIR = tmpDir;
+});
+
+/** Build a DB file with all migrations applied, then break it exactly like the beta incident. */
+function createBrokenDb(): void {
+  const sqlite = new Database(dbPath);
+  sqlite.pragma("foreign_keys = ON");
+  migrate(drizzle(sqlite, { schema }), { migrationsFolder: MIGRATIONS_DIR });
+  sqlite.exec("DROP TABLE mcp_channel_identities");
+  sqlite.close();
+}
+
+async function importGetDb() {
+  vi.resetModules();
+  const mod = await import("@/lib/db");
+  return mod.getDb;
+}
+
+describe("getDb() — does not cache a handle across a failed integrity check", () => {
+  it("throws again on the second call, not just the first", async () => {
+    createBrokenDb();
+    const getDb = await importGetDb();
+
+    expect(() => getDb()).toThrow(/mcp_channel_identities/);
+    // Before the fix, this second call returned the module-level `_db` cache
+    // populated by the failed first attempt, instead of re-running
+    // ensureSchemaIntegrity — i.e. it silently stopped throwing.
+    expect(() => getDb()).toThrow(/mcp_channel_identities/);
+  });
+
+  it("succeeds once the underlying schema is repaired, without restarting the process", async () => {
+    createBrokenDb();
+    const getDb = await importGetDb();
+
+    expect(() => getDb()).toThrow(/mcp_channel_identities/);
+
+    // Repair the table on disk (mirrors an operator running the migration
+    // SQL manually) — no process restart.
+    const repair = new Database(dbPath);
+    repair.exec(`
+      CREATE TABLE mcp_channel_identities (
+        channel_type text NOT NULL,
+        channel_user_id text NOT NULL,
+        user_id integer NOT NULL,
+        created_at integer NOT NULL,
+        PRIMARY KEY(channel_type, channel_user_id),
+        FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE no action ON DELETE cascade
+      );
+    `);
+    repair.close();
+
+    expect(() => getDb()).not.toThrow();
+  });
+});

--- a/src/__tests__/db/migrations.test.ts
+++ b/src/__tests__/db/migrations.test.ts
@@ -202,6 +202,20 @@ describe("ensureSchemaIntegrity — generic drift correction", () => {
 
     expect(() => ensureSchemaIntegrity(sqlite)).toThrow(/NOT NULL/);
   });
+
+  it("throws when an entire table is missing, not just a column (beta incident, 2026-07-27)", () => {
+    // mcp_channel_identities never got created on a live beta database even
+    // though __drizzle_migrations recorded 0002_mcp_channel_integration as
+    // applied. PRAGMA table_info() on a nonexistent table returns zero rows
+    // (not an error), so every expected column reads as "missing" — this must
+    // still throw exactly like a partial-column drift would, rather than being
+    // mistaken for "table has no columns defined" and skipped.
+    sqlite.exec("DROP TABLE mcp_channel_identities");
+
+    expect(() => ensureSchemaIntegrity(sqlite)).toThrow(
+      /"mcp_channel_identities"\..*is NOT NULL/,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -181,7 +181,14 @@ export function getDb() {
     const sqlite = new Database(DB_PATH);
     sqlite.pragma("journal_mode = WAL");
     sqlite.pragma("foreign_keys = ON");
-    _db = drizzle(sqlite, { schema });
+    // Kept local (not assigned to the module-level `_db` cache) until every
+    // init step below — in particular ensureSchemaIntegrity() — succeeds.
+    // Caching early meant a thrown integrity failure still left a usable
+    // handle in `_db`, so the very next call skipped `if (!_db)` entirely and
+    // silently returned the broken connection instead of retrying/re-throwing
+    // (issue: mcp_channel_identities missing on beta went from one log line
+    // at boot to permanently-broken-and-silent for every request after it).
+    const db = drizzle(sqlite, { schema });
 
     // ── 1. File metadata ─────────────────────────────────────────────────────
     // Logged first so it appears in output even if a later step crashes.
@@ -248,6 +255,7 @@ export function getDb() {
 
     // ── 4. Schema integrity check ────────────────────────────────────────────
     // Logs one line per table (OK / repaired / throws on NOT NULL drift).
+    // Must run — and succeed — before `_db` is cached below.
     ensureSchemaIntegrity(sqlite);
     logger.info("Database ready");
 
@@ -257,25 +265,29 @@ export function getDb() {
     // Rule: supportsRealtime = (realtimeModel !== "").
     // This is a data-level migration — ensureSchemaIntegrity only handles
     // column-level drift and cannot reach inside JSON config blobs.
-    migrateLlmEndpoints(_db);
+    migrateLlmEndpoints(db);
 
     // ── 6. Auto-generate internal API key ────────────────────────────────────
     // Generated once on first boot; the operator copies it from
     // Settings → Logs → Internal API Key and gives it to Claude for
     // the /beta-logs diagnostic command.
-    const existingApiKey = _db
+    const existingApiKey = db
       .select({ value: schema.appConfig.value })
       .from(schema.appConfig)
       .where(eq(schema.appConfig.key, "internal_api_key"))
       .get();
     if (!existingApiKey) {
       const newKey = randomBytes(32).toString("hex");
-      _db
+      db
         .insert(schema.appConfig)
         .values({ key: "internal_api_key", value: newKey, encrypted: true, updatedAt: new Date() })
         .run();
       logger.info("Generated internal API key for diagnostic endpoint");
     }
+
+    // Only cache once every step above has succeeded — see comment at the top
+    // of this function for why this can't happen any earlier.
+    _db = db;
   }
   return _db;
 }


### PR DESCRIPTION
## Summary
- Root cause of the beta WhatsApp/OpenClaw text-channel outage was a broken migration: `mcp_channel_identities`, `mcp_registration_tokens`, and `mcp_pending_baskets` never got created on the live beta DB even though `__drizzle_migrations` recorded the migration as applied. Confirmed via `/beta-logs` and fixed directly on the beta container (repair SQL run manually, container restarted) — logs now show all three tables reporting `status: "OK"`.
- This surfaced a real bug in `getDb()` (`src/lib/db/index.ts`): the module-level `_db` cache was assigned *before* `ensureSchemaIntegrity()` ran, so a thrown integrity failure still left a usable (broken) handle cached. Every `getDb()` call after the first silently skipped the check entirely instead of retrying — the failure logged once at boot and then went completely quiet for the rest of the process's life, even though the underlying tables were still missing. This is a real risk for any other self-hosted instance that hits the same kind of drift.
- Fix: `_db` is now only assigned once every init step (migrate → integrity check → data migrations → API key generation) has actually succeeded. A failed check is retried — and re-thrown — on every subsequent call instead of being cached.

## Test plan
- [x] `src/__tests__/db/migrations.test.ts` — new case: `ensureSchemaIntegrity` throws when an entire table is missing (not just a column), reproducing the exact beta scenario (`PRAGMA table_info` on a nonexistent table returns zero rows rather than erroring).
- [x] `src/__tests__/db/get-db-cache.test.ts` (new file) — `getDb()` throws again on a second call rather than silently returning a cached broken handle, and succeeds once the schema is repaired on disk without a process restart.
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 626/626 passing
- [x] `ARCHITECTURE.md` updated with the design-decision writeup
- [x] Version bumped `1.1.8-beta.5` → `1.1.8-beta.6` (dev/beta parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)