### PR TITLE
fix(mcp): confirm_request invisible to spec-compliant JSON-RPC MCP clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.8-beta.5",
+      "version": "1.1.8-beta.6",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/api/mcp-jsonrpc.test.ts
+++ b/src/__tests__/api/mcp-jsonrpc.test.ts
@@ -10,6 +10,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { resolveBasket } from "@/lib/tools/pending-basket";
+import { requestMovie } from "@/lib/services/overseerr";
 
 vi.mock("@/lib/db", () => ({
   getDb: () => ({
@@ -61,8 +63,8 @@ vi.mock("@/lib/services/overseerr", () => ({ requestMovie: vi.fn(), requestTv: v
 vi.mock("@/lib/tools/pending-basket", () => ({ createBasket: vi.fn(), resolveBasket: vi.fn() }));
 vi.mock("@/lib/tools/display-titles-text", () => ({ formatDisplayTitlesAsText: vi.fn() }));
 
-function makeRequest(body: unknown, bearer = "test-bearer"): Request {
-  return new Request("http://localhost/api/mcp", {
+function makeRequest(body: unknown, bearer = "test-bearer", url = "http://localhost/api/mcp"): Request {
+  return new Request(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -197,5 +199,88 @@ describe("POST /api/mcp — JSON-RPC 2.0 envelope (#461)", () => {
     // Legacy shape: bare { tools: [...] }, no jsonrpc/id envelope
     expect(data.jsonrpc).toBeUndefined();
     expect(Array.isArray(data.tools)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ?mode=text threading through the spec-compliant JSON-RPC path
+//
+// Regression: handleMcpProtocolRequest() originally reimplemented tools/list
+// filtering inline (ignoring textMode entirely) and hardcoded `textMode: false`
+// for tools/call. confirm_request was therefore invisible to, and unusable by,
+// any external MCP client that speaks proper JSON-RPC 2.0 — it only worked via
+// the legacy ad-hoc envelope used by the OpenClaw text-channel adapter.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/mcp?mode=text — textMode threading through the JSON-RPC path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tools/list includes confirm_request when ?mode=text is set", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(
+      makeRequest(
+        { jsonrpc: "2.0", method: "tools/list", id: 10 },
+        "test-bearer",
+        "http://localhost/api/mcp?mode=text",
+      ),
+    );
+    const data = await res.json();
+
+    const names = data.result.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain("confirm_request");
+  });
+
+  it("tools/list omits confirm_request when ?mode=text is absent", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({ jsonrpc: "2.0", method: "tools/list", id: 11 }));
+    const data = await res.json();
+
+    const names = data.result.tools.map((t: { name: string }) => t.name);
+    expect(names).not.toContain("confirm_request");
+  });
+
+  it("tools/call confirm_request succeeds via the JSON-RPC path when ?mode=text is set", async () => {
+    vi.mocked(resolveBasket).mockReturnValue({ overseerrId: 1, mediaType: "movie", title: "The Matrix" });
+    vi.mocked(requestMovie).mockResolvedValue({ success: true, message: "ok" });
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(
+      makeRequest(
+        {
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "confirm_request", arguments: { pendingKey: "abc", selection: 1 } },
+          id: 12,
+        },
+        "user-token",
+        "http://localhost/api/mcp?mode=text",
+      ),
+    );
+    const data = await res.json();
+
+    expect(data.result.isError).toBeUndefined();
+    const payload = JSON.parse(data.result.content[0].text);
+    expect(payload.success).toBe(true);
+  });
+
+  it("tools/call confirm_request is rejected via the JSON-RPC path when ?mode=text is absent", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(
+      makeRequest(
+        {
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "confirm_request", arguments: { pendingKey: "abc", selection: 1 } },
+          id: 13,
+        },
+        "user-token",
+      ),
+    );
+    const data = await res.json();
+
+    expect(data.error).toBeDefined();
+    expect(data.error.message).toMatch(/only available in text mode/i);
   });
 });

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -305,7 +305,7 @@ function buildToolList(permission: McpPermission, textMode: boolean) {
  * A fresh `Server` + transport is created per request — the SDK's stateless
  * transports (no `sessionIdGenerator`) cannot be reused across requests.
  */
-async function handleMcpProtocolRequest(request: Request, auth: AuthResult, token: string): Promise<Response> {
+async function handleMcpProtocolRequest(request: Request, auth: AuthResult, token: string, textMode: boolean): Promise<Response> {
   const server = new Server(
     { name: "thinkarr", version: process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown" },
     { capabilities: { tools: {} } },
@@ -313,13 +313,13 @@ async function handleMcpProtocolRequest(request: Request, auth: AuthResult, toke
 
   server.setRequestHandler(ListToolsRequestSchema, async (_req, extra) => {
     const permission = (extra.authInfo?.extra?.permission as McpPermission | undefined) ?? auth.permission;
-    const allTools = getOpenAITools();
-    const filtered =
-      permission === "admin"
-        ? allTools
-        : allTools.filter((t) => t.type === "function" && canExecuteTool(t.function.name, permission));
 
-    const tools: Tool[] = filtered
+    // Reuse buildToolList so confirm_request is included in ?mode=text here
+    // exactly as it is for the legacy ad-hoc dispatch below — this was
+    // previously reimplemented inline without the textMode branch, so
+    // spec-compliant JSON-RPC clients (unlike the legacy-envelope OpenClaw
+    // adapter) never saw confirm_request even when connecting with ?mode=text.
+    const tools: Tool[] = buildToolList(permission, textMode)
       .filter((t) => t.type === "function")
       .map((t) => ({
         name: t.function.name,
@@ -339,7 +339,7 @@ async function handleMcpProtocolRequest(request: Request, auth: AuthResult, toke
       toolName: name,
       rawArguments: args,
       auth: { permission, userId },
-      textMode: false,
+      textMode,
     });
 
     if (!outcome.ok) {
@@ -471,7 +471,7 @@ export async function POST(request: Request) {
       headers: request.headers,
       body: rawBody,
     });
-    return handleMcpProtocolRequest(freshRequest, auth, request.headers.get("authorization")!.slice(7));
+    return handleMcpProtocolRequest(freshRequest, auth, request.headers.get("authorization")!.slice(7), textMode);
   }
 
   // Legacy ad-hoc dispatch (no `jsonrpc` envelope) — kept for backward compatibility


### PR DESCRIPTION
## Summary
External MCP clients reported not seeing `confirm_request` in the tool list. Root cause is a regression from the official-SDK JSON-RPC migration (#461, `600b120`):

- `handleMcpProtocolRequest()` (the new spec-compliant JSON-RPC path, used by any client that sends a proper `jsonrpc: "2.0"` envelope) reimplemented tools/list filtering **inline** instead of reusing `buildToolList()` — so it never added `CONFIRM_REQUEST_TOOL`, regardless of `?mode=text`.
- The same function also hardcoded `textMode: false` when calling `runToolCall()` for `tools/call`, so even a client that somehow knew to call `confirm_request` got rejected with *"confirm_request is only available in text mode"*.
- The **legacy ad-hoc envelope** (no `jsonrpc` field) was unaffected — it already calls `buildToolList()` and threads `textMode` through correctly. That's why OpenClaw specifically kept working (it predates the JSON-RPC migration and uses the legacy shape) while other, spec-compliant third-party MCP clients hitting the same `?mode=text` endpoint got nothing.

## Fix
`handleMcpProtocolRequest()` now takes `textMode` as a parameter:
- `tools/list` builds its result via `buildToolList(permission, textMode)`, identical to the legacy path.
- `tools/call` passes the real `textMode` through to `runToolCall()` instead of a literal `false`.

## Test plan
- [x] New regression tests in `src/__tests__/api/mcp-jsonrpc.test.ts`:
  - `tools/list` includes `confirm_request` when `?mode=text` is set
  - `tools/list` omits it when `?mode=text` is absent
  - `tools/call confirm_request` succeeds via the JSON-RPC path with `?mode=text`
  - `tools/call confirm_request` is rejected via the JSON-RPC path without `?mode=text`
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 627/627 passing
- [x] Version bumped `1.1.8-beta.5` → `1.1.8-beta.6` (dev/beta parity). Note: PR #478 (separate, unrelated fix also open against `dev`) bumps to the same version — whichever merges second needs a trivial re-bump to avoid a collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)