### PR TITLE
feat(mcp): add overseerr_confirm_request tool to approve/decline requests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -242,7 +242,7 @@ LLM-powered chat frontend for the *arr media stack. Users log in via Plex OAuth,
 | Plex | `plex_search_library`, `plex_get_on_deck`, `plex_get_recently_added`, `plex_check_availability`, `plex_search_collection`, `plex_search_by_tag`, `plex_get_title_tags` |
 | Sonarr | `sonarr_search_series`, `sonarr_get_series_status`, `sonarr_get_calendar`, `sonarr_get_queue` |
 | Radarr | `radarr_search_movie`, `radarr_get_movie_status`, `radarr_get_queue` |
-| Seerr | `overseerr_search`, `overseerr_get_details`, `overseerr_list_requests`, `overseerr_discover`, `overseerr_get_season_episodes`, `overseerr_similar`, `overseerr_report_issue` |
+| Seerr | `overseerr_search`, `overseerr_get_details`, `overseerr_list_requests`, `overseerr_discover`, `overseerr_get_season_episodes`, `overseerr_similar`, `overseerr_report_issue`, `overseerr_confirm_request` (admin-only) |
 | Built-in | `display_titles` — renders TitleCarousel in chat (always registered) |
 | Text-channel only | `confirm_request` — submits an Overseerr request after explicit user confirmation; only available in `?mode=text` |
 

--- a/src/__tests__/lib/overseerr-confirm-request.test.ts
+++ b/src/__tests__/lib/overseerr-confirm-request.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the overseerr_confirm_request MCP tool — approves or declines
+ * a pending request in Overseerr's request queue via PUT /request/{id}/approve|decline.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockApproveRequest = vi.fn();
+const mockDeclineRequest = vi.fn();
+vi.mock("@/lib/services/overseerr", () => ({
+  approveRequest: (...a: unknown[]) => mockApproveRequest(...a),
+  declineRequest: (...a: unknown[]) => mockDeclineRequest(...a),
+}));
+
+describe("overseerr_confirm_request", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockApproveRequest.mockReset();
+    mockDeclineRequest.mockReset();
+  });
+
+  it("calls approveRequest with requestId when action is 'approve'", async () => {
+    mockApproveRequest.mockResolvedValue({ success: true, message: "Request approved" });
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_confirm_request", JSON.stringify({ requestId: 706, action: "approve" }));
+    const result = JSON.parse(raw);
+
+    expect(mockApproveRequest).toHaveBeenCalledWith(706);
+    expect(mockDeclineRequest).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: true, message: "Request approved" });
+  });
+
+  it("calls declineRequest with requestId when action is 'decline'", async () => {
+    mockDeclineRequest.mockResolvedValue({ success: true, message: "Request declined" });
+
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_confirm_request", JSON.stringify({ requestId: 42, action: "decline" }));
+    const result = JSON.parse(raw);
+
+    expect(mockDeclineRequest).toHaveBeenCalledWith(42);
+    expect(mockApproveRequest).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: true, message: "Request declined" });
+  });
+
+  it("rejects an invalid action via schema validation", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_confirm_request", JSON.stringify({ requestId: 706, action: "delete" }));
+    const result = JSON.parse(raw);
+
+    expect(result.error).toBeDefined();
+    expect(mockApproveRequest).not.toHaveBeenCalled();
+    expect(mockDeclineRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing requestId via schema validation", async () => {
+    const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
+    const { executeTool } = await import("@/lib/tools/registry");
+    registerOverseerrTools();
+
+    const raw = await executeTool("overseerr_confirm_request", JSON.stringify({ action: "approve" }));
+    const result = JSON.parse(raw);
+
+    expect(result.error).toBeDefined();
+    expect(mockApproveRequest).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/lib/overseerr.test.ts
+++ b/src/__tests__/lib/overseerr.test.ts
@@ -961,6 +961,74 @@ describe("createIssue — reports a playback issue to Seerr", () => {
   });
 });
 
