### PR TITLE
Merge pull request #480 from chrisrothwell/claude/fix-mcp-jsonrpc-textmode-confirm-request-671393

fix(mcp): confirm_request invisible to spec-compliant JSON-RPC MCP clients

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -272,6 +272,9 @@ plex.tv's `/api/v2/resources` can return a server resource with an empty `connec
 ### SQLite + Drizzle (no external DB)
 Stored at `/config/thinkarr.db`, auto-migrated on first connection. Zero external dependencies — no separate DB container. Uses better-sqlite3 (synchronous) configured as an external in `next.config.ts` for standalone builds.
 
+### Schema Integrity Check Is Only Cached On Success
+`ensureSchemaIntegrity()` (`src/lib/db/index.ts`) compares every table in `schema.ts` against the live SQLite file after `migrate()` runs, and throws if a NOT NULL column (or, degenerate case, a whole missing table) can't be safely auto-repaired — this is meant to fail loudly rather than let the app silently serve broken queries. `getDb()`'s module-level `_db` handle is only assigned *after* this check succeeds; a failed check is retried (and re-thrown) on every subsequent call within the same process instead of being cached. This matters because a live beta instance hit exactly this: `mcp_channel_identities`/`mcp_registration_tokens`/`mcp_pending_baskets` never got created despite `__drizzle_migrations` recording the migration as applied, and with the old caching order the failure logged once at boot and then went silent forever — the text-channel adapter kept 500ing on every request with no further signal. Fixed by an operator running the migration SQL directly against the live DB and restarting; regression coverage in `src/__tests__/db/get-db-cache.test.ts` and the "entire table missing" case in `src/__tests__/db/migrations.test.ts`.
+
 ### In-Process MCP Tool Registry
 Tools defined with Zod schemas, converted to JSON Schema → OpenAI function format at runtime. Single source of truth: same registry serves both the in-process chat engine and the external `/api/mcp` endpoint. Auto-initialized based on which services are configured.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinkarr",