+describe("approveRequest / declineRequest — Overseerr request queue actions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("PUTs to /request/{id}/approve", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 706, status: 2 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { approveRequest } = await import("@/lib/services/overseerr");
+    const result = await approveRequest(706);
+
+    expect(result.success).toBe(true);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/request/706/approve");
+    expect((opts as RequestInit).method).toBe("PUT");
+  });
+
+  it("PUTs to /request/{id}/decline", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 706, status: 3 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { declineRequest } = await import("@/lib/services/overseerr");
+    const result = await declineRequest(706);
+
+    expect(result.success).toBe(true);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/request/706/decline");
+    expect((opts as RequestInit).method).toBe("PUT");
+  });
+
+  it("returns success=false with error message when approve fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ message: "Forbidden" }),
+    }));
+
+    const { approveRequest } = await import("@/lib/services/overseerr");
+    const result = await approveRequest(706);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("403");
+  });
+
+  it("returns success=false with error message when decline fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: "Request not found" }),
+    }));
+
+    const { declineRequest } = await import("@/lib/services/overseerr");
+    const result = await declineRequest(999);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("404");
+  });
+});
+
 describe("getDetails — exposes seerrMediaId from mediaInfo", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/__tests__/lib/token-reduction.test.ts
+++ b/src/__tests__/lib/token-reduction.test.ts
@@ -509,7 +509,7 @@ describe("display_titles tool call arg compression", () => {
 describe("overseerr_list_requests llmSummary", () => {
   beforeEach(() => { vi.resetModules(); });
 
-  it("strips id, tmdbId, requestedAt; keeps display_titles-relevant fields including thumbPath and seasons", async () => {
+  it("strips tmdbId, requestedAt; keeps id (needed for overseerr_confirm_request) and display_titles-relevant fields including thumbPath and seasons", async () => {
     const { registerOverseerrTools } = await import("@/lib/tools/overseerr-tools");
     const { getToolLlmContent } = await import("@/lib/tools/registry");
 
@@ -543,8 +543,8 @@ describe("overseerr_list_requests llmSummary", () => {
     expect(item.overseerrId).toBe(550);
     // thumbPath is now preserved — needed for follow-up display_titles calls without re-fetching
     expect(item.thumbPath).toBe("https://image.tmdb.org/t/p/w300/poster.jpg");
+    expect(item.id).toBe(706);
     expect(item).not.toHaveProperty("requestedAt");
     expect(item).not.toHaveProperty("tmdbId");
-    expect(item).not.toHaveProperty("id");
   });
 });

--- a/src/lib/services/overseerr.ts
+++ b/src/lib/services/overseerr.ts
@@ -537,6 +537,24 @@ export async function similar(
   return { results, hasMore };
 }
 
+export async function approveRequest(requestId: number): Promise<{ success: boolean; message: string }> {
+  try {
+    await overseerrFetch(`/request/${requestId}/approve`, { method: "PUT" });
+    return { success: true, message: "Request approved" };
+  } catch (e: unknown) {
+    return { success: false, message: e instanceof Error ? e.message : "Failed to approve request" };
+  }
+}
+
+export async function declineRequest(requestId: number): Promise<{ success: boolean; message: string }> {
+  try {
+    await overseerrFetch(`/request/${requestId}/decline`, { method: "PUT" });
+    return { success: true, message: "Request declined" };
+  } catch (e: unknown) {
+    return { success: false, message: e instanceof Error ? e.message : "Failed to decline request" };
+  }
+}
+
 export async function createIssue(
   seerrMediaId: number,
   issueType: IssueType,

--- a/src/lib/tools/overseerr-tools.ts
+++ b/src/lib/tools/overseerr-tools.ts
@@ -162,8 +162,8 @@ export function registerOverseerrTools() {
     llmSummary: (result: unknown) => {
       const r = result as { results: (OverseerrRequest & { seasons?: overseerr.OverseerrSeasonStatus[]; seasonCount?: number })[]; hasMore: boolean };
       return {
-        results: r.results.map(({ mediaType, title, year, status, mediaStatus, requestedBy, overseerrId, seasonsRequested, thumbPath, seasons }) => ({
-          mediaType, title, year, status, mediaStatus, requestedBy, overseerrId, seasonsRequested,
+        results: r.results.map(({ id, mediaType, title, year, status, mediaStatus, requestedBy, overseerrId, seasonsRequested, thumbPath, seasons }) => ({
+          id, mediaType, title, year, status, mediaStatus, requestedBy, overseerrId, seasonsRequested,
           ...(thumbPath ? { thumbPath } : {}),
           ...(seasons && seasons.length > 0
             ? { seasons: seasons.map((s) => `S${s.seasonNumber}:${s.status.toLowerCase().replace(/ /g, "_")}`).join(" ") }
@@ -172,6 +172,19 @@ export function registerOverseerrTools() {
         hasMore: r.hasMore,
       };
     },
+  });
+
+  defineTool({
+    name: "overseerr_confirm_request",
+    description: "Approve or decline a pending media request in Overseerr's request queue. Use this when an admin asks to approve, confirm, or decline a specific request (e.g. 'approve the Breaking Bad request', 'decline request 42'). Requires the numeric request id — the `id` field from overseerr_list_requests, NOT the overseerrId/tmdbId used by other tools. Admin-only: Overseerr requires request-management permission to approve or decline requests submitted by other users.",
+    schema: z.object({
+      requestId: z.number().int().describe("The Overseerr request id to act on — the `id` field from overseerr_list_requests."),
+      action: z.enum(["approve", "decline"]).describe("Whether to approve or decline the request."),
+    }),
+    handler: async (args) =>
+      args.action === "approve"
+        ? overseerr.approveRequest(args.requestId)
+        : overseerr.declineRequest(args.requestId),
   });
 
   defineTool({


### PR DESCRIPTION
## Summary

MCP clients were reporting no `confirm_request` (or any approve/confirm variant) tool in the thinkarr MCP inventory. The MCP is read-heavy (search, browse, queue checks) with no write tool for approving/declining Overseerr requests.

- Adds `approveRequest(requestId)` / `declineRequest(requestId)` to `src/lib/services/overseerr.ts`, wrapping Overseerr's `PUT /api/v1/request/{id}/approve` and `PUT /api/v1/request/{id}/decline`.
- Registers a new MCP tool `overseerr_confirm_request` (`requestId`, `action: "approve" | "decline"`) in `src/lib/tools/overseerr-tools.ts`.
- Surfaces the request `id` field in `overseerr_list_requests`' `llmSummary` (previously stripped) since it's now needed to target a specific request for confirm/decline.
- The new tool is **admin-only**: it's intentionally absent from `canExecuteTool`'s read-only/user-action allowlists in `src/app/api/mcp/route.ts`, matching Overseerr's own request-management permission model.
- Updated `ARCHITECTURE.md`'s MCP tool table.

## Test plan

- [x] `npx tsc --noEmit` — no new errors
- [x] `npx vitest run` — 638/638 tests pass (51 files), including new/updated coverage:
  - `src/__tests__/lib/overseerr.test.ts` — `approveRequest`/`declineRequest` service tests (PUT method, correct URL, error handling)
  - `src/__tests__/lib/overseerr-confirm-request.test.ts` (new) — tool wiring, action dispatch, schema validation
  - `src/__tests__/lib/token-reduction.test.ts` — updated to assert `id` is now preserved in `overseerr_list_requests` llmSummary
- [ ] Not run: `npm run security:audit`, Semgrep, Trivy (not required for a `dev` PR per repo rules — only required before `dev → beta`)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NXhfVZTvpxoWJv8Wu38xjh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXhfVZTvpxoWJv8Wu38xjh)_