-      "version": "1.1.8-beta.5",
+      "version": "1.1.8-beta.6",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkarr",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/__tests__/api/mcp-jsonrpc.test.ts
+++ b/src/__tests__/api/mcp-jsonrpc.test.ts
@@ -10,6 +10,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { resolveBasket } from "@/lib/tools/pending-basket";
+import { requestMovie } from "@/lib/services/overseerr";
 
 vi.mock("@/lib/db", () => ({
   getDb: () => ({
@@ -61,8 +63,8 @@ vi.mock("@/lib/services/overseerr", () => ({ requestMovie: vi.fn(), requestTv: v
 vi.mock("@/lib/tools/pending-basket", () => ({ createBasket: vi.fn(), resolveBasket: vi.fn() }));
 vi.mock("@/lib/tools/display-titles-text", () => ({ formatDisplayTitlesAsText: vi.fn() }));
 
-function makeRequest(body: unknown, bearer = "test-bearer"): Request {
-  return new Request("http://localhost/api/mcp", {
+function makeRequest(body: unknown, bearer = "test-bearer", url = "http://localhost/api/mcp"): Request {
+  return new Request(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -197,5 +199,88 @@ describe("POST /api/mcp — JSON-RPC 2.0 envelope (#461)", () => {
     // Legacy shape: bare { tools: [...] }, no jsonrpc/id envelope
     expect(data.jsonrpc).toBeUndefined();
     expect(Array.isArray(data.tools)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ?mode=text threading through the spec-compliant JSON-RPC path
+//
+// Regression: handleMcpProtocolRequest() originally reimplemented tools/list
+// filtering inline (ignoring textMode entirely) and hardcoded `textMode: false`
+// for tools/call. confirm_request was therefore invisible to, and unusable by,
+// any external MCP client that speaks proper JSON-RPC 2.0 — it only worked via
+// the legacy ad-hoc envelope used by the OpenClaw text-channel adapter.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/mcp?mode=text — textMode threading through the JSON-RPC path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tools/list includes confirm_request when ?mode=text is set", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(
+      makeRequest(
+        { jsonrpc: "2.0", method: "tools/list", id: 10 },
+        "test-bearer",
+        "http://localhost/api/mcp?mode=text",
+      ),
+    );
+    const data = await res.json();
+
+    const names = data.result.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain("confirm_request");
+  });
+
+  it("tools/list omits confirm_request when ?mode=text is absent", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(makeRequest({ jsonrpc: "2.0", method: "tools/list", id: 11 }));
+    const data = await res.json();
+
+    const names = data.result.tools.map((t: { name: string }) => t.name);
+    expect(names).not.toContain("confirm_request");
+  });
+
+  it("tools/call confirm_request succeeds via the JSON-RPC path when ?mode=text is set", async () => {
+    vi.mocked(resolveBasket).mockReturnValue({ overseerrId: 1, mediaType: "movie", title: "The Matrix" });
+    vi.mocked(requestMovie).mockResolvedValue({ success: true, message: "ok" });
+
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(
+      makeRequest(
+        {
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "confirm_request", arguments: { pendingKey: "abc", selection: 1 } },
+          id: 12,
+        },
+        "user-token",
+        "http://localhost/api/mcp?mode=text",
+      ),
+    );
+    const data = await res.json();
+
+    expect(data.result.isError).toBeUndefined();
+    const payload = JSON.parse(data.result.content[0].text);
+    expect(payload.success).toBe(true);
+  });
+
+  it("tools/call confirm_request is rejected via the JSON-RPC path when ?mode=text is absent", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(
+      makeRequest(
+        {
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "confirm_request", arguments: { pendingKey: "abc", selection: 1 } },
+          id: 13,
+        },
+        "user-token",
+      ),
+    );
+    const data = await res.json();
+
+    expect(data.error).toBeDefined();
+    expect(data.error.message).toMatch(/only available in text mode/i);
   });
 });

--- a/src/__tests__/db/get-db-cache.test.ts
+++ b/src/__tests__/db/get-db-cache.test.ts
@@ -1,0 +1,88 @@
+/**
+ * getDb() — schema-integrity failures must not be cached
+ *
+ * Regression test for a production incident (beta, 2026-07-27): a live
+ * database was missing the mcp_channel_identities/mcp_registration_tokens/
+ * mcp_pending_baskets tables even though __drizzle_migrations recorded them as
+ * applied. ensureSchemaIntegrity() correctly threw — but getDb() assigned the
+ * module-level `_db` cache *before* running the integrity check, so the throw
+ * only surfaced on the very first call after a process start. Every
+ * subsequent getDb() call in that same process silently returned the cached
+ * (broken) handle instead of re-checking, so the failure produced one log
+ * line at boot and then went completely quiet — even though the underlying
+ * tables were still missing and any query against them would fail.
+ *
+ * getDb() must instead keep retrying (and re-throwing) on every call until
+ * the underlying schema is actually fixed.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+import path from "path";
+import fs from "fs";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import * as schema from "@/lib/db/schema";
+
+const MIGRATIONS_DIR = path.join(process.cwd(), "drizzle");
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "thinkarr-getdb-cache-test-"));
+  dbPath = path.join(tmpDir, "thinkarr.db");
+  process.env.CONFIG_DIR = tmpDir;
+});
+
+/** Build a DB file with all migrations applied, then break it exactly like the beta incident. */
+function createBrokenDb(): void {
+  const sqlite = new Database(dbPath);
+  sqlite.pragma("foreign_keys = ON");
+  migrate(drizzle(sqlite, { schema }), { migrationsFolder: MIGRATIONS_DIR });
+  sqlite.exec("DROP TABLE mcp_channel_identities");
+  sqlite.close();
+}
+
+async function importGetDb() {
+  vi.resetModules();
+  const mod = await import("@/lib/db");
+  return mod.getDb;
+}
+
+describe("getDb() — does not cache a handle across a failed integrity check", () => {
+  it("throws again on the second call, not just the first", async () => {
+    createBrokenDb();
+    const getDb = await importGetDb();
+
+    expect(() => getDb()).toThrow(/mcp_channel_identities/);
+    // Before the fix, this second call returned the module-level `_db` cache
+    // populated by the failed first attempt, instead of re-running
+    // ensureSchemaIntegrity — i.e. it silently stopped throwing.
+    expect(() => getDb()).toThrow(/mcp_channel_identities/);
+  });
+
+  it("succeeds once the underlying schema is repaired, without restarting the process", async () => {
+    createBrokenDb();
+    const getDb = await importGetDb();
+
+    expect(() => getDb()).toThrow(/mcp_channel_identities/);
+
+    // Repair the table on disk (mirrors an operator running the migration
+    // SQL manually) — no process restart.
+    const repair = new Database(dbPath);
+    repair.exec(`
+      CREATE TABLE mcp_channel_identities (
+        channel_type text NOT NULL,
+        channel_user_id text NOT NULL,
+        user_id integer NOT NULL,
+        created_at integer NOT NULL,
+        PRIMARY KEY(channel_type, channel_user_id),
+        FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE no action ON DELETE cascade
+      );
+    `);
+    repair.close();
+
+    expect(() => getDb()).not.toThrow();
+  });
+});

--- a/src/__tests__/db/migrations.test.ts
+++ b/src/__tests__/db/migrations.test.ts
@@ -202,6 +202,20 @@ describe("ensureSchemaIntegrity — generic drift correction", () => {
 
     expect(() => ensureSchemaIntegrity(sqlite)).toThrow(/NOT NULL/);
   });
+
+  it("throws when an entire table is missing, not just a column (beta incident, 2026-07-27)", () => {
+    // mcp_channel_identities never got created on a live beta database even
+    // though __drizzle_migrations recorded 0002_mcp_channel_integration as
+    // applied. PRAGMA table_info() on a nonexistent table returns zero rows
+    // (not an error), so every expected column reads as "missing" — this must
+    // still throw exactly like a partial-column drift would, rather than being
+    // mistaken for "table has no columns defined" and skipped.
+    sqlite.exec("DROP TABLE mcp_channel_identities");
+
+    expect(() => ensureSchemaIntegrity(sqlite)).toThrow(
+      /"mcp_channel_identities"\..*is NOT NULL/,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -305,7 +305,7 @@ function buildToolList(permission: McpPermission, textMode: boolean) {
  * A fresh `Server` + transport is created per request — the SDK's stateless
  * transports (no `sessionIdGenerator`) cannot be reused across requests.
  */
-async function handleMcpProtocolRequest(request: Request, auth: AuthResult, token: string): Promise<Response> {
+async function handleMcpProtocolRequest(request: Request, auth: AuthResult, token: string, textMode: boolean): Promise<Response> {
   const server = new Server(
     { name: "thinkarr", version: process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown" },
     { capabilities: { tools: {} } },
@@ -313,13 +313,13 @@ async function handleMcpProtocolRequest(request: Request, auth: AuthResult, toke
 
   server.setRequestHandler(ListToolsRequestSchema, async (_req, extra) => {
     const permission = (extra.authInfo?.extra?.permission as McpPermission | undefined) ?? auth.permission;
-    const allTools = getOpenAITools();
-    const filtered =
-      permission === "admin"
-        ? allTools
-        : allTools.filter((t) => t.type === "function" && canExecuteTool(t.function.name, permission));
 
-    const tools: Tool[] = filtered
+    // Reuse buildToolList so confirm_request is included in ?mode=text here
+    // exactly as it is for the legacy ad-hoc dispatch below — this was
+    // previously reimplemented inline without the textMode branch, so
+    // spec-compliant JSON-RPC clients (unlike the legacy-envelope OpenClaw
+    // adapter) never saw confirm_request even when connecting with ?mode=text.
+    const tools: Tool[] = buildToolList(permission, textMode)
       .filter((t) => t.type === "function")
       .map((t) => ({
         name: t.function.name,
@@ -339,7 +339,7 @@ async function handleMcpProtocolRequest(request: Request, auth: AuthResult, toke
       toolName: name,
       rawArguments: args,
       auth: { permission, userId },
-      textMode: false,
+      textMode,
     });
 
     if (!outcome.ok) {
@@ -471,7 +471,7 @@ export async function POST(request: Request) {
       headers: request.headers,
       body: rawBody,
     });
-    return handleMcpProtocolRequest(freshRequest, auth, request.headers.get("authorization")!.slice(7));
+    return handleMcpProtocolRequest(freshRequest, auth, request.headers.get("authorization")!.slice(7), textMode);
   }
 
   // Legacy ad-hoc dispatch (no `jsonrpc` envelope) — kept for backward compatibility

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -181,7 +181,14 @@ export function getDb() {
     const sqlite = new Database(DB_PATH);
     sqlite.pragma("journal_mode = WAL");
     sqlite.pragma("foreign_keys = ON");
-    _db = drizzle(sqlite, { schema });
+    // Kept local (not assigned to the module-level `_db` cache) until every
+    // init step below — in particular ensureSchemaIntegrity() — succeeds.
+    // Caching early meant a thrown integrity failure still left a usable
+    // handle in `_db`, so the very next call skipped `if (!_db)` entirely and
+    // silently returned the broken connection instead of retrying/re-throwing
+    // (issue: mcp_channel_identities missing on beta went from one log line
+    // at boot to permanently-broken-and-silent for every request after it).
+    const db = drizzle(sqlite, { schema });
 
     // ── 1. File metadata ─────────────────────────────────────────────────────
     // Logged first so it appears in output even if a later step crashes.
@@ -248,6 +255,7 @@ export function getDb() {
 
     // ── 4. Schema integrity check ────────────────────────────────────────────
     // Logs one line per table (OK / repaired / throws on NOT NULL drift).
+    // Must run — and succeed — before `_db` is cached below.
     ensureSchemaIntegrity(sqlite);
     logger.info("Database ready");
 
@@ -257,25 +265,29 @@ export function getDb() {
     // Rule: supportsRealtime = (realtimeModel !== "").
     // This is a data-level migration — ensureSchemaIntegrity only handles
     // column-level drift and cannot reach inside JSON config blobs.
-    migrateLlmEndpoints(_db);
+    migrateLlmEndpoints(db);
 
     // ── 6. Auto-generate internal API key ────────────────────────────────────
     // Generated once on first boot; the operator copies it from
     // Settings → Logs → Internal API Key and gives it to Claude for
     // the /beta-logs diagnostic command.
-    const existingApiKey = _db
+    const existingApiKey = db
       .select({ value: schema.appConfig.value })
       .from(schema.appConfig)
       .where(eq(schema.appConfig.key, "internal_api_key"))
       .get();
     if (!existingApiKey) {
       const newKey = randomBytes(32).toString("hex");
-      _db
+      db
         .insert(schema.appConfig)
         .values({ key: "internal_api_key", value: newKey, encrypted: true, updatedAt: new Date() })
         .run();
       logger.info("Generated internal API key for diagnostic endpoint");
     }
+
+    // Only cache once every step above has succeeded — see comment at the top
+    // of this function for why this can't happen any earlier.
+    _db = db;
   }
   return _db;
 }


### PR DESCRIPTION
## Summary

<!-- What's in this batch? Link the feature/fix PRs merged to dev since the last beta. -->

-

## Pre-merge checklist

- [ ] `package.json` version bumped (current on dev vs current on beta — bump if not done)
- [ ] `npm run security:audit` passes locally (exit 0)
- [ ] Semgrep SAST passes locally (0 findings)
- [ ] Trivy Docker image scan passes locally (0 unfixed CRITICAL/HIGH)

## Test plan

<!-- What should be manually verified on the :beta image? -->

- [ ]
